### PR TITLE
fix: address WordPress.org plugin review feedback

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -17,3 +17,5 @@ package-lock.json
 phpcs.xml.dist
 phpstan.neon.dist
 phpunit.xml.dist
+includes/db-viewer.php
+includes/debugger-widget.php

--- a/includes/post-list.php
+++ b/includes/post-list.php
@@ -28,7 +28,7 @@ function wp_presence_register_post_list_columns() {
 		add_action( "manage_{$post_type}_posts_custom_column", 'wp_presence_render_editors_column', 10, 2 );
 	}
 
-	add_action( 'admin_head-edit.php', 'wp_presence_editors_column_css' );
+	add_action( 'admin_enqueue_scripts', 'wp_presence_editors_column_css' );
 }
 
 /**
@@ -128,11 +128,16 @@ function wp_presence_render_editors_column( $column_name, $post_id ) {
 }
 
 /**
- * Outputs CSS for the editors column on the post list screen.
+ * Enqueues CSS for the editors column on the post list screen.
+ *
+ * @param string $hook_suffix The current admin page.
  */
-function wp_presence_editors_column_css() {
-	?>
-	<style>
+function wp_presence_editors_column_css( $hook_suffix ) {
+	if ( 'edit.php' !== $hook_suffix ) {
+		return;
+	}
+
+	$css = '
 		.column-presence_editors { width: 80px; }
 		.presence-editors-stack { display: flex; align-items: center; }
 		.presence-editors-stack img {
@@ -142,6 +147,9 @@ function wp_presence_editors_column_css() {
 			position: relative;
 		}
 		.presence-editors-stack img:first-child { margin-inline-start: 0; }
-	</style>
-	<?php
+	';
+
+	wp_register_style( 'presence-post-list', false, array(), WP_PRESENCE_VERSION );
+	wp_enqueue_style( 'presence-post-list' );
+	wp_add_inline_style( 'presence-post-list', $css );
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -74,8 +74,15 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget-active-posts.php';
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/debugger-widget.php';
-	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/db-viewer.php';
+	// Developer tooling is excluded from the distributed build (see .distignore),
+	// so guard the includes for installs that ship without these files.
+	$presence_debug_dir = WP_PRESENCE_PLUGIN_DIR . 'includes/';
+	if ( file_exists( $presence_debug_dir . 'debugger-widget.php' ) ) {
+		require_once $presence_debug_dir . 'debugger-widget.php';
+	}
+	if ( file_exists( $presence_debug_dir . 'db-viewer.php' ) ) {
+		require_once $presence_debug_dir . 'db-viewer.php';
+	}
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -103,13 +110,6 @@ function wp_presence_register_rest_routes() {
 }
 
 /**
- * Loads the plugin text domain for translations.
- */
-function wp_presence_load_textdomain() {
-	load_plugin_textdomain( 'presence-api', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-}
-
-/**
  * Handles plugin activation.
  */
 function wp_presence_activate() {
@@ -126,7 +126,6 @@ function wp_presence_deactivate() {
 
 add_action( 'init', 'wp_presence_register_table', 0 );
 add_action( 'init', 'wp_presence_register_post_type_support' );
-add_action( 'init', 'wp_presence_load_textdomain' );
 
 add_action( 'admin_init', 'wp_maybe_create_presence_table' );
 add_action( 'cli_init', 'wp_maybe_create_presence_table' );
@@ -159,7 +158,7 @@ add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Whos_Online', 'hear
 add_action( 'wp_dashboard_setup', array( 'WP_Presence_Widget_Active_Posts', 'register' ) );
 add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Active_Posts', 'heartbeat_received' ), 10, 3 );
 
-if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+if ( function_exists( 'wp_presence_heartbeat_widget_register' ) ) {
 	add_action( 'wp_dashboard_setup', 'wp_presence_heartbeat_widget_register' );
 	add_filter( 'heartbeat_received', 'wp_presence_heartbeat_widget_received', 10, 3 );
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -158,7 +158,9 @@ add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Whos_Online', 'hear
 add_action( 'wp_dashboard_setup', array( 'WP_Presence_Widget_Active_Posts', 'register' ) );
 add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Active_Posts', 'heartbeat_received' ), 10, 3 );
 
-if ( function_exists( 'wp_presence_heartbeat_widget_register' ) ) {
+if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG )
+	&& function_exists( 'wp_presence_heartbeat_widget_register' )
+	&& function_exists( 'wp_presence_heartbeat_widget_received' ) ) {
 	add_action( 'wp_dashboard_setup', 'wp_presence_heartbeat_widget_register' );
 	add_filter( 'heartbeat_received', 'wp_presence_heartbeat_widget_received', 10, 3 );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Presence API ===
-Contributors: flavor
+Contributors: joefusco
 Tags: presence, awareness, heartbeat, real-time
 Requires at least: 7.0
 Tested up to: 7.0
@@ -7,6 +7,7 @@ Stable tag: 0.1.2
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: presence-api
 
 System-wide presence and awareness for WordPress.
 
@@ -22,6 +23,16 @@ For full details, see the [GitHub repository](https://github.com/WordPress/prese
 2. Activate through the "Plugins" menu in WordPress.
 
 == Changelog ==
+
+= 0.1.2 =
+* Enqueue post list "Editors" column styles instead of inlining them.
+* Exclude WP_DEBUG-only developer tooling from the release build.
+* Remove redundant load_plugin_textdomain() call.
+* Add WordPress Playground blueprint for one-click testing.
+* Replace deprecated get_page_by_title() with WP_Query.
+
+= 0.1.1 =
+* Fix Plugin Check errors for directory submission.
 
 = 0.1.0 =
 * Initial release.

--- a/readme.txt
+++ b/readme.txt
@@ -25,11 +25,16 @@ For full details, see the [GitHub repository](https://github.com/WordPress/prese
 == Changelog ==
 
 = 0.1.2 =
-* Enqueue post list "Editors" column styles instead of inlining them.
-* Exclude WP_DEBUG-only developer tooling from the release build.
-* Remove redundant load_plugin_textdomain() call.
 * Add WordPress Playground blueprint for one-click testing.
+* Remove demo CLI command from production builds.
+* Split CI into separate PHPCS, PHPUnit, and Multisite workflows.
+* Exclude vendor directory from release zip.
+* Add readme.txt for WordPress.org directory submission.
+* Add WordPress.org repository compliance files (CONTRIBUTING, CODEOWNERS, CODE_OF_CONDUCT).
+* Move community health files to .github/.
 * Replace deprecated get_page_by_title() with WP_Query.
+* Add ABSPATH guards to db-viewer.php and demo-seeder.php.
+* Exclude .claude directory from release zip.
 
 = 0.1.1 =
 * Fix Plugin Check errors for directory submission.


### PR DESCRIPTION
Addresses WordPress.org pre-review feedback for `presence-api`.

- `readme.txt`: fix `Contributors` slug (`flavor` → `joefusco`), sync changelog with `CHANGELOG.md`, add `Text Domain` header.
- `includes/post-list.php`: enqueue the Editors column CSS via `wp_add_inline_style` (gated on `edit.php`) instead of an inline `<style>` tag.
- `presence-api.php`: remove redundant `load_plugin_textdomain()`; guard the `WP_DEBUG`-only debug-tool `require`s with `file_exists()` and their hooks with `function_exists()`.
- `.distignore`: exclude `db-viewer.php` and `debugger-widget.php` from the release build.

Naming (`wp_`/`WP_` prefixes, `wp-presence/v1`, plugin name/slug) is unchanged and handled in a separate reply to the review team.

Verified: PHPCS + PHPStan clean; simulated dist build ships no debug tools and no inline `<script>`/`<style>`.

---

_AI disclosure: this PR was prepared with AI assistance (Claude Code)._
