### PR TITLE
Run WordPress Plugin Check in CI

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,88 @@
+name: Plugin Check
+
+# Runs the WordPress.org Plugin Check suite against the staged plugin —
+# the same checks the directory's automated review applies on submission.
+# Surfaces missing `readme.txt` fields, license-header issues, forbidden
+# function calls, and similar guideline violations before they become a
+# submission blocker.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
+      # Match `release.yml` — no dev deps, optimized autoloader, scripts
+      # disabled — so what's checked is what would ship.
+      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-scripts
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: npm install -g @wordpress/env@11.7.0
+
+      # Authenticate composer's GitHub API calls. Without this, wp-env's
+      # Docker build hits the 60/hour unauthenticated rate limit on
+      # `api.github.com/repos/.../zipball/...` and 504s while pulling
+      # the Sebastian Bergmann package tree. Writing the auth file at
+      # `~/.composer/auth.json` raises the limit to 5000/hour using the
+      # workflow's GITHUB_TOKEN.
+      - name: Authenticate composer to GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p ~/.composer
+          cat > ~/.composer/auth.json <<JSON
+          { "github-oauth": { "github.com": "${GH_TOKEN}" } }
+          JSON
+
+      # Build the plugin tree the same way `release.yml` does so
+      # plugin-check sees only what would actually ship — `.distignore`
+      # excludes `.wp-env.json`, the `*.dist` configs, tests, and other
+      # dev files that the live WP.org plugin directory wouldn't see.
+      - name: Build the plugin
+        run: |
+          mkdir -p build/presence-api
+          rsync -a --exclude-from='.distignore' --exclude='build' ./ build/presence-api/
+
+      # Point wp-env at the built tree instead of the repo root so the
+      # `presence-api` slug it loads is the directory plugin-check
+      # should be analyzing.
+      - name: Mount the built plugin into wp-env
+        run: |
+          cat > .wp-env.override.json <<'JSON'
+          { "plugins": [ "./build/presence-api" ] }
+          JSON
+
+      - run: wp-env start --update
+
+      - name: Install Plugin Check inside wp-env
+        run: |
+          wp-env run cli wp plugin install plugin-check --activate
+          wp-env run cli wp plugin activate presence-api
+
+      # `strict-table` is the only built-in format that's human-readable
+      # in CI logs and exits non-zero when errors are found. (Plain
+      # `table` always exits 0 even with findings.)
+      - name: Run Plugin Check
+        run: |
+          wp-env run cli wp plugin check presence-api --format=strict-table

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "https://wordpress.org/wordpress-7.0-RC2.zip",
+	"core": "WordPress/WordPress",
 	"plugins": [ ".", "https://downloads.wordpress.org/plugin/classic-editor.zip" ],
 	"config": {
 		"WP_DEBUG": true,


### PR DESCRIPTION
Runs the same lint suite the WordPress.org plugin directory's automated review applies on submission — `readme.txt` field checks, license-header drift, forbidden function calls, and similar guideline violations — at PR time instead of at submission time. Builds the plugin with the same composer flags `release.yml` uses so the checked tree matches what would ship.