### PR TITLE
Run GitHub CodeQL security analysis in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,14 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write
   actions: read
-
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,9 @@ name: CodeQL
 # CodeQL database refreshes against newly-published query packs even on
 # code that hasn't changed.
 #
-# PHP support is currently in beta on CodeQL; add `language: 'actions'`
-# coverage of the GitHub-actions DSL plus our JS today, and revisit PHP
-# once the language pack is stable.
+# PHP support is currently in beta on CodeQL. We scan the GitHub Actions
+# DSL (`actions`) plus our JavaScript today, and should add PHP once the
+# language pack is stable.
 
 on:
   push:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+# GitHub-managed security analysis. Scans our JavaScript and CI workflow
+# definitions on every PR, every push to main, and weekly so the local
+# CodeQL database refreshes against newly-published query packs even on
+# code that hasn't changed.
+#
+# PHP support is currently in beta on CodeQL; add `language: 'actions'`
+# coverage of the GitHub-actions DSL plus our JS today, and revisit PHP
+# once the language pack is stable.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript', 'actions' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
GitHub-managed, free for public repos, no infrastructure on our side. Scans JavaScript and the GitHub Actions DSL on every PR, every push to `main`, and weekly so the local CodeQL database refreshes against newly-published query packs even on unchanged code. PHP support is currently in beta; add that language once it's stable.