### PR TITLE
docs: remove SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-# Security Policy
-
-## Reporting a Vulnerability
-
-To report a security vulnerability, please use [GitHub's private vulnerability reporting](https://github.com/WordPress/presence-api/security/advisories/new).
-
-Do not open a public issue for security vulnerabilities.


### PR DESCRIPTION
Org-level security process applies. Not eligible for HackerOne bug bounty per WordPress org repository criteria.