### PR TITLE
Skip the Playground preview on PRs that don't touch shippable code

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -8,6 +8,15 @@ name: Playground Preview
 
 on:
   pull_request:
+    # Skip the obvious non-shippable surface. Docs, CI, tests — none of
+    # them change what a reviewer sees when they open the Playground
+    # link. A demo-seeder or workflow-only PR can fire the preview by
+    # hand via `workflow_dispatch` when there's a real need.
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+      - 'tests/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Three `paths-ignore` globs cover everything that doesn't change what a reviewer sees in the preview: `**.md` for docs, `.github/**` for CI and meta, `tests/**` for test code. Demo-seeder-only or workflow-only PRs can still fire the preview by hand via `workflow_dispatch` when there's a real need.