### PR TITLE
Add a stale-screen demo helper for the Playground preview

### DIFF
--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -71,6 +71,7 @@ jobs:
           unzip -q -o -d artifacts/pr-meta pr-meta.zip
           test -f artifacts/release-assets/presence-api.zip
           test -f artifacts/release-assets/demo-seeder.php
+          test -f artifacts/release-assets/screen-stale-demo-helper.php
           test -f artifacts/pr-meta/pr-meta.json
 
           # Parse with jq and validate types. Never `source` the artifact.
@@ -97,6 +98,7 @@ jobs:
           gh release create "$TAG" \
             artifacts/release-assets/presence-api.zip \
             artifacts/release-assets/demo-seeder.php \
+            artifacts/release-assets/screen-stale-demo-helper.php \
             --prerelease \
             --target "$HEAD_SHA" \
             --title "PR #${PR_NUMBER} preview" \
@@ -113,21 +115,27 @@ jobs:
           # head repository — so a fork PR cannot redirect Playground.
           PLUGIN_URL="https://github.com/${REPO}/releases/download/${TAG}/presence-api.zip"
           SEEDER_URL="https://github.com/${REPO}/releases/download/${TAG}/demo-seeder.php"
+          HELPER_URL="https://github.com/${REPO}/releases/download/${TAG}/screen-stale-demo-helper.php"
 
+          # writeFile steps are matched by trailing path component so the
+          # seeder and helper get distinct URLs without depending on the
+          # order they appear in the blueprint.
           transform() {
-            jq --arg plugin "$1" --arg seeder "$2" '
+            jq --arg plugin "$1" --arg seeder "$2" --arg helper "$3" '
               .steps |= map(
                 if .step == "installPlugin" and (.pluginData.resource == "url") then
                   .pluginData.url = $plugin
                 elif .step == "writeFile" and (.data.resource == "url") then
-                  .data.url = $seeder
+                  if (.path | endswith("/demo-seeder.php")) then .data.url = $seeder
+                  elif (.path | endswith("/screen-stale-demo-helper.php")) then .data.url = $helper
+                  else . end
                 else . end
               )
-            ' "$3"
+            ' "$4"
           }
 
