### PR TITLE
Fix Playground preview comment permissions

### DIFF
--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -27,7 +27,7 @@ concurrency:
 permissions:
   contents: write
   actions: read
-  issues: write
+  pull-requests: write
 
 jobs:
   publish:


### PR DESCRIPTION
The publish workflow's `issues: write` scope returns 403 on the issue-comment POST despite the API listing both `issues=write` and `pull_requests=write` as acceptable. Switches to `pull-requests: write`, matching the scope GitHub actually grants for comments on a pull request.