### PR TITLE
ci: skip Playground preview for release-please branches

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -12,6 +12,8 @@ on:
     # them change what a reviewer sees when they open the Playground
     # link. A demo-seeder or workflow-only PR can fire the preview by
     # hand via `workflow_dispatch` when there's a real need.
+    branches-ignore:
+      - 'release-please--**'
     paths-ignore:
       - '**.md'
       - '.github/**'


### PR DESCRIPTION
release-please PRs only touch version strings and changelog, so a Playground preview serves no purpose and leaves a broken link after the PR merges.