### PR TITLE
ci: close referenced issues and post Playground link on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,7 +61,9 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -83,11 +85,11 @@ jobs:
           CLOSED=()
           PR_NUMBERS=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"%s" \
             | grep -oE 'Merge pull request #[0-9]+' \
-            | grep -oE '[0-9]+$')
+            | grep -oE '[0-9]+$' || true)
 
           for PR in $PR_NUMBERS; do
             BODY=$(gh pr view "$PR" --json body --jq '.body // ""' 2>/dev/null || true)
-            ISSUES=$(echo "$BODY" | grep -oiE '(closes|fixes|resolves)[[:space:]:]+#[0-9]+' | grep -oE '[0-9]+')
+            ISSUES=$(echo "$BODY" | grep -oiE '(closes|fixes|resolves)[[:space:]:]+#[0-9]+' | grep -oE '[0-9]+' || true)
             for ISSUE in $ISSUES; do
               if printf '%s\n' "${CLOSED[@]:-}" | grep -qx "$ISSUE"; then continue; fi
               CLOSED+=("$ISSUE")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,51 @@ jobs:
             git push
           fi
 
+  # Close issues that were fixed in this release and leave a comment with a
+  # Playground link so reporters can verify the fix without a local install.
+  close-issues:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Close issues fixed in this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v '^preview-' | grep -v "^${TAG}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag — skipping."
+            exit 0
+          fi
+
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+          PLAYGROUND_URL="https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/blueprint.json"
+
+          CLOSED=()
+          PR_NUMBERS=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"%s" \
+            | grep -oE 'Merge pull request #[0-9]+' \
+            | grep -oE '[0-9]+$')
+
+          for PR in $PR_NUMBERS; do
+            BODY=$(gh pr view "$PR" --json body --jq '.body // ""' 2>/dev/null || true)
+            ISSUES=$(echo "$BODY" | grep -oiE '(closes|fixes|resolves)[[:space:]:]+#[0-9]+' | grep -oE '[0-9]+')
+            for ISSUE in $ISSUES; do
+              if printf '%s\n' "${CLOSED[@]:-}" | grep -qx "$ISSUE"; then continue; fi
+              CLOSED+=("$ISSUE")
+              gh issue close "$ISSUE" --comment ":tada: Resolved in [**${TAG}**](${RELEASE_URL}).
+
+**[Try it on WordPress Playground →](${PLAYGROUND_URL})**"
+            done
+          done
+
+          echo "Closed: ${CLOSED[*]:-none}"
+
   # When release-please's PR is merged, it tags + cuts the GitHub Release.
   # Build the distribution zip and attach it to the release.
   build-release-asset:


### PR DESCRIPTION
PRs referencing issues with Closes/Fixes/Resolves weren't wired up to auto-close on release, so reporters had no notification when their fix shipped.