### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Allows manually re-running release-please without needing a push to main.