### PR TITLE
Authenticate composer to GitHub before wp-env start

### DIFF
--- a/.github/workflows/multisite.yml
+++ b/.github/workflows/multisite.yml
@@ -19,7 +19,15 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
       - run: npm ci
+      # Avoids the intermittent 504s on api.github.com during wp-env's
+      # Docker build (PR #22). Authenticated requests dodge the issue.
+      - name: Authenticate composer to GitHub
+        run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
       - run: npx wp-env start
       - run: npx wp-env run tests-cli -- composer require --dev phpunit/phpunit:^9.6 yoast/phpunit-polyfills:^2.0 --working-dir=/var/www/html --update-with-all-dependencies
       - run: npx wp-env run tests-cli -- wp core multisite-convert --title="Test Network"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,7 +24,15 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
       - run: npm ci
+      # Avoids the intermittent 504s on api.github.com during wp-env's
+      # Docker build (PR #22). Authenticated requests dodge the issue.
+      - name: Authenticate composer to GitHub
+        run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
       - run: npx wp-env start
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
Fixes intermittent PHPUnit and Multisite CI failures (e.g. PR #22) by authenticating composer to GitHub before wp-env's Docker build runs.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Diagnosing the 504s on PR #22's PHPUnit runs. All changes were reviewed and verified by me.