### PR TITLE
Skip presence ping for hidden tabs and refresh on visibility

### DIFF
--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -47,7 +47,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 			var frontContext = %s;
 			$(document).on("heartbeat-send", function(event, data) {
 				// A user with a hidden tab should not be reported as actively present.
-				// Skip the ping so the existing entry expires via the 60s TTL.
+				// Skip the ping so the existing entry expires via the default TTL.
 				if (document.visibilityState === "hidden") {
 					return;
 				}
@@ -113,6 +113,10 @@ function wp_presence_enqueue_editor_ping( $hook_suffix ) {
 			'(function($) {
 			if (typeof wp === "undefined" || typeof wp.heartbeat === "undefined") { return; }
 			$(document).on("heartbeat-send", function(event, data) {
+				// Match the main ping: a hidden tab should not be reported as actively editing.
+				if (document.visibilityState === "hidden") {
+					return;
+				}
 				data["presence-editor-ping"] = { post_id: %d };
 			});
 		})(jQuery);',

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -48,7 +48,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 			$(document).on("heartbeat-send", function(event, data) {
 				// A user with a hidden tab should not be reported as actively present.
 				// Skip the ping so the existing entry expires via the 60s TTL.
-				if (typeof document.visibilityState === "string" && document.visibilityState === "hidden") {
+				if (document.visibilityState === "hidden") {
 					return;
 				}
 				var ping = { screen: window.pagenow || "front" };

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -46,6 +46,11 @@ function wp_presence_enqueue_heartbeat_ping() {
 			if (typeof wp === "undefined" || typeof wp.heartbeat === "undefined") { return; }
 			var frontContext = %s;
 			$(document).on("heartbeat-send", function(event, data) {
+				// A user with a hidden tab should not be reported as actively present.
+				// Skip the ping so the existing entry expires via the 60s TTL.
+				if (typeof document.visibilityState === "string" && document.visibilityState === "hidden") {
+					return;
+				}
 				var ping = { screen: window.pagenow || "front" };
 				if (frontContext.postId) {
 					ping.post_id = frontContext.postId;
@@ -69,6 +74,14 @@ function wp_presence_enqueue_heartbeat_ping() {
 			// DOMContentLoaded does not fire again.
 			window.addEventListener("pageshow", function(event) {
 				if (event.persisted) {
+					tickNow();
+				}
+			});
+
+			// When the tab becomes visible again, re-establish presence so the user
+			// does not sit out the next heartbeat interval.
+			document.addEventListener("visibilitychange", function() {
+				if (document.visibilityState === "visible") {
 					tickNow();
 				}
 			});

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -46,8 +46,9 @@ function wp_presence_enqueue_heartbeat_ping() {
 			if (typeof wp === "undefined" || typeof wp.heartbeat === "undefined") { return; }
 			var frontContext = %s;
 			$(document).on("heartbeat-send", function(event, data) {
-				// A user with a hidden tab should not be reported as actively present.
-				// Skip the ping so the existing entry expires via the default TTL.
+				// Skip the ping while the document is hidden (background tab,
+				// minimized window, app switched away) so the existing entry
+				// expires via the default TTL.
 				if (document.visibilityState === "hidden") {
 					return;
 				}
@@ -113,7 +114,7 @@ function wp_presence_enqueue_editor_ping( $hook_suffix ) {
 			'(function($) {
 			if (typeof wp === "undefined" || typeof wp.heartbeat === "undefined") { return; }
 			$(document).on("heartbeat-send", function(event, data) {
-				// Match the main ping: a hidden tab should not be reported as actively editing.
+				// Match the main ping: skip while the document is hidden.
 				if (document.visibilityState === "hidden") {
 					return;
 				}

--- a/tests/e2e/presence-visibility.test.js
+++ b/tests/e2e/presence-visibility.test.js
@@ -1,0 +1,138 @@
+/**
+ * Presence API — Visibility E2E Tests
+ *
+ * Asserts the Page Visibility integration on the inline heartbeat
+ * script: a hidden tab suppresses both presence-ping and
+ * presence-editor-ping, and visibility restore triggers an immediate
+ * heartbeat tick.
+ *
+ * Playwright headless browsers don't fire real visibilitychange when a
+ * tab is backgrounded, so these tests stub `document.visibilityState`
+ * via Object.defineProperty and dispatch the event manually.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js tests/e2e/presence-visibility.test.js
+ *
+ * @package WordPress
+ * @since 7.1.0
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Fakes document.visibilityState and fires a visibilitychange event.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {'hidden' | 'visible'}            state
+ */
+async function setVisibility( page, state ) {
+	await page.evaluate( ( value ) => {
+		Object.defineProperty( document, 'visibilityState', {
+			configurable: true,
+			get: () => value,
+		} );
+		document.dispatchEvent( new Event( 'visibilitychange' ) );
+	}, state );
+}
+
+/**
+ * Forces a heartbeat tick and resolves with the data object that
+ * `heartbeat-send` listeners (including the plugin's) saw.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<object>}
+ */
+function captureHeartbeatSend( page ) {
+	return page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				// The plugin's handler is registered first, so by the time this
+				// one-shot listener fires the data object has already been
+				// mutated (or skipped) as appropriate.
+				jQuery( document ).one( 'heartbeat-send', ( event, data ) => {
+					resolve( data );
+				} );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+test.describe( 'Presence Visibility', () => {
+	test( 'heartbeat-send omits presence-ping while document is hidden', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( '/' );
+		// Warm up the heartbeat machinery so subsequent connectNow() calls
+		// route through our handler.
+		await page.evaluate( () => wp.heartbeat.connectNow() );
+		await page.waitForTimeout( 1000 );
+
+		await setVisibility( page, 'hidden' );
+		const hidden = await captureHeartbeatSend( page );
+		expect( hidden[ 'presence-ping' ] ).toBeUndefined();
+
+		await setVisibility( page, 'visible' );
+		const visible = await captureHeartbeatSend( page );
+		expect( visible[ 'presence-ping' ] ).toBeDefined();
+		expect( visible[ 'presence-ping' ].screen ).toBeTruthy();
+	} );
+
+	test( 'heartbeat-send omits presence-editor-ping while editor tab is hidden', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'E2E Visibility Editor Test',
+			status: 'draft',
+		} );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await page.evaluate( () => wp.heartbeat.connectNow() );
+		await page.waitForTimeout( 1000 );
+
+		await setVisibility( page, 'hidden' );
+		const hidden = await captureHeartbeatSend( page );
+		expect( hidden[ 'presence-editor-ping' ] ).toBeUndefined();
+
+		await setVisibility( page, 'visible' );
+		const visible = await captureHeartbeatSend( page );
+		expect( visible[ 'presence-editor-ping' ] ).toBeDefined();
+		expect( visible[ 'presence-editor-ping' ].post_id ).toBe( post.id );
+	} );
+
+	test( 'visibility restore triggers an immediate heartbeat tick', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( '/' );
+		await page.evaluate( () => wp.heartbeat.connectNow() );
+		await page.waitForTimeout( 1000 );
+
+		// Go hidden first so the next 'visible' event has something to do.
+		await setVisibility( page, 'hidden' );
+
+		// Wrap connectNow to count invocations from this point forward.
+		await page.evaluate( () => {
+			window.__connectNowCalls = 0;
+			const original = wp.heartbeat.connectNow.bind( wp.heartbeat );
+			wp.heartbeat.connectNow = function () {
+				window.__connectNowCalls++;
+				return original();
+			};
+		} );
+
+		await setVisibility( page, 'visible' );
+
+		await page.waitForFunction(
+			() => window.__connectNowCalls > 0,
+			null,
+			{ timeout: 5000 }
+		);
+		const calls = await page.evaluate( () => window.__connectNowCalls );
+		expect( calls ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/tests/e2e/presence-visibility.test.js
+++ b/tests/e2e/presence-visibility.test.js
@@ -19,6 +19,17 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 /**
+ * Waits until the WordPress heartbeat library is ready on the page.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+/**
  * Fakes document.visibilityState and fires a visibilitychange event.
  *
  * @param {import('@playwright/test').Page} page
@@ -57,15 +68,16 @@ function captureHeartbeatSend( page ) {
 }
 
 test.describe( 'Presence Visibility', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
 	test( 'heartbeat-send omits presence-ping while document is hidden', async ( {
 		admin,
 		page,
 	} ) => {
 		await admin.visitAdminPage( '/' );
-		// Warm up the heartbeat machinery so subsequent connectNow() calls
-		// route through our handler.
-		await page.evaluate( () => wp.heartbeat.connectNow() );
-		await page.waitForTimeout( 1000 );
+		await waitForHeartbeat( page );
 
 		await setVisibility( page, 'hidden' );
 		const hidden = await captureHeartbeatSend( page );
@@ -91,8 +103,7 @@ test.describe( 'Presence Visibility', () => {
 			'post.php',
 			`post=${ post.id }&action=edit`
 		);
-		await page.evaluate( () => wp.heartbeat.connectNow() );
-		await page.waitForTimeout( 1000 );
+		await waitForHeartbeat( page );
 
 		await setVisibility( page, 'hidden' );
 		const hidden = await captureHeartbeatSend( page );
@@ -109,30 +120,35 @@ test.describe( 'Presence Visibility', () => {
 		page,
 	} ) => {
 		await admin.visitAdminPage( '/' );
-		await page.evaluate( () => wp.heartbeat.connectNow() );
-		await page.waitForTimeout( 1000 );
+		await waitForHeartbeat( page );
 
 		// Go hidden first so the next 'visible' event has something to do.
 		await setVisibility( page, 'hidden' );
 
-		// Wrap connectNow to count invocations from this point forward.
-		await page.evaluate( () => {
-			window.__connectNowCalls = 0;
-			const original = wp.heartbeat.connectNow.bind( wp.heartbeat );
-			wp.heartbeat.connectNow = function () {
-				window.__connectNowCalls++;
-				return original();
-			};
+		// Wrap connectNow to count invocations and snapshot the counter
+		// immediately before flipping visible, so we measure exactly the
+		// delta caused by our visibilitychange handler.
+		const before = await page.evaluate( () => {
+			window.__connectNowCalls = window.__connectNowCalls || 0;
+			if ( ! window.__connectNowWrapped ) {
+				const original = wp.heartbeat.connectNow.bind( wp.heartbeat );
+				wp.heartbeat.connectNow = function () {
+					window.__connectNowCalls++;
+					return original();
+				};
+				window.__connectNowWrapped = true;
+			}
+			return window.__connectNowCalls;
 		} );
 
 		await setVisibility( page, 'visible' );
 
 		await page.waitForFunction(
-			() => window.__connectNowCalls > 0,
-			null,
+			( baseline ) => window.__connectNowCalls > baseline,
+			before,
 			{ timeout: 5000 }
 		);
-		const calls = await page.evaluate( () => window.__connectNowCalls );
-		expect( calls ).toBeGreaterThan( 0 );
+		const after = await page.evaluate( () => window.__connectNowCalls );
+		expect( after - before ).toBeGreaterThanOrEqual( 1 );
 	} );
 } );


### PR DESCRIPTION
Closes #16.

A user with a background tab on a presence-enabled page was still reported as actively present.

## Change

Two small additions to the inline heartbeat script:

1. In the `heartbeat-send` handler, return early when `document.visibilityState === 'hidden'`. The presence-ping is omitted, and the existing 60 s TTL plus the cron sweep clean up the stale entry naturally.
2. On `visibilitychange` to `'visible'`, call `wp.heartbeat.connectNow()` so the user is re-established in the room within milliseconds rather than waiting for the next heartbeat interval.

This is intentionally a soft fix (no explicit `DELETE`) so it can land independently of any pagehide-based cleanup. If we later add pagehide DELETEs (see #15 / #19), a small follow-up could fire the same `leave()` on hidden as well; out of scope here to keep this diff minimal.

## Files

- `includes/heartbeat.php`

## Verification

With wp-env running, log in as editor in window A and as admin in window B. From the admin window, watch the Who's Online widget. In window A, switch to a different tab — within roughly a heartbeat interval the editor's screen should stop updating. Switch back to the admin tab and the editor's presence should refresh on the next tick.