### PR TITLE
Trigger immediate heartbeat tick on page load

### DIFF
--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -59,7 +59,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 			// reflects the current screen without waiting for the next interval
 			// (which can be up to 60s on screens like the dashboard).
 			function tickNow() {
-				if (wp.heartbeat && typeof wp.heartbeat.connectNow === "function") {
+				if (typeof wp?.heartbeat?.connectNow === "function") {
 					wp.heartbeat.connectNow();
 				}
 			}
@@ -68,7 +68,9 @@ function wp_presence_enqueue_heartbeat_ping() {
 			// pageshow with event.persisted is the bfcache restore case, where
 			// DOMContentLoaded does not fire again.
 			window.addEventListener("pageshow", function(event) {
-				if (event.persisted) { tickNow(); }
+				if (event.persisted) {
+					tickNow();
+				}
 			});
 		})(jQuery);',
 			$front_context

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -54,6 +54,22 @@ function wp_presence_enqueue_heartbeat_ping() {
 				}
 				data["presence-ping"] = ping;
 			});
+
+			// Trigger an immediate heartbeat tick once the DOM is ready so presence
+			// reflects the current screen without waiting for the next interval
+			// (which can be up to 60s on screens like the dashboard).
+			function tickNow() {
+				if (wp.heartbeat && typeof wp.heartbeat.connectNow === "function") {
+					wp.heartbeat.connectNow();
+				}
+			}
+			$(tickNow);
+
+			// pageshow with event.persisted is the bfcache restore case, where
+			// DOMContentLoaded does not fire again.
+			window.addEventListener("pageshow", function(event) {
+				if (event.persisted) { tickNow(); }
+			});
 		})(jQuery);',
 			$front_context
 		)


### PR DESCRIPTION
Closes #14.

On screens other than the post editor, the first heartbeat tick can be up to 60 seconds away, leaving a user's reported screen stale right after they navigate.

## Change

Extend the inline script attached to the `heartbeat` handle with two small additions:

- Call `wp.heartbeat.connectNow()` on `DOMContentLoaded` so the first presence ping fires right away.
- Re-fire on `pageshow` when `event.persisted === true` (the bfcache-restore case, where `DOMContentLoaded` does not fire again).

A non-persisted `pageshow` is intentionally ignored — `DOMContentLoaded` already handles that path, and we don't want to double-tick.

## Files

- `includes/heartbeat.php`

## Verification

With wp-env running, log in as admin in window A and as editor in window B. As the editor, navigate from `wp-admin/` to `wp-admin/upload.php`. In window A's Who's Online widget, the editor's listed screen should update within a couple of seconds — not up to 60.