### PR TITLE
Rest API/Gutenberg: Alert when an admin screen goes stale due to another user's save

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Then open [localhost:8888/wp-admin/](http://localhost:8888/wp-admin/) (admin / p
 
 ## Rooms
 
-| Pattern | Example |
-|---|---|
-| `admin/online` | All admin pages |
+| Pattern                | Example            |
+| ---------------------- | ------------------ |
+| `admin/online`         | All admin pages    |
 | `postType/{type}:{id}` | `postType/post:42` |
 
 Post types opt in via `add_post_type_support( 'post', 'presence' )`.
@@ -53,6 +53,21 @@ Creates presence entries alongside `_edit_lock` postmeta when a post lock is ref
 ## Capability
 
 All features require `edit_posts`.
+
+## Stale-screen detection
+
+Warns users when an admin screen they are viewing has been modified by someone else.
+
+Classic admin screens that save via `POST` and redirect (like Settings or `post.php`) are covered automatically.
+
+Custom JS-driven screens (like Gutenberg settings panels or custom plugin screens) can opt-in by bumping the screen revision after a successful background save:
+
+```js
+// After a successful REST or AJAX save:
+if (window.wp?.presence?.markScreenStale) {
+    wp.presence.markScreenStale('options/my-custom-plugin-settings');
+}
+```
 
 ## Maintainers
 

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -37,10 +37,9 @@
 	 * save so other users viewing the same screen receive a stale notice.
 	 *
 	 * @param {string} key     The screen key (e.g. 'options/my-plugin').
-	 * @param {number} actorId Optional. User ID who made the change.
 	 * @return {Promise} jQuery Promise.
 	 */
-	window.wp.presence.markScreenStale = function ( key, actorId = 0 ) {
+	window.wp.presence.markScreenStale = function ( key ) {
 		if ( ! config.restUrl || ! config.nonce ) {
 			return $.Deferred().reject( 'Missing REST configuration.' ).promise();
 		}
@@ -53,7 +52,6 @@
 			},
 			data: {
 				screen_key: key,
-				actor_id: actorId,
 			},
 		} );
 	};

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -27,6 +27,37 @@
 		return;
 	}
 
