### PR TITLE
Run WordPress Plugin Check in CI

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -40,20 +40,10 @@ jobs:
 
       - run: npm install -g @wordpress/env@11.7.0
 
-      # Authenticate composer's GitHub API calls. Without this, wp-env's
-      # Docker build hits the 60/hour unauthenticated rate limit on
-      # `api.github.com/repos/.../zipball/...` and 504s while pulling
-      # the Sebastian Bergmann package tree. Writing the auth file at
-      # `~/.composer/auth.json` raises the limit to 5000/hour using the
-      # workflow's GITHUB_TOKEN.
+      # Avoids the intermittent 504s on api.github.com during wp-env's
+      # Docker build (PR #22). Authenticated requests dodge the issue.
       - name: Authenticate composer to GitHub
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p ~/.composer
-          cat > ~/.composer/auth.json <<JSON
-          { "github-oauth": { "github.com": "${GH_TOKEN}" } }
-          JSON
+        run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
 
       # Build the plugin tree the same way `release.yml` does so
       # plugin-check sees only what would actually ship — `.distignore`


### PR DESCRIPTION
Replaces the long-form heredoc that wrote `~/.composer/auth.json` by hand with the documented `composer config --global --auth` pattern. Same end-result file (which wp-env mounts into its Docker build), one line of code instead of seven.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Swapping the heredoc for the composer-config equivalent in the plugin-check workflow. All changes were reviewed and verified by me.