### PR TITLE
Add a Playground preview to every PR

### DIFF
--- a/.github/workflows/playground-preview-cleanup.yml
+++ b/.github/workflows/playground-preview-cleanup.yml
@@ -1,0 +1,32 @@
+name: Playground Preview Cleanup
+
+# Deletes the per-PR preview release + tag when a PR is closed.
+#
+# Uses `pull_request_target` so cleanup also fires for PRs from forks
+# (the token from `pull_request: closed` is read-only on forks). This
+# workflow never checks out PR code and only calls the release API
+# with values from the GitHub event payload, so `pull_request_target`
+# is safe here.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview release and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          TAG="preview-pr-${PR_NUMBER}"
+          # Tolerate "release not found" — the build may have failed or
+          # been skipped, leaving nothing to clean up.
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -1,0 +1,192 @@
+name: Playground Preview Publish
+
+# Runs in the base-repo context (via `workflow_run`) so it has write
+# access even for PRs from forks. Downloads the build artifacts from
+# the triggering workflow, publishes them as a prerelease, and posts
+# (or updates) the sticky Playground comment on the PR.
+#
+# Security model: every PR-derived input is untrusted.
+#   - `pr-meta.json` is parsed with jq and regex-validated; we never
+#     `source` it as shell.
+#   - The blueprint templates we encode into Playground URLs come from
+#     the base ref (this checkout), not from the PR — only the plugin
+#     and seeder URLs are rewritten in, and both point exclusively at
+#     github.com/${{ github.repository }} under our control, so a fork
+#     PR cannot direct Playground at attacker-controlled URLs through
+#     this workflow.
+
+on:
+  workflow_run:
+    workflows: ["Playground Preview"]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  actions: read
+  issues: write
+
+jobs:
+  publish:
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts from the triggering run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const list = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            for (const name of ['release-assets', 'pr-meta']) {
+              const found = list.data.artifacts.find(a => a.name === name);
+              if (!found) {
+                core.setFailed(`Required artifact "${name}" not found on workflow run.`);
+                return;
+              }
+              const dl = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: found.id,
+                archive_format: 'zip',
+              });
+              fs.writeFileSync(`${name}.zip`, Buffer.from(dl.data));
+            }
+
+      - name: Unpack and validate artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/release-assets artifacts/pr-meta
+          unzip -q -o -d artifacts/release-assets release-assets.zip
+          unzip -q -o -d artifacts/pr-meta pr-meta.zip
+          test -f artifacts/release-assets/presence-api.zip
+          test -f artifacts/release-assets/demo-seeder.php
+          test -f artifacts/pr-meta/pr-meta.json
+
+          # Parse with jq and validate types. Never `source` the artifact.
+          PR_NUMBER=$(jq -r '.pr_number' artifacts/pr-meta/pr-meta.json)
+          HEAD_SHA=$(jq -r '.head_sha' artifacts/pr-meta/pr-meta.json)
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] \
+            || { echo "Invalid PR number in pr-meta: $PR_NUMBER"; exit 1; }
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "Invalid SHA in pr-meta: $HEAD_SHA"; exit 1; }
+          {
+            echo "PR_NUMBER=$PR_NUMBER"
+            echo "HEAD_SHA=$HEAD_SHA"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish prerelease (replaces any prior preview for this PR)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="preview-pr-${PR_NUMBER}"
+          # Drop any prior release+tag for this PR so we always serve the
+          # latest preview from a stable URL. Tolerate first-time absence.
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$TAG" \
+            artifacts/release-assets/presence-api.zip \
+            artifacts/release-assets/demo-seeder.php \
+            --prerelease \
+            --target "$HEAD_SHA" \
+            --title "PR #${PR_NUMBER} preview" \
+            --notes "Auto-built from \`${HEAD_SHA}\` for PR #${PR_NUMBER}. Deleted on PR close."
+
+      - name: Assemble Playground URLs from base-ref blueprints
+        id: playground
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TAG="preview-pr-${PR_NUMBER}"
+          # Both URLs resolve to github.com/${REPO} — never to the PR's
+          # head repository — so a fork PR cannot redirect Playground.
+          PLUGIN_URL="https://github.com/${REPO}/releases/download/${TAG}/presence-api.zip"
+          SEEDER_URL="https://github.com/${REPO}/releases/download/${TAG}/demo-seeder.php"
+
+          transform() {
+            jq --arg plugin "$1" --arg seeder "$2" '
+              .steps |= map(
+                if .step == "installPlugin" and (.pluginData.resource == "url") then
+                  .pluginData.url = $plugin
+                elif .step == "writeFile" and (.data.resource == "url") then
+                  .data.url = $seeder
+                else . end
+              )
+            ' "$3"
+          }
+
+          BLUEPRINT=$(transform "$PLUGIN_URL" "$SEEDER_URL" blueprint.json)
+          BLUEPRINT_40=$(transform "$PLUGIN_URL" "$SEEDER_URL" blueprint-40.json)
+
+          encode() { printf '%s' "$1" | base64 -w0; }
+
+          {
+            echo "url=https://playground.wordpress.net/#$(encode "$BLUEPRINT")"
+            echo "url_40=https://playground.wordpress.net/#$(encode "$BLUEPRINT_40")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+          PLAYGROUND_URL: ${{ steps.playground.outputs.url }}
+          PLAYGROUND_URL_40: ${{ steps.playground.outputs.url_40 }}
+        with:
+          script: |
+            const marker = '<!-- presence-api:playground-preview -->';
+            const url = process.env.PLAYGROUND_URL;
+            const url40 = process.env.PLAYGROUND_URL_40;
+            const sha = process.env.HEAD_SHA;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const badge = 'https://img.shields.io/badge/Open%20in-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white';
+
+            const body = [
+              marker,
+              '## ▶ Preview in WordPress Playground',
+              '',
+              `[![Open in WordPress Playground](${badge})](${url})`,
+              '',
+              "Boots a fresh WordPress, installs this PR's presence-api build, seeds 5 demo users, lands you in the dashboard.",
+              '',
+              `[![Open in WordPress Playground](${badge})](${url40})`,
+              '',
+              'Same, with 40 demo users.',
+              '',
+              `<sub>Built from \`${sha}\`. Auto-updates when you push.</sub>`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,103 @@
+name: Playground Preview
+
+# Builds `presence-api.zip` from the PR commit and uploads it (plus the
+# demo seeder and a small metadata file) as workflow artifacts. The
+# sibling `Playground Preview Publish` workflow picks the artifacts up
+# on `workflow_run` and hands them to GitHub Releases for hosting — we
+# don't depend on any third-party artifact proxy.
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only token. The build runs PR code, so it must be treated as
+# untrusted. Hosting and commenting happen in the sibling workflow_run
+# job under a base-repo token.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
+      # `--no-scripts` prevents a hostile fork PR from running arbitrary
+      # PHP via composer.json's `scripts` block during install.
+      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-scripts
+
+      - name: Build presence-api.zip
+        run: |
+          set -euo pipefail
+          mkdir -p build/presence-api
+          rsync -a --exclude-from='.distignore' --exclude='build' ./ build/presence-api/
+          (cd build && zip -qr presence-api.zip presence-api/)
+
+      # Cheap smoke test: parse every PHP file in the staged plugin and
+      # confirm the entry file is present. Catches the regression class
+      # where `.distignore` drifts out of sync with `require_once`
+      # graphs — install succeeds but the plugin fatals on first hit.
+      - name: Smoke-test the build
+        run: |
+          set -euo pipefail
+          test -f build/presence-api/presence-api.php
+          find build/presence-api -name '*.php' -print0 \
+            | xargs -0 -n1 -P 4 php -l > /dev/null
+
+      # Asserts each blueprint matches the shape the publish workflow
+      # rewrites — exactly one URL-resource `installPlugin` and one
+      # URL-resource `writeFile`, and only the step types we expect.
+      # Fork PRs can't sneak in additional `installPlugin` steps that
+      # pull from attacker URLs because the publish workflow uses the
+      # BASE-REF blueprints, but this still catches accidental breakage.
+      - name: Schema-validate blueprints
+        run: |
+          set -euo pipefail
+          for f in blueprint.json blueprint-40.json; do
+            jq -e '
+              (.steps | length > 0)
+              and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP")))
+              and (.steps | map(select(.step == "installPlugin" and (.pluginData.resource // "") == "url")) | length == 1)
+              and (.steps | map(select(.step == "writeFile" and (.data.resource // "") == "url")) | length == 1)
+            ' "$f" > /dev/null
+          done
+
+      - name: Stage release assets
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          cp build/presence-api.zip release-assets/
+          cp tests/e2e/demo-seeder.php release-assets/
+
+      # PR metadata as JSON (no shell-`source` upstream). The publish
+      # workflow validates these fields with regex before using.
+      - name: Save PR metadata
+        run: |
+          jq -n \
+            --argjson pr "${{ github.event.pull_request.number }}" \
+            --arg sha "${{ github.event.pull_request.head.sha }}" \
+            '{pr_number: $pr, head_sha: $sha}' > pr-meta.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets/
+          retention-days: 14
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta.json
+          retention-days: 14
+          if-no-files-found: error


### PR DESCRIPTION
Builds `presence-api.zip` from the PR commit, attaches it to a `preview-pr-<N>` prerelease, and posts a sticky comment with Playground URLs that install from that release. A `pull_request_target: closed` cleanup workflow deletes the release and tag when the PR closes.