### PR TITLE
Fix: Hidden post-edit tabs still refresh the post-lock presence entry

### DIFF
--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -149,32 +149,36 @@ function wp_presence_enqueue_heartbeat_ping() {
 			// Guards against duplicate leave() invocations.
 			let hasLeft = false;
 
-			$(document).on('heartbeat-send', function (event, data) {
-				// Skip while the document is hidden (background tab, minimized
-				// window, app switched away) so the existing entries expire via
-				// the default TTL. One early-return suppresses both presence-ping
-				// and presence-editor-ping, since the consolidated handler emits
-				// both.
-				if (document.visibilityState === 'hidden') {
-					return;
-				}
-
-				const ping = { screen: window.pagenow || 'front' };
-				if (frontContext) {
-					if (frontContext.title) {
-						ping.title = frontContext.title;
+			// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
+			$(function () {
+				$(document).on('heartbeat-send', function (event, data) {
+					// Skip while the document is hidden (background tab, minimized
+					// window, app switched away) so the existing entries expire via
+					// the default TTL. One early-return suppresses both presence-ping
+					// and presence-editor-ping, since the consolidated handler emits
+					// both.
+					if (document.visibilityState === 'hidden') {
+						delete data['wp-refresh-post-lock'];
+						return;
 					}
-					if (frontContext.post_id) {
-						ping.post_id = frontContext.post_id;
+
+					const ping = { screen: window.pagenow || 'front' };
+					if (frontContext) {
+						if (frontContext.title) {
+							ping.title = frontContext.title;
+						}
+						if (frontContext.post_id) {
+							ping.post_id = frontContext.post_id;
+						}
 					}
-				}
-				data['presence-ping'] = ping;
+					data['presence-ping'] = ping;
 
-				if (editorPostId) {
-					data['presence-editor-ping'] = { post_id: editorPostId };
-				}
+					if (editorPostId) {
+						data['presence-editor-ping'] = { post_id: editorPostId };
+					}
 
-				hasLeft = false;
+					hasLeft = false;
+				});
 			});
 
 			function leave() {

--- a/tests/e2e/presence-visibility.test.js
+++ b/tests/e2e/presence-visibility.test.js
@@ -89,7 +89,7 @@ test.describe( 'Presence Visibility', () => {
 		expect( visible[ 'presence-ping' ].screen ).toBeTruthy();
 	} );
 
-	test( 'heartbeat-send omits presence-editor-ping while editor tab is hidden', async ( {
+	test( 'heartbeat-send omits presence-editor-ping and wp-refresh-post-lock while editor tab is hidden', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -108,6 +108,7 @@ test.describe( 'Presence Visibility', () => {
 		await setVisibility( page, 'hidden' );
 		const hidden = await captureHeartbeatSend( page );
 		expect( hidden[ 'presence-editor-ping' ] ).toBeUndefined();
+		expect( hidden[ 'wp-refresh-post-lock' ] ).toBeUndefined();
 
 		await setVisibility( page, 'visible' );
 		const visible = await captureHeartbeatSend( page );

--- a/tests/e2e/presence-visibility.test.js
+++ b/tests/e2e/presence-visibility.test.js
@@ -16,7 +16,68 @@
  * @package WordPress
  * @since 7.1.0
  */
-import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
+import { chromium } from '@playwright/test';
+
+const BASE_URL = ( process.env.WP_BASE_URL || 'http://localhost:8888' ).replace( /\/$/, '' );
+
+const TEST_USERS = [
+	{
+		username: 'presence_test_b',
+		email: 'presence_test_b@example.com',
+		firstName: 'User',
+		lastName: 'B',
+		password: 'password',
+		roles: [ 'editor' ],
+	},
+];
+
+const test = base.extend( {
+	testUsers: [
+		async ( { requestUtils }, use ) => {
+			for ( const user of TEST_USERS ) {
+				await requestUtils.createUser( user ).catch( ( error ) => {
+					if ( error?.code !== 'existing_user_login' ) {
+						throw error;
+					}
+				} );
+			}
+			await use( TEST_USERS );
+			await requestUtils.deleteAllUsers();
+		},
+		{ scope: 'test' },
+	],
+} );
+
+async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
+	const context = await headlessBrowser.newContext( {
+		baseURL: BASE_URL,
+		ignoreHTTPSErrors: true,
+	} );
+
+	// Authenticate via POST request to set cookies on the context.
+	await context.request.post( `${ BASE_URL }/wp-login.php`, {
+		form: {
+			log: user.username,
+			pwd: user.password,
+			'wp-submit': 'Log In',
+			redirect_to: destinationUrl || `${ BASE_URL }/wp-admin/`,
+			testcookie: '1',
+		},
+	} );
+
+	const userPage = await context.newPage();
+	await userPage.goto( destinationUrl || `${ BASE_URL }/wp-admin/` );
+	await userPage.waitForLoadState( 'networkidle' );
+
+	await userPage.evaluate( () => {
+		if ( typeof wp !== 'undefined' && wp.heartbeat ) {
+			wp.heartbeat.connectNow();
+		}
+	} );
+
+	return { context, page: userPage };
+}
 
 /**
  * Waits until the WordPress heartbeat library is ready on the page.
@@ -89,7 +150,7 @@ test.describe( 'Presence Visibility', () => {
 		expect( visible[ 'presence-ping' ].screen ).toBeTruthy();
 	} );
 
-	test( 'heartbeat-send omits presence-editor-ping and wp-refresh-post-lock while editor tab is hidden', async ( {
+	test( 'heartbeat-send omits presence-editor-ping while editor tab is hidden', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -108,12 +169,67 @@ test.describe( 'Presence Visibility', () => {
 		await setVisibility( page, 'hidden' );
 		const hidden = await captureHeartbeatSend( page );
 		expect( hidden[ 'presence-editor-ping' ] ).toBeUndefined();
-		expect( hidden[ 'wp-refresh-post-lock' ] ).toBeUndefined();
 
 		await setVisibility( page, 'visible' );
 		const visible = await captureHeartbeatSend( page );
 		expect( visible[ 'presence-editor-ping' ] ).toBeDefined();
 		expect( visible[ 'presence-editor-ping' ].post_id ).toBe( post.id );
+	} );
+
+	test( 'heartbeat-send omits wp-refresh-post-lock while editor tab is hidden', async ( {
+		admin,
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'E2E Visibility Editor Post Lock Test',
+			status: 'draft',
+		} );
+
+		// User A opens the post editor to create the initial lock.
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( page );
+
+		// User B opens the same post editor in a new browser context.
+		const headlessBrowser = await chromium.launch( { headless: true } );
+
+		try {
+			const userB = await loginHeadlessUser(
+				headlessBrowser,
+				testUsers[ 0 ],
+				`${ BASE_URL }/wp-admin/post.php?post=${ post.id }&action=edit`
+			);
+
+			// User B clicks "Take over" to become the active lock holder.
+			const takeOverButton = userB.page.locator( 'a:has-text("Take over")' );
+			await takeOverButton.click();
+
+			// Wait for heartbeat library on User B's page.
+			await waitForHeartbeat( userB.page );
+
+			// Verify that wp-refresh-post-lock is present when visible initially.
+			const initial = await captureHeartbeatSend( userB.page );
+			expect( initial[ 'wp-refresh-post-lock' ] ).toBeDefined();
+			expect( initial[ 'wp-refresh-post-lock' ].post_id ).toBe( String( post.id ) );
+
+			// Verify that wp-refresh-post-lock is deleted when page is hidden.
+			await setVisibility( userB.page, 'hidden' );
+			const hidden = await captureHeartbeatSend( userB.page );
+			expect( hidden[ 'wp-refresh-post-lock' ] ).toBeUndefined();
+
+			// Restore visibility to User B's page and assert it is sent again.
+			await setVisibility( userB.page, 'visible' );
+			const visible = await captureHeartbeatSend( userB.page );
+			expect( visible[ 'wp-refresh-post-lock' ] ).toBeDefined();
+
+			await userB.context.close();
+		} finally {
+			await headlessBrowser.close();
+		}
 	} );
 
 	test( 'visibility restore triggers an immediate heartbeat tick', async ( {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to the Presence API feature plugin.

This GitHub repository is where the feature plugin's work happens — issues
track scope and PRs land changes. Keep larger design discussions in the
linked issue and use this Pull Request for code review.

If this is your first time contributing, the following may be helpful:
- Contributing guide: ../blob/main/.github/CONTRIBUTING.md
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Resolves Issue: #21 <!-- link a GitHub issue here, e.g. #12 -->
Related PRs: #19 , #20 

## How?
- Deletes the `wp-refresh-post-lock` key from the shared heartbeat `data` object when the tab/document is backgrounded (`document.visibilityState === 'hidden'`).
  - Because this key is deleted, WordPress Core's own heartbeat ping doesn't get sent and is thus no longer causing the intercept to update the presence database.
- Wrapped the heartbeat listener in a document ready hook (`$(function() { ... })`). Because our script runs earlier/faster than WordPress Core, registering our listener resulted in an empty data object when attempting to delete the key. Delaying to document ready ensures that the `data['wp-refresh-post-lock']` key exists by the time our handler runs, allowing us to successfully delete it.
- Updated the visibility E2E test to assert that `wp-refresh-post-lock` is omitted from the heartbeat payload when the editor tab is hidden.

> [!NOTE]
> Since we defer the registration specifically to ensure we run after WordPress Core's handler. Keeping all of our code inside this single deferred handler is the simplest approach for now. If we ever need to run other tasks at the very beginning of the heartbeat tick in the future, we can easily split this into two separate listeners (one immediate, one deferred) without any breaking changes.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Antigravity IDE
Model(s): Gemini 3.5 Flash (Low)
Used for: Identifying relevant code file, going through related PRs, it suggested utilising the deferred execution later when debugging.