### PR TITLE
ci: surface build(deps) commits in the release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,19 @@
 	"include-v-in-tag": true,
 	"bump-minor-pre-major": true,
 	"bump-patch-for-minor-pre-major": true,
+	"changelog-sections": [
+		{ "type": "feat",     "section": "Features" },
+		{ "type": "fix",      "section": "Bug Fixes" },
+		{ "type": "perf",     "section": "Performance Improvements" },
+		{ "type": "revert",   "section": "Reverts" },
+		{ "type": "build",    "section": "Dependencies" },
+		{ "type": "docs",     "section": "Documentation",          "hidden": true },
+		{ "type": "style",    "section": "Styles",                 "hidden": true },
+		{ "type": "chore",    "section": "Miscellaneous Chores",   "hidden": true },
+		{ "type": "refactor", "section": "Code Refactoring",       "hidden": true },
+		{ "type": "test",     "section": "Tests",                  "hidden": true },
+		{ "type": "ci",       "section": "Continuous Integration", "hidden": true }
+	],
 	"packages": {
 		".": {
 			"package-name": "presence-api"


### PR DESCRIPTION
Override release-please's default `changelog-sections` so Dependabot bumps (`build(deps):` / `build(deps-dev):`) appear under a "Dependencies" section in the generated CHANGELOG and release notes instead of being hidden. Keeps the same bump-rules — only `feat:`, `fix:`, `perf:`, `revert:` move the version number. The first release that benefits is 0.1.3 (currently staged), where the five merged \@wordpress/env, \@playwright/test, github-actions, and e2e-test-utils bumps will now be visible.