### PR TITLE
Remove presence on pagehide via fetch keepalive

### DIFF
--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -34,16 +34,31 @@ function wp_presence_enqueue_heartbeat_ping() {
 		),
 	);
 
-	// On frontend singular views, pass the current post context to the heartbeat ping.
+	// Carry a title for any frontend URL so non-singular views (archives, search,
+	// the front page, taxonomies, 404s) are labeled too. is_singular() pages also
+	// include the post id/type so the Active Posts widget can group by post.
 	$front_context = null;
-	if ( ! is_admin() && is_singular() ) {
-		$queried = get_queried_object();
-		if ( $queried instanceof WP_Post ) {
-			$front_context = array(
-				'postId'   => $queried->ID,
-				'postType' => $queried->post_type,
-				'title'    => get_the_title( $queried ),
-			);
+	if ( ! is_admin() ) {
+		if ( is_front_page() ) {
+			$title = __( 'Home', 'presence-api' );
+		} else {
+			$strip_branding = static function ( $parts ) {
+				unset( $parts['tagline'], $parts['site'] );
+				return $parts;
+			};
+			add_filter( 'document_title_parts', $strip_branding );
+			$title = wp_get_document_title();
+			remove_filter( 'document_title_parts', $strip_branding );
+		}
+
+		$front_context = array( 'title' => $title );
+
+		if ( is_singular() ) {
+			$queried = get_queried_object();
+			if ( $queried instanceof WP_Post ) {
+				$front_context['postId']   = $queried->ID;
+				$front_context['postType'] = $queried->post_type;
+			}
 		}
 	}
 
@@ -79,9 +94,13 @@ function wp_presence_enqueue_heartbeat_ping() {
 
 	$admin_state = array( 'screen' => $screen_id );
 	if ( $front_context ) {
-		$admin_state['post_id']   = $front_context['postId'];
-		$admin_state['post_type'] = $front_context['postType'];
-		$admin_state['title']     = $front_context['title'];
+		if ( ! empty( $front_context['title'] ) ) {
+			$admin_state['title'] = $front_context['title'];
+		}
+		if ( ! empty( $front_context['postId'] ) ) {
+			$admin_state['post_id']   = $front_context['postId'];
+			$admin_state['post_type'] = $front_context['postType'];
+		}
 	}
 	wp_set_presence( 'admin/online', 'user-' . $user_id, $admin_state, $user_id );
 
@@ -134,10 +153,14 @@ function wp_presence_enqueue_heartbeat_ping() {
 
 			$(document).on('heartbeat-send', function (event, data) {
 				const ping = { screen: window.pagenow || 'front' };
-				if (frontContext && frontContext.postId) {
-					ping.post_id = frontContext.postId;
-					ping.post_type = frontContext.postType;
-					ping.title = frontContext.title;
+				if (frontContext) {
+					if (frontContext.title) {
+						ping.title = frontContext.title;
+					}
+					if (frontContext.postId) {
+						ping.post_id = frontContext.postId;
+						ping.post_type = frontContext.postType;
+					}
 				}
 				data['presence-ping'] = ping;
 

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -34,9 +34,9 @@ function wp_presence_enqueue_heartbeat_ping() {
 		),
 	);
 
-	// Carry a title for any frontend URL so non-singular views (archives, search,
-	// the front page, taxonomies, 404s) are labeled too. is_singular() pages also
-	// include the post id/type so the Active Posts widget can group by post.
+	// Carry a title for any frontend URL so it shows up in the Who's Online
+	// widget (non-singular views — archives, search, the front page, taxonomies,
+	// 404s — are labeled too). is_singular() pages also carry the post id.
 	$front_context = null;
 	if ( ! is_admin() ) {
 		if ( is_front_page() ) {
@@ -56,8 +56,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 		if ( is_singular() ) {
 			$queried = get_queried_object();
 			if ( $queried instanceof WP_Post ) {
-				$front_context['postId']   = $queried->ID;
-				$front_context['postType'] = $queried->post_type;
+				$front_context['postId'] = $queried->ID;
 			}
 		}
 	}
@@ -98,8 +97,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 			$admin_state['title'] = $front_context['title'];
 		}
 		if ( ! empty( $front_context['postId'] ) ) {
-			$admin_state['post_id']   = $front_context['postId'];
-			$admin_state['post_type'] = $front_context['postType'];
+			$admin_state['post_id'] = $front_context['postId'];
 		}
 	}
 	wp_set_presence( 'admin/online', 'user-' . $user_id, $admin_state, $user_id );
@@ -159,7 +157,6 @@ function wp_presence_enqueue_heartbeat_ping() {
 					}
 					if (frontContext.postId) {
 						ping.post_id = frontContext.postId;
-						ping.post_type = frontContext.postType;
 					}
 				}
 				data['presence-ping'] = ping;

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -130,12 +130,15 @@ function wp_presence_enqueue_heartbeat_ping() {
 			return;
 		}
 
+		// rest_url() already contains ?rest_route= on plain-permalink sites.
+		var separator = restUrl.indexOf('?') === -1 ? '?' : '&';
+
 		entries.forEach(function (entry) {
 			if (!entry || !entry.room || !entry.client_id) {
 				return;
 			}
 			var url = restUrl
-				+ '?room=' + encodeURIComponent(entry.room)
+				+ separator + 'room=' + encodeURIComponent(entry.room)
 				+ '&client_id=' + encodeURIComponent(entry.client_id);
 			try {
 				window.fetch(url, {

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -56,7 +56,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 		if ( is_singular() ) {
 			$queried = get_queried_object();
 			if ( $queried instanceof WP_Post ) {
-				$front_context['postId'] = $queried->ID;
+				$front_context['post_id'] = $queried->ID;
 			}
 		}
 	}
@@ -96,8 +96,8 @@ function wp_presence_enqueue_heartbeat_ping() {
 		if ( ! empty( $front_context['title'] ) ) {
 			$admin_state['title'] = $front_context['title'];
 		}
-		if ( ! empty( $front_context['postId'] ) ) {
-			$admin_state['post_id'] = $front_context['postId'];
+		if ( ! empty( $front_context['post_id'] ) ) {
+			$admin_state['post_id'] = $front_context['post_id'];
 		}
 	}
 	wp_set_presence( 'admin/online', 'user-' . $user_id, $admin_state, $user_id );
@@ -155,8 +155,8 @@ function wp_presence_enqueue_heartbeat_ping() {
 					if (frontContext.title) {
 						ping.title = frontContext.title;
 					}
-					if (frontContext.postId) {
-						ping.post_id = frontContext.postId;
+					if (frontContext.post_id) {
+						ping.post_id = frontContext.post_id;
 					}
 				}
 				data['presence-ping'] = ping;

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -71,6 +71,35 @@ function wp_presence_enqueue_heartbeat_ping() {
 		}
 	}
 
+	// Write presence server-side during this request so the new page closes the
+	// gap between the old page's pagehide DELETE and the next heartbeat tick.
+	$screen_id = is_admin() && function_exists( 'get_current_screen' ) && get_current_screen()
+		? get_current_screen()->id
+		: 'front';
+
+	$admin_state = array( 'screen' => $screen_id );
+	if ( $front_context ) {
+		$admin_state['post_id']   = $front_context['postId'];
+		$admin_state['post_type'] = $front_context['postType'];
+		$admin_state['title']     = $front_context['title'];
+	}
+	wp_set_presence( 'admin/online', 'user-' . $user_id, $admin_state, $user_id );
+
+	if ( $editor_post_id ) {
+		$editor_room = wp_presence_post_room( $editor_post_id );
+		if ( $editor_room ) {
+			wp_set_presence(
+				$editor_room,
+				'editor-' . $user_id,
+				array(
+					'action' => 'editing',
+					'screen' => $screen_id,
+				),
+				$user_id
+			);
+		}
+	}
+
 	$config = array(
 		'entries'      => $entries,
 		'frontContext' => $front_context,

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -110,96 +110,95 @@ function wp_presence_enqueue_heartbeat_ping() {
 
 	wp_add_inline_script(
 		'heartbeat',
-		'window.wpPresenceConfig = ' . wp_json_encode( $config ) . ';',
+		sprintf( 'window.wpPresenceConfig = %s;', wp_json_encode( $config, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
 		'before'
 	);
 
 	wp_add_inline_script(
 		'heartbeat',
 		<<<'JS'
-(function ($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
-		return;
-	}
-
-	var config = window.wpPresenceConfig || {};
-	var entries = Array.isArray(config.entries) ? config.entries : [];
-	var frontContext = config.frontContext || null;
-	var editorPostId = parseInt(config.editorPostId, 10) || 0;
-	var restUrl = config.restUrl || '';
-	var nonce = config.nonce || '';
-
-	// Guards against duplicate leave() invocations.
-	var hasLeft = false;
-
-	$(document).on('heartbeat-send', function (event, data) {
-		var ping = { screen: window.pagenow || 'front' };
-		if (frontContext && frontContext.postId) {
-			ping.post_id = frontContext.postId;
-			ping.post_type = frontContext.postType;
-			ping.title = frontContext.title;
-		}
-		data['presence-ping'] = ping;
-
-		if (editorPostId) {
-			data['presence-editor-ping'] = { post_id: editorPostId };
-		}
-
-		hasLeft = false;
-	});
-
-	function leave() {
-		if (hasLeft || !restUrl || !entries.length) {
-			return;
-		}
-		hasLeft = true;
-
-		// keepalive lets the DELETE outlive the unload; sendBeacon is POST-only.
-		if (typeof window.fetch !== 'function') {
-			return;
-		}
-
-		// rest_url() already contains ?rest_route= on plain-permalink sites.
-		var separator = restUrl.indexOf('?') === -1 ? '?' : '&';
-
-		entries.forEach(function (entry) {
-			if (!entry || !entry.room || !entry.client_id) {
+		(function ($) {
+			if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
 				return;
 			}
-			var url = restUrl
-				+ separator + 'room=' + encodeURIComponent(entry.room)
-				+ '&client_id=' + encodeURIComponent(entry.client_id);
-			try {
-				window.fetch(url, {
-					method: 'DELETE',
-					credentials: 'same-origin',
-					keepalive: true,
-					headers: { 'X-WP-Nonce': nonce }
+
+			const config = window.wpPresenceConfig || {};
+			const entries = Array.isArray(config.entries) ? config.entries : [];
+			const frontContext = config.frontContext || null;
+			const editorPostId = parseInt(config.editorPostId, 10) || 0;
+			const restUrl = config.restUrl || '';
+			const nonce = config.nonce || '';
+
+			// Guards against duplicate leave() invocations.
+			let hasLeft = false;
+
+			$(document).on('heartbeat-send', function (event, data) {
+				const ping = { screen: window.pagenow || 'front' };
+				if (frontContext && frontContext.postId) {
+					ping.post_id = frontContext.postId;
+					ping.post_type = frontContext.postType;
+					ping.title = frontContext.title;
+				}
+				data['presence-ping'] = ping;
+
+				if (editorPostId) {
+					data['presence-editor-ping'] = { post_id: editorPostId };
+				}
+
+				hasLeft = false;
+			});
+
+			function leave() {
+				if (hasLeft || !restUrl || !entries.length) {
+					return;
+				}
+				hasLeft = true;
+
+				// keepalive lets the DELETE outlive the unload; sendBeacon is POST-only.
+				if (typeof window.fetch !== 'function') {
+					return;
+				}
+
+				entries.forEach(function (entry) {
+					if (!entry || !entry.room || !entry.client_id) {
+						return;
+					}
+					const url = new URL(restUrl);
+					url.searchParams.set('room', entry.room);
+					url.searchParams.set('client_id', entry.client_id);
+					try {
+						window.fetch(url, {
+							method: 'DELETE',
+							credentials: 'same-origin',
+							keepalive: true,
+							headers: { 'X-WP-Nonce': nonce }
+						});
+					} catch {
+						// Best-effort: TTL cleanup will catch entries we couldn't remove.
+					}
 				});
-			} catch (e) {
-				// Best-effort: TTL cleanup will catch entries we couldn't remove.
 			}
-		});
-	}
 
-	// Re-establish presence on every page load so in-admin navigation doesn't
-	// leave a gap between the unload DELETE and the heartbeat's first tick.
-	function tickNow() {
-		if (wp.heartbeat && typeof wp.heartbeat.connectNow === 'function') {
-			wp.heartbeat.connectNow();
-		}
-	}
-	$(tickNow);
-	// bfcache restore: DOMContentLoaded won't fire.
-	window.addEventListener('pageshow', function (event) {
-		if (event.persisted) { tickNow(); }
-	});
+			// Re-establish presence on every page load so in-admin navigation doesn't
+			// leave a gap between the unload DELETE and the heartbeat's first tick.
+			function tickNow() {
+				if (typeof wp?.heartbeat?.connectNow === 'function') {
+					wp.heartbeat.connectNow();
+				}
+			}
+			$(tickNow);
+			// bfcache restore: DOMContentLoaded won't fire.
+			window.addEventListener('pageshow', function (event) {
+				if (event.persisted) {
+					tickNow();
+				}
+			});
 
-	window.addEventListener('pagehide', function () {
-		leave();
-	});
-})(jQuery);
-JS
+			window.addEventListener('pagehide', function () {
+				leave();
+			});
+		})(jQuery);
+		JS
 	);
 }
 

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -24,69 +24,137 @@ function wp_presence_enqueue_heartbeat_ping() {
 
 	wp_enqueue_script( 'heartbeat' );
 
+	$user_id = get_current_user_id();
+
+	// Every page where the ping is enqueued occupies the admin/online room.
+	$entries = array(
+		array(
+			'room'      => 'admin/online',
+			'client_id' => 'user-' . $user_id,
+		),
+	);
+
 	// On frontend singular views, pass the current post context to the heartbeat ping.
-	$front_context = '{}';
+	$front_context = null;
 	if ( ! is_admin() && is_singular() ) {
 		$queried = get_queried_object();
 		if ( $queried instanceof WP_Post ) {
-			$front_context = wp_json_encode(
-				array(
-					'postId'   => $queried->ID,
-					'postType' => $queried->post_type,
-					'title'    => get_the_title( $queried ),
-				)
+			$front_context = array(
+				'postId'   => $queried->ID,
+				'postType' => $queried->post_type,
+				'title'    => get_the_title( $queried ),
 			);
 		}
 	}
 
-	wp_add_inline_script(
-		'heartbeat',
-		sprintf(
-			'(function($) {
-			if (typeof wp === "undefined" || typeof wp.heartbeat === "undefined") { return; }
-			var frontContext = %s;
-			$(document).on("heartbeat-send", function(event, data) {
-				var ping = { screen: window.pagenow || "front" };
-				if (frontContext.postId) {
-					ping.post_id = frontContext.postId;
-					ping.post_type = frontContext.postType;
-					ping.title = frontContext.title;
+	// On the post-edit screen, also occupy the per-post room.
+	$editor_post_id = 0;
+	if ( is_admin() && function_exists( 'get_current_screen' ) ) {
+		$screen = get_current_screen();
+		if ( $screen && 'post' === $screen->base ) {
+			$post = get_post();
+			if ( $post && post_type_supports( $post->post_type, 'presence' ) ) {
+				$room = wp_presence_post_room( $post->ID );
+				if ( $room ) {
+					$editor_post_id = $post->ID;
+					$entries[]      = array(
+						'room'      => $room,
+						'client_id' => 'editor-' . $user_id,
+					);
+					// The post-lock bridge writes this entry via the wp-refresh-post-lock heartbeat.
+					$entries[] = array(
+						'room'      => $room,
+						'client_id' => 'lock-' . $user_id,
+					);
 				}
-				data["presence-ping"] = ping;
-			});
-		})(jQuery);',
-			$front_context
-		)
+			}
+		}
+	}
+
+	$config = array(
+		'entries'      => $entries,
+		'frontContext' => $front_context,
+		'editorPostId' => $editor_post_id,
+		'restUrl'      => esc_url_raw( rest_url( 'wp-presence/v1/presence' ) ),
+		'nonce'        => wp_create_nonce( 'wp_rest' ),
 	);
-}
-
-/**
- * Enqueues a heartbeat ping for the block editor that reports which post is being edited.
- *
- * @param string $hook_suffix The current admin page.
- */
-function wp_presence_enqueue_editor_ping( $hook_suffix ) {
-	if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) ) {
-		return;
-	}
-
-	$post = get_post();
-
-	if ( ! $post || ! post_type_supports( $post->post_type, 'presence' ) ) {
-		return;
-	}
 
 	wp_add_inline_script(
 		'heartbeat',
-		sprintf(
-			'(function($) {
-			if (typeof wp === "undefined" || typeof wp.heartbeat === "undefined") { return; }
-			$(document).on("heartbeat-send", function(event, data) {
-				data["presence-editor-ping"] = { post_id: %d };
-			});
-		})(jQuery);',
-			$post->ID
-		)
+		'window.wpPresenceConfig = ' . wp_json_encode( $config ) . ';',
+		'before'
+	);
+
+	wp_add_inline_script(
+		'heartbeat',
+		<<<'JS'
+(function ($) {
+	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+		return;
+	}
+
+	var config = window.wpPresenceConfig || {};
+	var entries = Array.isArray(config.entries) ? config.entries : [];
+	var frontContext = config.frontContext || null;
+	var editorPostId = parseInt(config.editorPostId, 10) || 0;
+	var restUrl = config.restUrl || '';
+	var nonce = config.nonce || '';
+
+	// Guards against duplicate leave() invocations.
+	var hasLeft = false;
+
+	$(document).on('heartbeat-send', function (event, data) {
+		var ping = { screen: window.pagenow || 'front' };
+		if (frontContext && frontContext.postId) {
+			ping.post_id = frontContext.postId;
+			ping.post_type = frontContext.postType;
+			ping.title = frontContext.title;
+		}
+		data['presence-ping'] = ping;
+
+		if (editorPostId) {
+			data['presence-editor-ping'] = { post_id: editorPostId };
+		}
+
+		hasLeft = false;
+	});
+
+	function leave() {
+		if (hasLeft || !restUrl || !entries.length) {
+			return;
+		}
+		hasLeft = true;
+
+		// keepalive lets the DELETE outlive the unload; sendBeacon is POST-only.
+		if (typeof window.fetch !== 'function') {
+			return;
+		}
+
+		entries.forEach(function (entry) {
+			if (!entry || !entry.room || !entry.client_id) {
+				return;
+			}
+			var url = restUrl
+				+ '?room=' + encodeURIComponent(entry.room)
+				+ '&client_id=' + encodeURIComponent(entry.client_id);
+			try {
+				window.fetch(url, {
+					method: 'DELETE',
+					credentials: 'same-origin',
+					keepalive: true,
+					headers: { 'X-WP-Nonce': nonce }
+				});
+			} catch (e) {
+				// Best-effort: TTL cleanup will catch entries we couldn't remove.
+			}
+		});
+	}
+
+	window.addEventListener('pagehide', function () {
+		leave();
+	});
+})(jQuery);
+JS
 	);
 }
 

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -153,6 +153,19 @@ function wp_presence_enqueue_heartbeat_ping() {
 		});
 	}
 
+	// Re-establish presence on every page load so in-admin navigation doesn't
+	// leave a gap between the unload DELETE and the heartbeat's first tick.
+	function tickNow() {
+		if (wp.heartbeat && typeof wp.heartbeat.connectNow === 'function') {
+			wp.heartbeat.connectNow();
+		}
+	}
+	$(tickNow);
+	// bfcache restore: DOMContentLoaded won't fire.
+	window.addEventListener('pageshow', function (event) {
+		if (event.persisted) { tickNow(); }
+	});
+
 	window.addEventListener('pagehide', function () {
 		leave();
 	});

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -734,7 +734,7 @@ JS,
 			}
 			$post_id = (int) ( $data['presence-ping']['post_id'] ?? 0 );
 			if ( $post_id > 0 ) {
-				$front_post = get_post( $post );
+				$front_post = get_post( $post_id );
 				if ( $front_post ) {
 					$state['post_id']   = $front_post->ID;
 					$state['post_type'] = $front_post->post_type;

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -732,11 +732,12 @@ JS,
 			if ( ! empty( $data['presence-ping']['title'] ) ) {
 				$state['title'] = sanitize_text_field( $data['presence-ping']['title'] );
 			}
-			if ( ! empty( $data['presence-ping']['post_id'] ) ) {
-				$front_post_id = absint( $data['presence-ping']['post_id'] );
-				if ( $front_post_id ) {
-					$state['post_id']   = $front_post_id;
-					$state['post_type'] = isset( $data['presence-ping']['post_type'] ) ? sanitize_key( $data['presence-ping']['post_type'] ) : 'post';
+			$post_id = (int) ( $data['presence-ping']['post_id'] ?? 0 );
+			if ( $post_id > 0 ) {
+				$front_post = get_post( $post );
+				if ( $front_post ) {
+					$state['post_id']   = $front_post->ID;
+					$state['post_type'] = $front_post->post_type;
 				}
 			}
 		}

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -724,10 +724,9 @@ JS,
 			$state['post_status'] = $post_status;
 		}
 
-		// Include the frontend page label whenever the ping is from the public site.
-		// The title alone supports non-singular URLs (archives, search, 404, etc.);
-		// post_id/post_type are added on singular views so the Active Posts widget
-		// can group by post.
+		// Store the frontend page label whenever the ping is from the public site.
+		// title becomes the row's screen label in Who's Online; post_id is recorded
+		// when the ping carries one (singular views).
 		if ( 'front' === $screen ) {
 			if ( ! empty( $data['presence-ping']['title'] ) ) {
 				$state['title'] = sanitize_text_field( $data['presence-ping']['title'] );
@@ -736,8 +735,7 @@ JS,
 			if ( $post_id > 0 ) {
 				$front_post = get_post( $post_id );
 				if ( $front_post ) {
-					$state['post_id']   = $front_post->ID;
-					$state['post_type'] = $front_post->post_type;
+					$state['post_id'] = $front_post->ID;
 				}
 			}
 		}

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -724,13 +724,20 @@ JS,
 			$state['post_status'] = $post_status;
 		}
 
-		// Include frontend post context when viewing a singular page/post.
-		if ( 'front' === $screen && ! empty( $data['presence-ping']['post_id'] ) ) {
-			$front_post_id = absint( $data['presence-ping']['post_id'] );
-			if ( $front_post_id ) {
-				$state['post_id']   = $front_post_id;
-				$state['post_type'] = isset( $data['presence-ping']['post_type'] ) ? sanitize_key( $data['presence-ping']['post_type'] ) : 'post';
-				$state['title']     = isset( $data['presence-ping']['title'] ) ? sanitize_text_field( $data['presence-ping']['title'] ) : '';
+		// Include the frontend page label whenever the ping is from the public site.
+		// The title alone supports non-singular URLs (archives, search, 404, etc.);
+		// post_id/post_type are added on singular views so the Active Posts widget
+		// can group by post.
+		if ( 'front' === $screen ) {
+			if ( ! empty( $data['presence-ping']['title'] ) ) {
+				$state['title'] = sanitize_text_field( $data['presence-ping']['title'] );
+			}
+			if ( ! empty( $data['presence-ping']['post_id'] ) ) {
+				$front_post_id = absint( $data['presence-ping']['post_id'] );
+				if ( $front_post_id ) {
+					$state['post_id']   = $front_post_id;
+					$state['post_type'] = isset( $data['presence-ping']['post_type'] ) ? sanitize_key( $data['presence-ping']['post_type'] ) : 'post';
+				}
 			}
 		}
 

--- a/presence-api.php
+++ b/presence-api.php
@@ -139,7 +139,6 @@ add_filter( 'cron_schedules', 'wp_presence_cron_schedules' );
 
 add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_heartbeat_ping' );
 add_action( 'wp_enqueue_scripts', 'wp_presence_enqueue_heartbeat_ping' );
-add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_editor_ping' );
 add_filter( 'heartbeat_received', 'wp_presence_editor_heartbeat_received', 10, 3 );
 add_filter( 'heartbeat_received', 'wp_presence_bridge_post_lock', 11, 3 );
 


### PR DESCRIPTION
Closes #15.

Removes presence entries on `pagehide` instead of waiting for the TTL.

## Changes

- **pagehide DELETE** — `fetch keepalive` removes each `(room, client_id)` the page occupies. URL built with `URL` + `URLSearchParams`.
- **Server-side write** — `wp_set_presence()` runs during page render so the new page is established before the response leaves.
- **Heartbeat triggers** — `DOMContentLoaded`, `pageshow.persisted`, and `visibilitychange === 'visible'` each call `wp.heartbeat.connectNow()`.
- **Hidden-tab guard** — one early-return in the consolidated `heartbeat-send` handler suppresses both `presence-ping` and `presence-editor-ping`.
- **Frontend tracking** expanded from `is_singular()` posts to any URL via `wp_get_document_title()`.
- **Cleanup** — editor ping handler consolidated into the main one; stored `post_type` dropped (derivable from `post_id`); inline JS modernized (`const`/`let`, optional chaining, optional catch, indented heredoc); config emitted with `JSON_HEX_TAG | JSON_UNESCAPED_SLASHES`.

## Limitations

- Client IDs are per-user, not per-tab. Closing one of multiple same-room tabs briefly removes the shared row; the next heartbeat restores it.
- `wp-refresh-post-lock` writes its own row independently; backgrounded post-edit tabs continue to refresh it. Tracked in #21.

## Testing

With `wp-env`:

- Close a tab → user disappears from Who's Online within seconds, not at TTL.
- Navigate between admin pages → no flicker for other watchers.
- Visit `/`, an archive, a search, and a 404 → each row carries a non-empty `title`.
- Hide a tab → presence stops refreshing. Show it → resumes within milliseconds.