### PR TITLE
Alert when an admin screen goes stale due to another user's save

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,10 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: '22'
 
-      - run: npm install -g @wordpress/env@11.7.0
+      - run: npm install -g @wordpress/env@11.8.1
 
       # Avoids the intermittent 504s on api.github.com during wp-env's
       # Docker build (PR #22). Authenticated requests dodge the issue.

--- a/assets/css/stale-screen.css
+++ b/assets/css/stale-screen.css
@@ -1,0 +1,30 @@
+/**
+ * Stale-screen banner styles.
+ *
+ * Layout for the dynamically-injected warning notice that fires when
+ * another user saves the screen the current viewer is on.
+ *
+ * @package Presence_API
+ */
+
+.wp-presence-stale-notice p {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 10px;
+	/* Reset core's `.notice p` margin so it doesn't compound with `gap`. */
+	margin: 0;
+}
+
+.wp-presence-stale-avatar {
+	flex-shrink: 0;
+	border-radius: 50%;
+}
+
+.wp-presence-stale-text {
+	flex: 1 1 auto;
+}
+
+.wp-presence-stale-notice .button-primary {
+	flex-shrink: 0;
+}

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -1,0 +1,136 @@
+/**
+ * Stale-screen banner client.
+ *
+ * Pings the server with the current screen key on every Heartbeat tick and
+ * renders a non-blocking warning notice when the server reports a revision
+ * newer than this page's baseline. The baseline, current screen key, and
+ * translated strings are passed in via `window.wpPresenceStaleScreen`,
+ * which the enqueue handler emits as a `before` inline script.
+ *
+ * @package Presence_API
+ */
+
+( function ( $ ) {
+	'use strict';
+
+	if ( typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined' ) {
+		return;
+	}
+
+	const config      = window.wpPresenceStaleScreen || {};
+	const screenKey   = config.screenKey || '';
+	const strings     = config.strings || {};
+	let baselineRev   = parseInt( config.baselineRev, 10 ) || 0;
+	let bannerShown   = false;
+
+	if ( ! screenKey ) {
+		return;
+	}
+
+	$( document ).on( 'heartbeat-send', function ( event, data ) {
+		if ( document.visibilityState === 'hidden' ) {
+			return;
+		}
+		data[ 'presence-screen-ping' ] = { key: screenKey };
+	} );
+
+	$( document ).on( 'heartbeat-tick', function ( event, data ) {
+		const info = data && data[ 'presence-screen-rev' ];
+		if ( ! info || info.key !== screenKey ) {
+			return;
+		}
+		const rev = parseInt( info.rev, 10 ) || 0;
+		if ( rev <= baselineRev ) {
+			return;
+		}
+		// If the latest save was by the current user AND the revision jumped
+		// by exactly one, advance the baseline silently so we don't yell at
+		// them about their own save. A jump of more than one means someone
+		// else saved in between and only the latest actor reaches us — fall
+		// through to render the notice in that case.
+		if ( info.actor_is_me && rev === baselineRev + 1 ) {
+			baselineRev = rev;
+			return;
+		}
+		if ( bannerShown ) {
+			return;
+		}
+		showBanner( info );
+	} );
+
+	function showBanner( info ) {
+		bannerShown = true;
+		const target = document.querySelector( '.wrap' ) || document.getElementById( 'wpbody-content' );
+		if ( ! target ) {
+			return;
+		}
+
+		// Place the notice after the screen heading, matching where
+		// `do_action('admin_notices')` injects on a normal page load.
+		const heading = target.querySelector( ':scope > h1' );
+		const before  = heading && heading.nextSibling ? heading.nextSibling : target.firstChild;
+
+		const notice = document.createElement( 'div' );
+		notice.className = 'notice notice-warning is-dismissible wp-presence-stale-notice';
+		// Announce the new banner to assistive tech without interrupting
+		// whatever the user is currently doing on the screen.
+		notice.setAttribute( 'role', 'status' );
+		notice.setAttribute( 'aria-live', 'polite' );
+
+		const p = document.createElement( 'p' );
+
+		if ( info.actor_avatar_url ) {
+			const avatar = document.createElement( 'img' );
+			avatar.src       = info.actor_avatar_url;
+			avatar.width     = 24;
+			avatar.height    = 24;
+			// Decorative — the actor name is already in the adjacent text.
+			avatar.alt       = '';
+			avatar.className = 'wp-presence-stale-avatar';
+			p.appendChild( avatar );
+		}
+
+		const text = document.createElement( 'span' );
+		text.className   = 'wp-presence-stale-text';
+		text.textContent = formatMessage( info );
+		p.appendChild( text );
+
+		const reload = document.createElement( 'button' );
+		reload.type        = 'button';
+		reload.className   = 'button button-primary';
+		reload.textContent = strings.reload || 'Reload';
+		reload.addEventListener( 'click', function () {
+			window.location.reload();
+		} );
+		p.appendChild( reload );
+		notice.appendChild( p );
+
+		const dismiss = document.createElement( 'button' );
+		dismiss.type      = 'button';
+		dismiss.className = 'notice-dismiss';
+		const sr = document.createElement( 'span' );
+		sr.className   = 'screen-reader-text';
+		sr.textContent = strings.dismiss || 'Dismiss this notice.';
+		dismiss.appendChild( sr );
+		dismiss.addEventListener( 'click', function () {
+			notice.remove();
+		} );
+		notice.appendChild( dismiss );
+
+		target.insertBefore( notice, before );
+	}
+
+	function formatMessage( info ) {
+		const timeAgo = info.time_ago || '';
+		if ( info.actor_name ) {
+			// `split('%1$s').join(name)` avoids String.replace's $-pattern
+			// interpretation so display names with `$&`, `$1`, etc. don't
+			// get reinterpreted as backreferences.
+			return ( strings.updatedBy || '%1$s updated this screen %2$s.' )
+				.split( '%1$s' ).join( info.actor_name )
+				.split( '%2$s' ).join( timeAgo );
+		}
+		return ( strings.updatedAnonymously || 'This screen was updated %s.' )
+			.split( '%s' ).join( timeAgo );
+	}
+} )( jQuery );

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -59,11 +59,11 @@
 	} );
 
 	function showBanner( info ) {
-		bannerShown = true;
 		const target = document.querySelector( '.wrap' ) || document.getElementById( 'wpbody-content' );
 		if ( ! target ) {
 			return;
 		}
+		bannerShown = true;
 
 		// Place the notice after the screen heading, matching where
 		// `do_action('admin_notices')` injects on a normal page load.

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -323,12 +323,19 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	if ( ! is_scalar( $raw_key ) || '' === (string) $raw_key ) {
 		return $response;
 	}
-	if ( ! current_user_can( 'edit_posts' ) ) {
-		return $response;
-	}
 	// Cap key length to the InnoDB index limit so we can't be made to do
 	// pointless work by clients pinging with megabyte-long keys.
-	$key   = wp_presence_normalize_screen_key( $raw_key );
+	$key = wp_presence_normalize_screen_key( $raw_key );
+
+	// Require the viewer to have access to the screen whose revision is being disclosed.
+	if ( 0 === strpos( $key, 'options/' ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return $response;
+		}
+	} elseif ( ! current_user_can( 'edit_posts' ) ) {
+		return $response;
+	}
+
 	$entry = wp_presence_get_screen_revision( $key );
 	if ( ! $entry ) {
 		return $response;

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -223,6 +223,11 @@ function wp_presence_on_updated_option( $option ) {
 	if ( ! $option_page ) {
 		return;
 	}
+	static $bumped_option_pages = array();
+	if ( isset( $bumped_option_pages[ $option_page ] ) ) {
+		return;
+	}
+	$bumped_option_pages[ $option_page ] = true;
 	wp_presence_bump_screen_revision( 'options/' . $option_page );
 }
 

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -8,7 +8,7 @@
  * a non-blocking notice prompting them to reload.
  *
  * Coverage in this first cut: classic admin screens that submit via POST and
- * redirect on success — Settings → General/Writing/Reading/Discussion/Media,
+ * redirect on success — Settings → General/Writing/Reading/Discussion/Media/Permalinks,
  * post edits (post.php), user edits (user-edit.php, profile.php), term edits
  * (edit-tags.php), and comment edits (comment.php). JS-driven and REST-driven
  * screens can opt in via the `wp_presence_current_screen_key` filter plus a

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -301,7 +301,8 @@ function wp_presence_on_edit_comment( $comment_id ) {
  */
 function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	unset( $screen_id );
-	if ( empty( $data['presence-screen-ping']['key'] ) ) {
+	$raw_key = $data['presence-screen-ping']['key'] ?? null;
+	if ( ! is_scalar( $raw_key ) || '' === (string) $raw_key ) {
 		return $response;
 	}
 	if ( ! current_user_can( 'edit_posts' ) ) {
@@ -309,7 +310,7 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	}
 	// Cap key length to the InnoDB index limit so we can't be made to do
 	// pointless work by clients pinging with megabyte-long keys.
-	$key   = substr( (string) $data['presence-screen-ping']['key'], 0, 191 );
+	$key   = substr( (string) $raw_key, 0, 191 );
 	$entry = wp_presence_get_screen_revision( $key );
 	if ( ! $entry ) {
 		return $response;

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -326,7 +326,7 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 		? sprintf(
 			/* translators: %s: human-readable time difference like "2 minutes". */
 			__( '%s ago', 'default' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Intentionally reuses core's "%s ago" string so we inherit its translation for every locale.
-			human_time_diff( $actor_time )
+			human_time_diff( $actor_time, time() )
 		)
 		: '';
 

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -26,6 +26,10 @@ if ( ! defined( 'WP_PRESENCE_SCREEN_REV_LIMIT' ) ) {
 	define( 'WP_PRESENCE_SCREEN_REV_LIMIT', 200 );
 }
 
+if ( ! defined( 'WP_PRESENCE_SCREEN_KEY_LIMIT' ) ) {
+	define( 'WP_PRESENCE_SCREEN_KEY_LIMIT', 191 );
+}
+
 /**
  * Returns the full screen-revision map.
  *
@@ -52,6 +56,16 @@ function wp_presence_get_screen_revision( $screen_key ) {
 }
 
 /**
+ * Normalizes a screen key for storage and lookup.
+ *
+ * @param string $screen_key Screen key to normalize.
+ * @return string
+ */
+function wp_presence_normalize_screen_key( $screen_key ) {
+	return substr( (string) $screen_key, 0, WP_PRESENCE_SCREEN_KEY_LIMIT );
+}
+
+/**
  * Increments the revision counter for a screen and records the actor.
  *
  * @param string $screen_key Screen key to bump.
@@ -59,7 +73,7 @@ function wp_presence_get_screen_revision( $screen_key ) {
  * @return int|false New revision number, or false when the key is empty.
  */
 function wp_presence_bump_screen_revision( $screen_key, $actor_id = 0 ) {
-	$screen_key = (string) $screen_key;
+	$screen_key = wp_presence_normalize_screen_key( $screen_key );
 	if ( '' === $screen_key ) {
 		return false;
 	}
@@ -310,7 +324,7 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	}
 	// Cap key length to the InnoDB index limit so we can't be made to do
 	// pointless work by clients pinging with megabyte-long keys.
-	$key   = substr( (string) $raw_key, 0, 191 );
+	$key   = wp_presence_normalize_screen_key( $raw_key );
 	$entry = wp_presence_get_screen_revision( $key );
 	if ( ! $entry ) {
 		return $response;

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -51,6 +51,10 @@ function wp_presence_get_screen_revisions() {
  * @return array|null
  */
 function wp_presence_get_screen_revision( $screen_key ) {
+	$screen_key = wp_presence_normalize_screen_key( $screen_key );
+	if ( '' === $screen_key ) {
+		return null;
+	}
 	$map = wp_presence_get_screen_revisions();
 	return isset( $map[ $screen_key ] ) ? $map[ $screen_key ] : null;
 }

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -223,8 +223,8 @@ function wp_presence_current_screen_key() {
 	 * @param string    $key    Computed screen key, or '' when none applies.
 	 * @param WP_Screen $screen Current screen.
 	 */
-	return (string) apply_filters( 'wp_presence_current_screen_key', $key, $screen );
-}
+	$key = (string) apply_filters( 'wp_presence_current_screen_key', $key, $screen );
+	return '' === $key ? '' : wp_presence_normalize_screen_key( $key );
 
 /**
  * Bumps the Settings screen's revision when its option_page is saved.

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -225,6 +225,7 @@ function wp_presence_current_screen_key() {
 	 */
 	$key = (string) apply_filters( 'wp_presence_current_screen_key', $key, $screen );
 	return '' === $key ? '' : wp_presence_normalize_screen_key( $key );
+}
 
 /**
  * Bumps the Settings screen's revision when its option_page is saved.

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * Stale-screen detection: alert users when an admin screen they're viewing is out of date.
+ *
+ * When a user saves a Settings page, a post, a user, a term, or a comment, a
+ * per-screen revision counter is bumped. Other users currently viewing the
+ * same screen receive the new revision on the next Heartbeat tick and render
+ * a non-blocking notice prompting them to reload.
+ *
+ * Coverage in this first cut: classic admin screens that submit via POST and
+ * redirect on success — Settings → General/Writing/Reading/Discussion/Media,
+ * post edits (post.php), user edits (user-edit.php, profile.php), term edits
+ * (edit-tags.php), and comment edits (comment.php). JS-driven and REST-driven
+ * screens can opt in via the `wp_presence_current_screen_key` filter plus a
+ * future client-side `markScreenStale()` API.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Bound the option row that stores per-screen revisions.
+if ( ! defined( 'WP_PRESENCE_SCREEN_REV_LIMIT' ) ) {
+	define( 'WP_PRESENCE_SCREEN_REV_LIMIT', 200 );
+}
+
+/**
+ * Returns the full screen-revision map.
+ *
+ * Shape: array( '<screen_key>' => array( 'rev' => int, 'actor_id' => int, 'time' => int ) ).
+ * The actor's display name and avatar are looked up fresh on each heartbeat
+ * tick — not stored — so renames and avatar changes show immediately.
+ *
+ * @return array
+ */
+function wp_presence_get_screen_revisions() {
+	$map = get_option( 'wp_presence_screen_revisions', array() );
+	return is_array( $map ) ? $map : array();
+}
+
+/**
+ * Returns the revision entry for a single screen, or null if none.
+ *
+ * @param string $screen_key Screen key to look up.
+ * @return array|null
+ */
+function wp_presence_get_screen_revision( $screen_key ) {
+	$map = wp_presence_get_screen_revisions();
+	return isset( $map[ $screen_key ] ) ? $map[ $screen_key ] : null;
+}
+
+/**
+ * Increments the revision counter for a screen and records the actor.
+ *
+ * @param string $screen_key Screen key to bump.
+ * @param int    $actor_id   Optional. Defaults to the current user.
+ * @return int|false New revision number, or false when the key is empty.
+ */
+function wp_presence_bump_screen_revision( $screen_key, $actor_id = 0 ) {
+	$screen_key = (string) $screen_key;
+	if ( '' === $screen_key ) {
+		return false;
+	}
+	if ( ! $actor_id ) {
+		$actor_id = get_current_user_id();
+	}
+
+	$map      = wp_presence_get_screen_revisions();
+	$previous = isset( $map[ $screen_key ]['rev'] ) ? (int) $map[ $screen_key ]['rev'] : 0;
+	$revision = $previous + 1;
+
+	$map[ $screen_key ] = array(
+		'rev'      => $revision,
+		'actor_id' => (int) $actor_id,
+		'time'     => time(),
+	);
+
+	// LRU-ish trim by oldest update time when over the limit.
+	if ( count( $map ) > WP_PRESENCE_SCREEN_REV_LIMIT ) {
+		uasort(
+			$map,
+			static function ( $a, $b ) {
+				$at = isset( $a['time'] ) ? (int) $a['time'] : 0;
+				$bt = isset( $b['time'] ) ? (int) $b['time'] : 0;
+				return $at <=> $bt;
+			}
+		);
+		$map = array_slice( $map, - WP_PRESENCE_SCREEN_REV_LIMIT, null, true );
+	}
+
+	update_option( 'wp_presence_screen_revisions', $map, false );
+
+	/**
+	 * Fires after a screen revision is bumped.
+	 *
+	 * @param string $screen_key Screen key that was bumped.
+	 * @param int    $revision   New revision number.
+	 * @param int    $actor_id   User who triggered the bump.
+	 */
+	do_action( 'wp_presence_screen_revision_bumped', $screen_key, $revision, $actor_id );
+
+	return $revision;
+}
+
+/**
+ * True when the current request is a user-initiated admin save (not cron, CLI, or REST).
+ *
+ * The REST gate is verified by inspection only; defining REST_REQUEST in a
+ * PHPUnit test would leak into every subsequent test in the same process
+ * (PHP constants can't be unset), so the gate is intentionally not exercised
+ * via integration tests.
+ *
+ * @return bool
+ */
+function wp_presence_is_admin_screen_save() {
+	if ( wp_doing_cron() ) {
+		return false;
+	}
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return false;
+	}
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return false;
+	}
+	return is_admin();
+}
+
+/**
+ * Resolves the screen key for the currently rendered admin screen.
+ *
+ * @return string Empty string when the current screen has no stale-detection coverage.
+ */
+function wp_presence_current_screen_key() {
+	if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+		return '';
+	}
+	$screen = get_current_screen();
+	if ( ! $screen ) {
+		return '';
+	}
+
+	$key = '';
+
+	switch ( $screen->base ) {
+		case 'options-general':
+		case 'options-writing':
+		case 'options-reading':
+		case 'options-discussion':
+		case 'options-media':
+		case 'options-permalink':
+			// Slash-separated to match the plugin's room naming convention
+			// (cf. `admin/online`, `postType/post:42`).
+			$key = str_replace( 'options-', 'options/', $screen->base );
+			break;
+
+		case 'post':
+			$post = get_post();
+			if ( $post ) {
+				$key = 'post/' . $post->ID;
+			}
+			break;
+
+		case 'user-edit':
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen identification.
+			$user_id = isset( $_GET['user_id'] ) ? absint( $_GET['user_id'] ) : 0;
+			if ( $user_id ) {
+				$key = 'user-edit/' . $user_id;
+			}
+			break;
+
+		case 'profile':
+			$current = get_current_user_id();
+			if ( $current ) {
+				$key = 'user-edit/' . $current;
+			}
+			break;
+
+		case 'edit-tags':
+		case 'term':
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen identification.
+			$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_key( wp_unslash( $_GET['taxonomy'] ) ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen identification.
+			$term_id = isset( $_GET['tag_ID'] ) ? absint( $_GET['tag_ID'] ) : 0;
+			if ( $taxonomy && $term_id ) {
+				$key = 'term/' . $taxonomy . '/' . $term_id;
+			}
+			break;
+
+		case 'comment':
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen identification.
+			$comment_id = isset( $_GET['c'] ) ? absint( $_GET['c'] ) : 0;
+			if ( $comment_id ) {
+				$key = 'comment/' . $comment_id;
+			}
+			break;
+	}
+
+	/**
+	 * Filters the screen key used to track stale-screen state.
+	 *
+	 * Return a non-empty string to opt a custom screen into stale-screen detection.
+	 *
+	 * @param string    $key    Computed screen key, or '' when none applies.
+	 * @param WP_Screen $screen Current screen.
+	 */
+	return (string) apply_filters( 'wp_presence_current_screen_key', $key, $screen );
+}
+
+/**
+ * Bumps the Settings screen's revision when its option_page is saved.
+ *
+ * @param string $option Updated option name. Unused; we key on $_POST['option_page'].
+ */
+function wp_presence_on_updated_option( $option ) {
+	unset( $option );
+	if ( ! wp_presence_is_admin_screen_save() ) {
+		return;
+	}
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- options.php verifies its own nonce; we only read $_POST to identify the originating screen.
+	$option_page = isset( $_POST['option_page'] ) ? sanitize_key( wp_unslash( $_POST['option_page'] ) ) : '';
+	if ( ! $option_page ) {
+		return;
+	}
+	wp_presence_bump_screen_revision( 'options/' . $option_page );
+}
+
+/**
+ * Bumps a post's screen revision when the post is updated.
+ *
+ * @param int     $post_id     Post ID.
+ * @param WP_Post $post_after  Post after update.
+ * @param WP_Post $post_before Post before update. Unused.
+ */
+function wp_presence_on_post_updated( $post_id, $post_after, $post_before ) {
+	unset( $post_before );
+	if ( ! wp_presence_is_admin_screen_save() ) {
+		return;
+	}
+	if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+	if ( isset( $post_after->post_status ) && 'auto-draft' === $post_after->post_status ) {
+		return;
+	}
+	wp_presence_bump_screen_revision( 'post/' . (int) $post_id );
+}
+
+/**
+ * Bumps a user-edit screen's revision when the user is updated.
+ *
+ * @param int $user_id User ID.
+ */
+function wp_presence_on_profile_update( $user_id ) {
+	if ( ! wp_presence_is_admin_screen_save() ) {
+		return;
+	}
+	wp_presence_bump_screen_revision( 'user-edit/' . (int) $user_id );
+}
+
+/**
+ * Bumps a term-edit screen's revision when the term is updated.
+ *
+ * @param int    $term_id  Term ID.
+ * @param int    $tt_id    Term taxonomy ID. Unused.
+ * @param string $taxonomy Taxonomy slug.
+ */
+function wp_presence_on_edited_term( $term_id, $tt_id, $taxonomy ) {
+	unset( $tt_id );
+	if ( ! wp_presence_is_admin_screen_save() ) {
+		return;
+	}
+	wp_presence_bump_screen_revision( 'term/' . sanitize_key( $taxonomy ) . '/' . (int) $term_id );
+}
+
+/**
+ * Bumps a comment-edit screen's revision when the comment is updated.
+ *
+ * @param int $comment_id Comment ID.
+ */
+function wp_presence_on_edit_comment( $comment_id ) {
+	if ( ! wp_presence_is_admin_screen_save() ) {
+		return;
+	}
+	wp_presence_bump_screen_revision( 'comment/' . (int) $comment_id );
+}
+
+/**
+ * Returns the current revision for the screen the client claims to be on.
+ *
+ * @param array  $response  Heartbeat response.
+ * @param array  $data      $_POST data.
+ * @param string $screen_id Heartbeat screen id. Unused.
+ * @return array
+ */
+function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
+	unset( $screen_id );
+	if ( empty( $data['presence-screen-ping']['key'] ) ) {
+		return $response;
+	}
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		return $response;
+	}
+	// Cap key length to the InnoDB index limit so we can't be made to do
+	// pointless work by clients pinging with megabyte-long keys.
+	$key   = substr( (string) $data['presence-screen-ping']['key'], 0, 191 );
+	$entry = wp_presence_get_screen_revision( $key );
+	if ( ! $entry ) {
+		return $response;
+	}
+	$actor_id   = (int) $entry['actor_id'];
+	$actor_time = (int) $entry['time'];
+	// Resolve display name and avatar fresh on every tick so renames and
+	// avatar changes show immediately instead of carrying stale data from
+	// the moment of the bump.
+	$user       = $actor_id ? get_userdata( $actor_id ) : null;
+	$actor_name = $user ? (string) $user->display_name : '';
+	$avatar_url = $user ? (string) get_avatar_url( $actor_id, array( 'size' => 48 ) ) : '';
+	$time_ago   = $actor_time
+		? sprintf(
+			/* translators: %s: human-readable time difference like "2 minutes". */
+			__( '%s ago', 'default' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Intentionally reuses core's "%s ago" string so we inherit its translation for every locale.
+			human_time_diff( $actor_time )
+		)
+		: '';
+
+	$response['presence-screen-rev'] = array(
+		'key'              => $key,
+		'rev'              => (int) $entry['rev'],
+		'actor_id'         => $actor_id,
+		'actor_name'       => $actor_name,
+		'actor_avatar_url' => $avatar_url,
+		'time'             => $actor_time,
+		'time_ago'         => $time_ago,
+		// Only treat the viewer as the actor when both sides are a real user;
+		// `0 === 0` would otherwise advance the baseline for anonymous bumps.
+		'actor_is_me'      => $actor_id > 0 && get_current_user_id() === $actor_id,
+	);
+	return $response;
+}
+
+/**
+ * Enqueues the stale-screen banner script on screens we cover.
+ */
+function wp_presence_enqueue_stale_screen_banner() {
+	if ( ! is_admin() ) {
+		return;
+	}
+	if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+		return;
+	}
+
+	$screen_key = wp_presence_current_screen_key();
+	if ( '' === $screen_key ) {
+		return;
+	}
+
+	$entry        = wp_presence_get_screen_revision( $screen_key );
+	$baseline_rev = $entry ? (int) $entry['rev'] : 0;
+
+	wp_enqueue_style(
+		'wp-presence-stale-screen',
+		WP_PRESENCE_PLUGIN_URL . 'assets/css/stale-screen.css',
+		array(),
+		WP_PRESENCE_VERSION
+	);
+
+	wp_enqueue_script(
+		'wp-presence-stale-screen',
+		WP_PRESENCE_PLUGIN_URL . 'assets/js/stale-screen.js',
+		array( 'jquery', 'heartbeat' ),
+		WP_PRESENCE_VERSION,
+		true
+	);
+
+	$config = array(
+		'screenKey'   => $screen_key,
+		'baselineRev' => $baseline_rev,
+		'strings'     => array(
+			/* translators: 1: display name, 2: relative time like "2 minutes ago". */
+			'updatedBy'          => __( '%1$s updated this screen %2$s.', 'presence-api' ),
+			/* translators: %s: relative time like "2 minutes ago". */
+			'updatedAnonymously' => __( 'This screen was updated %s.', 'presence-api' ),
+			'reload'             => __( 'Reload', 'presence-api' ),
+			'dismiss'            => __( 'Dismiss this notice.', 'presence-api' ),
+		),
+	);
+
+	wp_add_inline_script(
+		'wp-presence-stale-screen',
+		sprintf( 'window.wpPresenceStaleScreen = %s;', wp_json_encode( $config, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
+		'before'
+	);
+}

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -341,8 +341,8 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	if ( ! $entry ) {
 		return $response;
 	}
-	$actor_id   = (int) $entry['actor_id'];
-	$actor_time = (int) $entry['time'];
+	$actor_id   = (int) ( $entry['actor_id'] ?? 0 );
+	$actor_time = (int) ( $entry['time'] ?? 0 );
 	// Resolve display name and avatar fresh on every tick so renames and
 	// avatar changes show immediately instead of carrying stale data from
 	// the moment of the bump.
@@ -359,7 +359,7 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 
 	$response['presence-screen-rev'] = array(
 		'key'              => $key,
-		'rev'              => (int) $entry['rev'],
+		'rev'              => (int) ( $entry['rev'] ?? 0 ),
 		'actor_id'         => $actor_id,
 		'actor_name'       => $actor_name,
 		'actor_avatar_url' => $avatar_url,

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -376,7 +376,7 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 
 	$response['presence-screen-rev'] = array(
 		'key'              => $key,
-		'rev'              => (int) $entry['rev'],
+		'rev'              => isset( $entry['rev'] ) ? (int) $entry['rev'] : 0,
 		'actor_id'         => $actor_id,
 		'actor_name'       => $actor_name,
 		'actor_avatar_url' => $avatar_url,

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -320,7 +320,8 @@ function wp_presence_on_edit_comment( $comment_id ) {
  */
 function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	unset( $screen_id );
-	$raw_key = $data['presence-screen-ping']['key'] ?? null;
+	$ping    = $data['presence-screen-ping'] ?? null;
+	$raw_key = is_array( $ping ) && array_key_exists( 'key', $ping ) ? $ping['key'] : null;
 	if ( ! is_scalar( $raw_key ) || '' === (string) $raw_key ) {
 		return $response;
 	}

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -334,6 +334,22 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return $response;
 		}
+	} elseif ( preg_match( '#^post/(\d+)$#', $key, $m ) ) {
+		if ( ! current_user_can( 'edit_post', (int) $m[1] ) ) {
+			return $response;
+		}
+	} elseif ( preg_match( '#^user-edit/(\d+)$#', $key, $m ) ) {
+		if ( ! current_user_can( 'edit_user', (int) $m[1] ) ) {
+			return $response;
+		}
+	} elseif ( preg_match( '#^term/([^/]+)/(\d+)$#', $key, $m ) ) {
+		if ( ! current_user_can( 'edit_term', (int) $m[2], $m[1] ) ) {
+			return $response;
+		}
+	} elseif ( preg_match( '#^comment/(\d+)$#', $key, $m ) ) {
+		if ( ! current_user_can( 'edit_comment', (int) $m[1] ) ) {
+			return $response;
+		}
 	} elseif ( ! current_user_can( 'edit_posts' ) ) {
 		return $response;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "presence-api",
 			"devDependencies": {
 				"@playwright/test": "^1.58.2",
-				"@wordpress/e2e-test-utils-playwright": "^1.42.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.48.1",
 				"@wordpress/env": "^11.0.0"
 			}
 		},
@@ -2377,9 +2377,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.42.0.tgz",
-			"integrity": "sha512-IN5OK4QTymZxnUzOswK52y/YfHecmiMh+09LcVglxfqHecFgRqd40j1BcNv/7oFIlah6jRO74zC0bqKXX5fw/w==",
+			"version": "1.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.48.1.tgz",
+			"integrity": "sha512-jaBTZHZ0SG1MQ/Nb4GdaH7DMcieFp/ysYOoCodmhfoScFoWTI66/e8egPxU8cOs06gXnOYNPvJ9hnCaeCTz3ug==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"name": "presence-api",
 			"devDependencies": {
-				"@playwright/test": "^1.58.2",
+				"@playwright/test": "^1.61.0",
 				"@wordpress/e2e-test-utils-playwright": "^1.48.1",
 				"@wordpress/env": "^11.0.0"
 			}
@@ -1994,13 +1994,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.2"
+				"playwright": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5965,13 +5965,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.2"
+				"playwright-core": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5984,9 +5984,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"devDependencies": {
 				"@playwright/test": "^1.58.2",
 				"@wordpress/e2e-test-utils-playwright": "^1.48.1",
-				"@wordpress/env": "^11.0.0"
+				"@wordpress/env": "^11.8.1"
 			}
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -2412,24 +2412,24 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.2.0.tgz",
-			"integrity": "sha512-nypFE7APrPNjdukwTvfb95Tu56OdABksoycYHGPK8fid+OBx/8MnHgo4iESZoRm7ad6S287I3hH5p4pDNa1CRQ==",
+			"version": "11.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.8.1.tgz",
+			"integrity": "sha512-wboYnQNPfMfcgYgiNDbrGGZj8RkdeZtaz2UvmAVUrhOgAvHFpZXsKuXuLdCCSv7JdcHGG5xLWMYhvRLTGOcQ1g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
 				"@wp-playground/cli": "^3.0.48",
-				"chalk": "^4.0.0",
+				"adm-zip": "^0.5.9",
+				"chalk": "^4.1.1",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
 				"docker-compose": "^0.24.3",
-				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"js-yaml": "^3.13.1",
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
-				"simple-git": "^3.5.0",
+				"simple-git": "^3.24.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -2703,6 +2703,16 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
+			}
+		},
+		"node_modules/adm-zip": {
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+			"integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -3067,13 +3077,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3435,62 +3438,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
-			"engines": [
-				"node >= 0.8"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
-			}
-		},
-		"node_modules/concat-stream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/concat-stream/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/concat-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/concat-stream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -3566,13 +3513,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
 			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4076,22 +4016,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/extract-zip": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"concat-stream": "^1.6.2",
-				"debug": "^2.6.9",
-				"mkdirp": "^0.5.4",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -5493,19 +5417,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
 		"node_modules/module-details-from-path": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -6048,13 +5959,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/progress": {
 			"version": "2.0.3",
@@ -7296,13 +7200,6 @@
 			"version": "2.12.1",
 			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
 			"integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
 	"devDependencies": {
 		"@playwright/test": "^1.58.2",
 		"@wordpress/e2e-test-utils-playwright": "^1.48.1",
-		"@wordpress/env": "^11.0.0"
+		"@wordpress/env": "^11.8.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"test": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- /var/www/html/vendor/bin/phpunit --testdox"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.61.0",
 		"@wordpress/e2e-test-utils-playwright": "^1.48.1",
 		"@wordpress/env": "^11.0.0"
 	}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.58.2",
-		"@wordpress/e2e-test-utils-playwright": "^1.42.0",
+		"@wordpress/e2e-test-utils-playwright": "^1.48.1",
 		"@wordpress/env": "^11.0.0"
 	}
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -47,6 +47,7 @@ if ( isset( $wpdb->presence ) ) {
 define( 'WP_PRESENCE_VERSION', '0.1.2' );
 define( 'WP_PRESENCE_DB_VERSION', '1' );
 define( 'WP_PRESENCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WP_PRESENCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
 	define( 'WP_PRESENCE_DEFAULT_TTL', 60 );
 }
@@ -66,6 +67,7 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/class-wp-rest-presence-controlle
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/heartbeat.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/cron.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/post-lock-bridge.php';
+require_once WP_PRESENCE_PLUGIN_DIR . 'includes/screen-revisions.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/lifecycle.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/admin-bar.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/user-list.php';
@@ -141,6 +143,14 @@ add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_heartbeat_ping' );
 add_action( 'wp_enqueue_scripts', 'wp_presence_enqueue_heartbeat_ping' );
 add_filter( 'heartbeat_received', 'wp_presence_editor_heartbeat_received', 10, 3 );
 add_filter( 'heartbeat_received', 'wp_presence_bridge_post_lock', 11, 3 );
+add_filter( 'heartbeat_received', 'wp_presence_screen_heartbeat_received', 12, 3 );
+
+add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_stale_screen_banner' );
+add_action( 'updated_option', 'wp_presence_on_updated_option' );
+add_action( 'post_updated', 'wp_presence_on_post_updated', 10, 3 );
+add_action( 'profile_update', 'wp_presence_on_profile_update' );
+add_action( 'edited_term', 'wp_presence_on_edited_term', 10, 3 );
+add_action( 'edit_comment', 'wp_presence_on_edit_comment' );
 
 add_action( 'wp_login', 'wp_presence_on_login', 10, 2 );
 add_action( 'wp_logout', 'wp_presence_on_logout' );

--- a/tests/e2e/screen-stale-demo-helper.php
+++ b/tests/e2e/screen-stale-demo-helper.php
@@ -53,7 +53,7 @@ function presence_demo_render_buttons() {
 	<div class="notice notice-info is-dismissible">
 		<p>
 			<strong><?php esc_html_e( 'Demo:', 'presence-api' ); ?></strong>
-			<?php esc_html_e( 'pretend another user just saved this screen — the stale-screen notice should appear within a few seconds.', 'presence-api' ); ?>
+			<?php esc_html_e( 'simulate another user saving this screen. The stale notice will appear within seconds.', 'presence-api' ); ?>
 		</p>
 		<p>
 			<?php foreach ( $others as $user ) : ?>

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -375,15 +375,13 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_id );
 		set_current_screen( 'dashboard' );
 
-		add_filter(
-			'wp_presence_current_screen_key',
-			static function ( $key ) {
-				return $key ?: 'custom-screen';
-			}
-		);
+		$callback = static function ( $key ) {
+			return $key ?: 'custom-screen';
+		};
+		add_filter( 'wp_presence_current_screen_key', $callback );
 
 		$this->assertSame( 'custom-screen', wp_presence_current_screen_key() );
 
-		remove_all_filters( 'wp_presence_current_screen_key' );
+		remove_filter( 'wp_presence_current_screen_key', $callback );
 	}
 }

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -9,10 +9,12 @@
 class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
 	private static $admin_id;
+	private static $admin2_id;
 	private static $editor_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$admin2_id = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
@@ -263,7 +265,10 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_id );
 		wp_presence_bump_screen_revision( 'options/general', self::$admin_id );
 
-		wp_set_current_user( self::$editor_id );
+		// View as a *different* admin so the viewer can read an `options/*`
+		// revision (the handler requires `manage_options` for that prefix)
+		// without satisfying `actor_is_me`.
+		wp_set_current_user( self::$admin2_id );
 
 		$response = wp_presence_screen_heartbeat_received(
 			array(),

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -241,10 +241,8 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_presence_screen_heartbeat_received
 	 */
-	public function test_heartbeat_caps_oversized_screen_key() {
+	public function test_heartbeat_matches_oversized_screen_key_after_normalization() {
 		wp_set_current_user( self::$admin_id );
-		// 200-char key is bumped on the server but the heartbeat handler
-		// only looks up the first 191 chars, so it should not match.
 		$long_key = str_repeat( 'a', 200 );
 		wp_presence_bump_screen_revision( $long_key );
 
@@ -254,7 +252,8 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 			'long'
 		);
 
-		$this->assertArrayNotHasKey( 'presence-screen-rev', $response );
+		$this->assertArrayHasKey( 'presence-screen-rev', $response );
+		$this->assertSame( substr( $long_key, 0, 191 ), $response['presence-screen-rev']['key'] );
 	}
 
 	/**

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * Tests for stale-screen detection.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ */
+class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
+
+	private static $admin_id;
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	public function tear_down() {
+		delete_option( 'wp_presence_screen_revisions' );
+		unset( $_POST['option_page'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::wp_presence_bump_screen_revision
+	 */
+	public function test_bump_increments_revision_and_records_actor() {
+		wp_set_current_user( self::$admin_id );
+
+		$first  = wp_presence_bump_screen_revision( 'options/general' );
+		$second = wp_presence_bump_screen_revision( 'options/general' );
+
+		$this->assertSame( 1, $first );
+		$this->assertSame( 2, $second );
+
+		$entry = wp_presence_get_screen_revision( 'options/general' );
+		$this->assertNotNull( $entry );
+		$this->assertSame( 2, (int) $entry['rev'] );
+		$this->assertSame( self::$admin_id, (int) $entry['actor_id'] );
+		$this->assertArrayNotHasKey(
+			'actor_name',
+			$entry,
+			'Display name is resolved fresh on heartbeat — not stored — so renames show immediately.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_bump_screen_revision
+	 */
+	public function test_bump_rejects_empty_screen_key() {
+		wp_set_current_user( self::$admin_id );
+
+		$this->assertFalse( wp_presence_bump_screen_revision( '' ) );
+		$this->assertSame( array(), wp_presence_get_screen_revisions() );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_updated_option
+	 */
+	public function test_updated_option_bumps_when_option_page_present() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'options-general' );
+		$_POST['option_page'] = 'general';
+
+		update_option( 'blogname', 'New Title ' . wp_generate_password( 6, false ) );
+
+		$entry = wp_presence_get_screen_revision( 'options/general' );
+		$this->assertNotNull( $entry );
+		$this->assertSame( 1, (int) $entry['rev'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_updated_option
+	 */
+	public function test_updated_option_does_not_bump_without_option_page() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'options-general' );
+		// No $_POST['option_page']: this looks like a side-effect option update, not a Settings page save.
+
+		update_option( 'blogname', 'Side Effect ' . wp_generate_password( 6, false ) );
+
+		$this->assertSame( array(), wp_presence_get_screen_revisions() );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_post_updated
+	 */
+	public function test_post_updated_bumps_post_screen() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'post' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		// factory->post->create() runs save_post; assert it produced a bump.
+		$entry = wp_presence_get_screen_revision( 'post/' . $post_id );
+		$this->assertNull( $entry, 'A fresh insert is not "post_updated" — only updates bump.' );
+
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Updated title ' . wp_generate_password( 6, false ),
+			)
+		);
+
+		$entry = wp_presence_get_screen_revision( 'post/' . $post_id );
+		$this->assertNotNull( $entry );
+		$this->assertSame( 1, (int) $entry['rev'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_post_updated
+	 */
+	public function test_post_updated_skips_autosave_and_revision() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'post' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		delete_option( 'wp_presence_screen_revisions' );
+
+		// Autosaves and revisions go through post_updated too, so the hook
+		// must filter them out — otherwise every autosave tick would bump.
+		wp_create_post_autosave(
+			array(
+				'post_ID'      => $post_id,
+				'post_type'    => 'post',
+				'post_content' => 'Autosaved content',
+				'post_title'   => 'Autosaved title',
+			)
+		);
+
+		$this->assertNull(
+			wp_presence_get_screen_revision( 'post/' . $post_id ),
+			'Autosaves should not bump the parent post\'s screen revision.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_on_profile_update
+	 */
+	public function test_profile_update_bumps_user_screen() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'user-edit' );
+
+		wp_update_user(
+			array(
+				'ID'           => self::$editor_id,
+				'display_name' => 'Edited Editor ' . wp_generate_password( 6, false ),
+			)
+		);
+
+		$entry = wp_presence_get_screen_revision( 'user-edit/' . self::$editor_id );
+		$this->assertNotNull( $entry );
+		$this->assertSame( 1, (int) $entry['rev'] );
+		$this->assertSame( self::$admin_id, (int) $entry['actor_id'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_edited_term
+	 */
+	public function test_edited_term_bumps_term_screen() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'edit-tags' );
+
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
+		delete_option( 'wp_presence_screen_revisions' );
+
+		wp_update_term( $term_id, 'category', array( 'description' => 'Updated' ) );
+
+		$entry = wp_presence_get_screen_revision( 'term/category/' . $term_id );
+		$this->assertNotNull( $entry );
+		$this->assertSame( 1, (int) $entry['rev'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_edit_comment
+	 */
+	public function test_edit_comment_bumps_comment_screen() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'comment' );
+
+		$comment_id = self::factory()->comment->create();
+		delete_option( 'wp_presence_screen_revisions' );
+
+		wp_update_comment(
+			array(
+				'comment_ID'      => $comment_id,
+				'comment_content' => 'Updated comment ' . wp_generate_password( 6, false ),
+			)
+		);
+
+		$entry = wp_presence_get_screen_revision( 'comment/' . $comment_id );
+		$this->assertNotNull( $entry );
+		$this->assertSame( 1, (int) $entry['rev'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_bump_screen_revision
+	 */
+	public function test_bump_fires_revision_bumped_action() {
+		wp_set_current_user( self::$admin_id );
+
+		$captured = array();
+		$callback = static function ( $key, $rev, $actor_id ) use ( &$captured ) {
+			$captured[] = compact( 'key', 'rev', 'actor_id' );
+		};
+		add_action( 'wp_presence_screen_revision_bumped', $callback, 10, 3 );
+
+		wp_presence_bump_screen_revision( 'options/general' );
+
+		remove_action( 'wp_presence_screen_revision_bumped', $callback, 10 );
+
+		$this->assertCount( 1, $captured );
+		$this->assertSame( 'options/general', $captured[0]['key'] );
+		$this->assertSame( 1, $captured[0]['rev'] );
+		$this->assertSame( self::$admin_id, $captured[0]['actor_id'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_requires_edit_posts_capability() {
+		wp_presence_bump_screen_revision( 'options/general', self::$admin_id );
+
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/general' ) ),
+			'options-general'
+		);
+
+		$this->assertArrayNotHasKey(
+			'presence-screen-rev',
+			$response,
+			'A subscriber without edit_posts should not learn screen-revision state via Heartbeat.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_caps_oversized_screen_key() {
+		wp_set_current_user( self::$admin_id );
+		// 200-char key is bumped on the server but the heartbeat handler
+		// only looks up the first 191 chars, so it should not match.
+		$long_key = str_repeat( 'a', 200 );
+		wp_presence_bump_screen_revision( $long_key );
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => $long_key ) ),
+			'long'
+		);
+
+		$this->assertArrayNotHasKey( 'presence-screen-rev', $response );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_returns_current_revision_for_screen() {
+		wp_set_current_user( self::$admin_id );
+		wp_presence_bump_screen_revision( 'options/general', self::$admin_id );
+
+		wp_set_current_user( self::$editor_id );
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/general' ) ),
+			'options-general'
+		);
+
+		$this->assertArrayHasKey( 'presence-screen-rev', $response );
+		$payload = $response['presence-screen-rev'];
+		$this->assertSame( 'options/general', $payload['key'] );
+		$this->assertSame( 1, (int) $payload['rev'] );
+		$this->assertSame( self::$admin_id, (int) $payload['actor_id'] );
+		$this->assertFalse( $payload['actor_is_me'] );
+		$this->assertNotEmpty( $payload['actor_name'], 'Heartbeat should resolve the actor display name fresh.' );
+		$this->assertNotEmpty( $payload['actor_avatar_url'], 'Heartbeat should carry the actor avatar URL.' );
+		$this->assertNotEmpty( $payload['time_ago'], 'Heartbeat should carry a human-readable time diff.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_picks_up_renamed_actor() {
+		wp_set_current_user( self::$admin_id );
+		wp_presence_bump_screen_revision( 'options/general', self::$editor_id );
+
+		// Rename the editor AFTER the bump — the heartbeat should reflect the new name.
+		$renamed = 'Renamed Editor ' . wp_generate_password( 6, false );
+		wp_update_user(
+			array(
+				'ID'           => self::$editor_id,
+				'display_name' => $renamed,
+			)
+		);
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/general' ) ),
+			'options-general'
+		);
+
+		$this->assertSame( $renamed, $response['presence-screen-rev']['actor_name'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_flags_actor_is_me_for_current_user() {
+		wp_set_current_user( self::$admin_id );
+		wp_presence_bump_screen_revision( 'options/general', self::$admin_id );
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/general' ) ),
+			'options-general'
+		);
+
+		$this->assertTrue( $response['presence-screen-rev']['actor_is_me'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_returns_nothing_when_no_ping() {
+		$response = wp_presence_screen_heartbeat_received( array(), array(), 'options-general' );
+		$this->assertArrayNotHasKey( 'presence-screen-rev', $response );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_returns_nothing_for_unknown_screen() {
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/never-saved' ) ),
+			'options-general'
+		);
+		$this->assertArrayNotHasKey( 'presence-screen-rev', $response );
+	}
+
+	/**
+	 * @covers ::wp_presence_bump_screen_revision
+	 */
+	public function test_revision_map_is_bounded_by_limit() {
+		wp_set_current_user( self::$admin_id );
+
+		for ( $i = 0; $i < WP_PRESENCE_SCREEN_REV_LIMIT + 5; $i++ ) {
+			wp_presence_bump_screen_revision( 'options/test-' . $i );
+		}
+
+		$map = wp_presence_get_screen_revisions();
+		$this->assertLessThanOrEqual( WP_PRESENCE_SCREEN_REV_LIMIT, count( $map ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_current_screen_key_matches_save_path_for_settings() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'options-general' );
+
+		$this->assertSame( 'options/general', wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_current_screen_key_filter_is_applied() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'dashboard' );
+
+		add_filter(
+			'wp_presence_current_screen_key',
+			static function ( $key ) {
+				return $key ?: 'custom-screen';
+			}
+		);
+
+		$this->assertSame( 'custom-screen', wp_presence_current_screen_key() );
+
+		remove_all_filters( 'wp_presence_current_screen_key' );
+	}
+}

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -222,15 +222,17 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 	 * @covers ::wp_presence_screen_heartbeat_received
 	 */
 	public function test_heartbeat_requires_edit_posts_capability() {
-		wp_presence_bump_screen_revision( 'options/general', self::$admin_id );
+		// Use a non-`options/*` key so the viewer is gated on `edit_posts`
+		// (the `options/*` prefix is gated on `manage_options` instead).
+		wp_presence_bump_screen_revision( 'post/1', self::$admin_id );
 
 		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $subscriber_id );
 
 		$response = wp_presence_screen_heartbeat_received(
 			array(),
-			array( 'presence-screen-ping' => array( 'key' => 'options/general' ) ),
-			'options-general'
+			array( 'presence-screen-ping' => array( 'key' => 'post/1' ) ),
+			'post'
 		);
 
 		$this->assertArrayNotHasKey(

--- a/uninstall.php
+++ b/uninstall.php
@@ -23,6 +23,7 @@ function wp_presence_uninstall_site() {
 	$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 
 	delete_option( 'wp_presence_db_version' );
+	delete_option( 'wp_presence_screen_revisions' );
 }
 
 if ( is_multisite() ) {


### PR DESCRIPTION
Each covered admin screen tracks a revision that increments on save and is broadcast over Heartbeat; when a viewer's page-load baseline falls behind, a dismissible notice prompts them to reload and names the user who saved.

<img width="1844" height="982" alt="Stale-screen notice on Settings → General: actor avatar, 'Alex Smith updated this screen a few seconds ago.' message, and a primary Reload button. Below: the demo-helper notice with four 'Save as ...' buttons." src="https://github.com/user-attachments/assets/51a81864-a32f-43a7-b433-8c9e6a5e0814" />

Related: #12

## How to test

- Playground preview → Settings → General → click a **Save as &lt;name&gt;** button → yellow notice appears within seconds. Repeat on post, term, user, and comment edit screens.
- WP-CLI option updates and self-saves do not fire the notice.

## Follow-ups

- #28 — extend coverage to JS- and REST-driven save flows.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Implementation of the screen-revisions module, the JS banner client, the test suite, and the Playground demo helper. All changes were reviewed and verified by me.