### PR TITLE
Add a pull request template based on WordPress core's

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+Hi there! Thanks for contributing to the Presence API feature plugin.
+
+This GitHub repository is where the feature plugin's work happens — issues
+track scope and PRs land changes. Keep larger design discussions in the
+linked issue and use this Pull Request for code review.
+
+If this is your first time contributing, the following may be helpful:
+- Contributing guide: ../blob/main/.github/CONTRIBUTING.md
+- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
+- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
+- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
+- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
+-->
+
+<!-- Insert a description of your changes here -->
+
+Related: <!-- link a GitHub issue here, e.g. #12 -->
+
+## Use of AI Tools
+
+<!--
+You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
+
+Example disclosure:
+
+AI assistance: Yes
+Tool(s): GitHub Copilot, ChatGPT
+Model(s): GPT-5.1
+Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
+-->


### PR DESCRIPTION
Mirrors the wordpress-develop template — same intro structure, the same "Use of AI Tools" section verbatim — adapted for this feature plugin's context: links `.github/CONTRIBUTING.md` instead of the Trac-tied core handbook entries, and tracks against GitHub issues (`Related: #N`) rather than a Trac ticket since PRs land here.