### PR TITLE
docs: add WordPress.org repository compliance files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @josephfusco

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project follows the [WordPress Community Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+## Local development
+
+```bash
+npm install
+npx wp-env start
+```
+
+Dashboard: [localhost:8888/wp-admin/](http://localhost:8888/wp-admin/) (admin / password)
+
+## Running tests
+
+```bash
+# Coding standards
+composer install
+./vendor/bin/phpcs --standard=phpcs.xml.dist
+
+# Static analysis
+./vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=2G
+
+# Unit tests (requires wp-env running)
+npx wp-env run tests-cli -- composer require --dev phpunit/phpunit:^9.6 yoast/phpunit-polyfills:^2.0 --working-dir=/var/www/html --update-with-all-dependencies
+npm test
+
+# E2E tests
+npx playwright test --config tests/e2e/playwright.config.js
+```
+
+The PHPUnit install step only needs to be run once per `wp-env start`.
+
+## Pull requests
+
+1. Branch off `main`.
+2. All CI checks must pass before merge (PHPCS, PHPUnit across PHP 7.4 + 8.3, multisite).
+3. Keep commits focused — one logical change per commit.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Presence API
 
+> **Status:** Experimental feature plugin
+
 System-wide presence and awareness for WordPress.
+
+## Problem
+
+WordPress has no way to know who is logged in, what screen they are on, or which posts are being edited — without writing to shared tables like `wp_postmeta` or `wp_options`. High-frequency writes to those tables invalidate caches site-wide ([#64696](https://core.trac.wordpress.org/ticket/64696)). This plugin uses a dedicated `wp_presence` table with a 60-second TTL to provide that awareness with zero cache side effects.
 
 > "This idea of presence I think is really cool and seeing where people are... you log into your WordPress, I see oh Matias is moderating some comments, Lynn is on the dashboard maybe reading some news... that idea of like you log in and you can kind of see the neighborhood of like who else is also there." — [Matt Mullenweg, WordPress 7.0 planning session](https://youtu.be/F-xMPY9WqG4?si=YK0rIUM2nuYy7x45&t=2435)
 
@@ -42,3 +48,13 @@ Creates presence entries alongside `_edit_lock` postmeta when a post lock is ref
 ## Capability
 
 All features require `edit_posts`.
+
+## Maintainers
+
+- [@josephfusco](https://github.com/josephfusco)
+
+Sponsored by the [Core team](https://make.wordpress.org/core/). Updates posted on [make.wordpress.org/core](https://make.wordpress.org/core/) with the tag `#presence-api`.
+
+## Support
+
+Questions and bug reports: [GitHub Issues](https://github.com/WordPress/presence-api/issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please use [GitHub's private vulnerability reporting](https://github.com/WordPress/presence-api/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,7 +13,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 /**
  * Drops the presence table and deletes options for a single site.
- *
  */
 function wp_presence_uninstall_site() {
 	global $wpdb;


### PR DESCRIPTION
Add problem statement and maintainers section to README. Add CONTRIBUTING.md with local dev setup, test commands, and PR process. Add CODEOWNERS file.

Ref: https://make.wordpress.org/project/2025/06/04/criteria-for-creating-or-migrating-repositories-under-the-wordpress-github-organization/