### PR TITLE
feat: add 40-user Playground blueprint

### DIFF
--- a/blueprint-40.json
+++ b/blueprint-40.json
@@ -1,0 +1,28 @@
+{
+	"preferredVersions": {
+		"wp": "beta"
+	},
+	"landingPage": "/wp-admin/",
+	"login": true,
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "url",
+				"url": "https://github.com/WordPress/presence-api/releases/latest/download/presence-api.zip"
+			}
+		},
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/plugins/presence-api/demo-seeder.php",
+			"data": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/main/tests/e2e/demo-seeder.php"
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; require '/wordpress/wp-content/plugins/presence-api/demo-seeder.php'; wp_presence_demo_seed( 40 ); update_user_meta( 1, 'show_welcome_panel', 0 ); update_user_meta( 1, 'meta-box-order_dashboard', array( 'normal' => 'presence_whos_online,presence_active_posts,dashboard_right_now,dashboard_activity', 'side' => 'dashboard_quick_press,dashboard_primary' ) ); ?>"
+		}
+	]
+}


### PR DESCRIPTION
Adds `blueprint-40.json` — same flow as `blueprint.json`, seeds 40 editor accounts instead of 5 to show how the Who's Online widget, admin bar avatar stack, and Active Posts widget handle density.

40 was chosen over 100 to keep Playground boot time reasonable.

Presence entries expire via the existing 60-second TTL, so no new infrastructure. `blueprint.json` is unchanged.

Supports a "see it at scale" link in the upcoming Make blog post announcement.

**Test:** https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/feat/playground-100-users/blueprint-40.json