### PR TITLE
fix: exclude vendor from release zip

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -7,6 +7,7 @@
 .phpunit.result.cache
 .distignore
 node_modules
+vendor
 tests
 artifacts
 build


### PR DESCRIPTION
No production composer dependencies - only dev tooling. The vendor directory adds unnecessary weight to the release.