### PR TITLE
chore: bump @wordpress/env to 11.8.1 in plugin-check workflow

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: '22'
 
-      - run: npm install -g @wordpress/env@11.7.0
+      - run: npm install -g @wordpress/env@11.8.1
 
       # Avoids the intermittent 504s on api.github.com during wp-env's
       # Docker build (PR #22). Authenticated requests dodge the issue.


### PR DESCRIPTION
Matches the devDependency version Dependabot bumped to in #52 so the globally-installed wp-env in `plugin-check.yml` stays in sync with what local dev / other workflows use.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Bumping the version pin in one workflow file. All changes were reviewed and verified by me.