+	window.wp = window.wp || {};
+	window.wp.presence = window.wp.presence || {};
+
+	/**
+	 * Marks a screen as stale, bumping its revision on the server.
+	 *
+	 * Custom REST or AJAX-driven screens should call this after a successful
+	 * save so other users viewing the same screen receive a stale notice.
+	 *
+	 * @param {string} key     The screen key (e.g. 'options/my-plugin').
+	 * @param {number} actorId Optional. User ID who made the change.
+	 * @return {Promise} jQuery Promise.
+	 */
+	window.wp.presence.markScreenStale = function ( key, actorId = 0 ) {
+		if ( ! config.restUrl || ! config.nonce ) {
+			return $.Deferred().reject( 'Missing REST configuration.' ).promise();
+		}
+
+		return $.ajax( {
+			url: config.restUrl,
+			method: 'POST',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', config.nonce );
+			},
+			data: {
+				screen_key: key,
+				actor_id: actorId,
+			},
+		} );
+	};
+
 	$( document ).on( 'heartbeat-send', function ( event, data ) {
 		if ( document.visibilityState === 'hidden' ) {
 			return;

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -150,6 +150,30 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/screen-revisions/stale',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'bump_screen_revision' ),
+					'permission_callback' => array( $this, 'bump_screen_revision_permissions_check' ),
+					'args'                => array(
+						'screen_key' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'actor_id'   => array(
+							'type'              => 'integer',
+							'default'           => 0,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -628,9 +628,7 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 	 */
 	public function bump_screen_revision( $request ) {
 		$screen_key = $request->get_param( 'screen_key' );
-		$actor_id   = $request->get_param( 'actor_id' );
-
-		$revision = wp_presence_bump_screen_revision( $screen_key, $actor_id );
+		$revision   = wp_presence_bump_screen_revision( $screen_key );
 
 		if ( false === $revision ) {
 			return new WP_Error(

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -164,11 +164,9 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 							'required'          => true,
 							'type'              => 'string',
 							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'actor_id'   => array(
-							'type'              => 'integer',
-							'default'           => 0,
-							'sanitize_callback' => 'absint',
+							'validate_callback' => static function ( $value ) {
+								return (bool) preg_match( '#^[a-z0-9/_-]+$#', $value );
+							},
 						),
 					),
 				),

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -578,6 +578,55 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks if the current user has permission to bump the given screen revision.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function bump_screen_revision_permissions_check( $request ) {
+		$screen_key = $request->get_param( 'screen_key' );
+		$key        = wp_presence_normalize_screen_key( $screen_key );
+
+		if ( ! wp_presence_current_user_can_access_screen( $key ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to update this screen revision.', 'presence-api' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Bumps a screen revision.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error on failure.
+	 */
+	public function bump_screen_revision( $request ) {
+		$screen_key = $request->get_param( 'screen_key' );
+		$actor_id   = $request->get_param( 'actor_id' );
+
+		$revision = wp_presence_bump_screen_revision( $screen_key, $actor_id );
+
+		if ( false === $revision ) {
+			return new WP_Error(
+				'rest_invalid_screen_key',
+				__( 'Invalid or empty screen key provided.', 'presence-api' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'screen_key' => wp_presence_normalize_screen_key( $screen_key ),
+				'rev'        => $revision,
+			)
+		);
+	}
+
+	/**
 	 * Retrieves the presence entry schema, conforming to JSON Schema.
 	 *
 	 * @return array Item schema data.

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -311,6 +311,40 @@ function wp_presence_on_edit_comment( $comment_id ) {
 }
 
 /**
+ * Checks if the current user has permission to access or edit a given screen.
+ *
+ * @param string $screen_key Normalized screen key.
+ * @return bool
+ */
+function wp_presence_current_user_can_access_screen( $screen_key ) {
+	if ( 0 === strpos( $screen_key, 'options/' ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+	} elseif ( preg_match( '#^post/(\d+)$#', $screen_key, $m ) ) {
+		if ( ! current_user_can( 'edit_post', (int) $m[1] ) ) {
+			return false;
+		}
+	} elseif ( preg_match( '#^user-edit/(\d+)$#', $screen_key, $m ) ) {
+		if ( ! current_user_can( 'edit_user', (int) $m[1] ) ) {
+			return false;
+		}
+	} elseif ( preg_match( '#^term/([^/]+)/(\d+)$#', $screen_key, $m ) ) {
+		if ( ! current_user_can( 'edit_term', (int) $m[2], $m[1] ) ) {
+			return false;
+		}
+	} elseif ( preg_match( '#^comment/(\d+)$#', $screen_key, $m ) ) {
+		if ( ! current_user_can( 'edit_comment', (int) $m[1] ) ) {
+			return false;
+		}
+	} elseif ( ! current_user_can( 'edit_posts' ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Returns the current revision for the screen the client claims to be on.
  *
  * @param array  $response  Heartbeat response.
@@ -330,27 +364,7 @@ function wp_presence_screen_heartbeat_received( $response, $data, $screen_id ) {
 	$key = wp_presence_normalize_screen_key( $raw_key );
 
 	// Require the viewer to have access to the screen whose revision is being disclosed.
-	if ( 0 === strpos( $key, 'options/' ) ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return $response;
-		}
-	} elseif ( preg_match( '#^post/(\d+)$#', $key, $m ) ) {
-		if ( ! current_user_can( 'edit_post', (int) $m[1] ) ) {
-			return $response;
-		}
-	} elseif ( preg_match( '#^user-edit/(\d+)$#', $key, $m ) ) {
-		if ( ! current_user_can( 'edit_user', (int) $m[1] ) ) {
-			return $response;
-		}
-	} elseif ( preg_match( '#^term/([^/]+)/(\d+)$#', $key, $m ) ) {
-		if ( ! current_user_can( 'edit_term', (int) $m[2], $m[1] ) ) {
-			return $response;
-		}
-	} elseif ( preg_match( '#^comment/(\d+)$#', $key, $m ) ) {
-		if ( ! current_user_can( 'edit_comment', (int) $m[1] ) ) {
-			return $response;
-		}
-	} elseif ( ! current_user_can( 'edit_posts' ) ) {
+	if ( ! wp_presence_current_user_can_access_screen( $key ) ) {
 		return $response;
 	}
 

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -440,6 +440,8 @@ function wp_presence_enqueue_stale_screen_banner() {
 	$config = array(
 		'screenKey'   => $screen_key,
 		'baselineRev' => $baseline_rev,
+		'restUrl'     => esc_url_raw( rest_url( 'wp-presence/v1/presence/screen-revisions/stale' ) ),
+		'nonce'       => wp_create_nonce( 'wp_rest' ),
 		'strings'     => array(
 			/* translators: 1: display name, 2: relative time like "2 minutes ago". */
 			'updatedBy'          => __( '%1$s updated this screen %2$s.', 'presence-api' ),

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -22,6 +22,7 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
+		delete_option( 'wp_presence_screen_revisions' );
 		parent::tear_down();
 	}
 
@@ -292,5 +293,56 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$this->assertSame( 'rest_presence_limit_exceeded', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::bump_screen_revision
+	 */
+	public function test_bump_screen_revision_success() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/screen-revisions/stale' );
+		$request->set_param( 'screen_key', 'options/general' );
+
+		$controller = new WP_REST_Presence_Controller();
+		$response   = $controller->bump_screen_revision( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$data = $response->get_data();
+
+		$this->assertSame( 'options/general', $data['screen_key'] );
+		$this->assertSame( 1, $data['rev'] );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::bump_screen_revision_permissions_check
+	 */
+	public function test_bump_screen_revision_permissions() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/screen-revisions/stale' );
+		$request->set_param( 'screen_key', 'options/general' );
+
+		$controller = new WP_REST_Presence_Controller();
+		$result     = $controller->bump_screen_revision_permissions_check( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::bump_screen_revision
+	 */
+	public function test_bump_screen_revision_invalid_key() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/screen-revisions/stale' );
+		$request->set_param( 'screen_key', '' );
+
+		$controller = new WP_REST_Presence_Controller();
+		$response   = $controller->bump_screen_revision( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$this->assertSame( 'rest_invalid_screen_key', $response->get_error_code() );
 	}
 }

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -301,7 +301,7 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	public function test_bump_screen_revision_success() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/screen-revisions/stale' );
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence/screen-revisions/stale' );
 		$request->set_param( 'screen_key', 'options/general' );
 
 		$controller = new WP_REST_Presence_Controller();
@@ -320,7 +320,7 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	public function test_bump_screen_revision_permissions() {
 		wp_set_current_user( self::$editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/screen-revisions/stale' );
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence/screen-revisions/stale' );
 		$request->set_param( 'screen_key', 'options/general' );
 
 		$controller = new WP_REST_Presence_Controller();
@@ -336,7 +336,7 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	public function test_bump_screen_revision_invalid_key() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/screen-revisions/stale' );
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence/screen-revisions/stale' );
 		$request->set_param( 'screen_key', '' );
 
 		$controller = new WP_REST_Presence_Controller();

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -20,9 +20,9 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 
 	public function tear_down() {
 		global $wpdb;
+		delete_option( 'wp_presence_screen_revisions' );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		delete_option( 'wp_presence_screen_revisions' );
 		parent::tear_down();
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to the Presence API feature plugin.

This GitHub repository is where the feature plugin's work happens — issues
track scope and PRs land changes. Keep larger design discussions in the
linked issue and use this Pull Request for code review.

If this is your first time contributing, the following may be helpful:
- Contributing guide: ../blob/main/.github/CONTRIBUTING.md
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Closes: #28
Follow-up to: #22 

## How?

This PR implements the stale-screen detection enhancements by introducing a new client-side API and a supporting REST route to handle non-redirecting, JS-driven saves:

### Server-Side Changes
- Refactored the screen access gating logic from `wp_presence_screen_heartbeat_received()` into a new shared helper function: `wp_presence_current_user_can_access_screen()`.
- Added a new POST endpoint `/wp-presence/v1/presence/screen-revisions/stale` to `WP_REST_Presence_Controller`. 
  - It verifies permissions using the extracted helper and calls `wp_presence_bump_screen_revision()` to increment the revision.
- Extended the script configuration in `wp_presence_enqueue_stale_screen_banner()` to pass down the `restUrl` and the `nonce` to the client.

### Client-Side Changes
- `wp.presence.markScreenStale()`: Added this new global method on the `window.wp.presence` namespace.
  - It performs a `POST` request to the new REST endpoint.

Additionally added unit tests for the bump wrapper methods success, failure and updated README with info on Stale Screen Detection.

## Demo Video

https://github.com/user-attachments/assets/6e2c0ebf-c4c5-40dd-ab3e-b5602b6de9b8


## Use of AI Tools
AI assistance: Yes
Tool(s): Antigravity IDE
Model(s): Gemini 3.1 Pro (Low)
Used for: Identifying relevant code files, deciding on implementation and architecture for enhancement. Unit tests were implemented via it. Final implementation and tests were reviewed and edited by me.