-          BLUEPRINT=$(transform "$PLUGIN_URL" "$SEEDER_URL" blueprint.json)
-          BLUEPRINT_40=$(transform "$PLUGIN_URL" "$SEEDER_URL" blueprint-40.json)
+          BLUEPRINT=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint.json)
+          BLUEPRINT_40=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint-40.json)
 
           encode() { printf '%s' "$1" | base64 -w0; }
 

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -68,7 +68,7 @@ jobs:
               (.steps | length > 0)
               and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP")))
               and (.steps | map(select(.step == "installPlugin" and (.pluginData.resource // "") == "url")) | length == 1)
-              and (.steps | map(select(.step == "writeFile" and (.data.resource // "") == "url")) | length == 1)
+              and (.steps | map(select(.step == "writeFile" and (.data.resource // "") == "url")) | length == 2)
             ' "$f" > /dev/null
           done
 
@@ -78,6 +78,7 @@ jobs:
           mkdir -p release-assets
           cp build/presence-api.zip release-assets/
           cp tests/e2e/demo-seeder.php release-assets/
+          cp tests/e2e/screen-stale-demo-helper.php release-assets/
 
       # PR metadata as JSON (no shell-`source` upstream). The publish
       # workflow validates these fields with regex before using.

--- a/blueprint-40.json
+++ b/blueprint-40.json
@@ -21,6 +21,14 @@
 			}
 		},
 		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/screen-stale-demo-helper.php",
+			"data": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/main/tests/e2e/screen-stale-demo-helper.php"
+			}
+		},
+		{
 			"step": "runPHP",
 			"code": "<?php require '/wordpress/wp-load.php'; require '/wordpress/wp-content/plugins/presence-api/demo-seeder.php'; wp_presence_demo_seed( 40 ); update_user_meta( 1, 'show_welcome_panel', 0 ); update_user_meta( 1, 'meta-box-order_dashboard', array( 'normal' => 'presence_whos_online,presence_active_posts,dashboard_right_now,dashboard_activity', 'side' => 'dashboard_quick_press,dashboard_primary' ) ); ?>"
 		}

--- a/blueprint.json
+++ b/blueprint.json
@@ -21,6 +21,14 @@
 			}
 		},
 		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/screen-stale-demo-helper.php",
+			"data": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/main/tests/e2e/screen-stale-demo-helper.php"
+			}
+		},
+		{
 			"step": "runPHP",
 			"code": "<?php require '/wordpress/wp-load.php'; require '/wordpress/wp-content/plugins/presence-api/demo-seeder.php'; wp_presence_demo_seed( 5 ); update_user_meta( 1, 'show_welcome_panel', 0 ); update_user_meta( 1, 'meta-box-order_dashboard', array( 'normal' => 'presence_whos_online,presence_active_posts,dashboard_right_now,dashboard_activity', 'side' => 'dashboard_quick_press,dashboard_primary' ) ); ?>"
 		}

--- a/tests/e2e/screen-stale-demo-helper.php
+++ b/tests/e2e/screen-stale-demo-helper.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Stale-screen detection demo helper.
+ *
+ * Loaded as a must-use plugin by the Playground demo blueprint. Renders
+ * a "pretend another user just saved this screen" button bar on every
+ * covered admin screen so a single-session Playground viewer can see
+ * the stale-screen notice fire as if another user had saved.
+ *
+ * This file ships only with the Playground demo blueprint; it is not
+ * part of the plugin itself.
+ *
+ * @package Presence_API_Demo
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const PRESENCE_DEMO_NONCE_ACTION = 'presence_demo_bump_screen';
+
+/**
+ * Renders the demo button bar on covered admin screens.
+ */
+function presence_demo_render_buttons() {
+	if ( ! function_exists( 'wp_presence_current_screen_key' ) ) {
+		return;
+	}
+	$key = wp_presence_current_screen_key();
+	if ( '' === $key ) {
+		return;
+	}
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		return;
+	}
+
+	$me     = get_current_user_id();
+	$others = get_users(
+		array(
+			'exclude' => array( $me ),
+			'number'  => 4,
+			'orderby' => 'ID',
+			'fields'  => array( 'ID', 'display_name' ),
+		)
+	);
+	if ( ! $others ) {
+		return;
+	}
+
+	$nonce    = wp_create_nonce( PRESENCE_DEMO_NONCE_ACTION );
+	$ajax_url = admin_url( 'admin-ajax.php' );
+	?>
+	<div class="notice notice-info is-dismissible">
+		<p>
+			<strong><?php esc_html_e( 'Demo:', 'presence-api' ); ?></strong>
+			<?php esc_html_e( 'pretend another user just saved this screen — the stale-screen notice should appear within a few seconds.', 'presence-api' ); ?>
+		</p>
+		<p>
+			<?php foreach ( $others as $user ) : ?>
+				<button
+					type="button"
+					class="button"
+					data-presence-demo-bump
+					data-screen-key="<?php echo esc_attr( $key ); ?>"
+					data-actor-id="<?php echo esc_attr( (string) $user->ID ); ?>"
+				>
+					<?php
+					/* translators: %s: demo user's display name. */
+					printf( esc_html__( 'Save as %s', 'presence-api' ), esc_html( $user->display_name ) );
+					?>
+				</button>
+			<?php endforeach; ?>
+		</p>
+	</div>
+	<script>
+	(function () {
+		const ajaxUrl = <?php echo wp_json_encode( $ajax_url ); ?>;
+		const nonce   = <?php echo wp_json_encode( $nonce ); ?>;
+		document.querySelectorAll('[data-presence-demo-bump]').forEach(function (btn) {
+			btn.addEventListener('click', function () {
+				const body = new FormData();
+				body.append('action', 'presence_demo_bump_screen');
+				body.append('screen_key', btn.dataset.screenKey);
+				body.append('actor_id', btn.dataset.actorId);
+				body.append('_wpnonce', nonce);
+				btn.disabled = true;
+				btn.textContent = '✓ ' + btn.textContent;
+				fetch(ajaxUrl, { method: 'POST', credentials: 'same-origin', body: body })
+					.then(function () {
+						if (window.wp && window.wp.heartbeat && typeof window.wp.heartbeat.connectNow === 'function') {
+							window.wp.heartbeat.connectNow();
+						}
+					});
+			});
+		});
+	})();
+	</script>
+	<?php
+}
+add_action( 'admin_notices', 'presence_demo_render_buttons' );
+
+/**
+ * AJAX: bump the current screen's revision with a chosen seeded user as actor.
+ */
+function presence_demo_handle_bump() {
+	if ( ! function_exists( 'wp_presence_bump_screen_revision' ) ) {
+		wp_send_json_error( array( 'reason' => 'plugin-missing' ), 500 );
+	}
+	check_ajax_referer( PRESENCE_DEMO_NONCE_ACTION );
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		wp_send_json_error( array( 'reason' => 'forbidden' ), 403 );
+	}
+	$key   = isset( $_POST['screen_key'] ) ? sanitize_text_field( wp_unslash( $_POST['screen_key'] ) ) : '';
+	$actor = isset( $_POST['actor_id'] ) ? absint( $_POST['actor_id'] ) : 0;
+	if ( '' === $key || ! $actor ) {
+		wp_send_json_error( array( 'reason' => 'bad-input' ), 400 );
+	}
+	wp_presence_bump_screen_revision( $key, $actor );
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_presence_demo_bump_screen', 'presence_demo_handle_bump' );


### PR DESCRIPTION
Demo blueprints install a must-use plugin that renders "Save as <name>" buttons on covered admin screens; clicking one fires the real stale-screen notice in a single-session Playground. The build and publish workflows ship the helper alongside the plugin and seeder.