### PR TITLE
ci: deploy to WordPress.org Plugin Directory on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        description: 'Dry run (deploy without publishing to WordPress.org).'
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -100,6 +105,25 @@ jobs:
           done
 
           echo "Closed: ${CLOSED[*]:-none}"
+
+  # Push the release to the WordPress.org Plugin Directory via SVN.
+  # Requires WPORG_SVN_USERNAME and WPORG_SVN_PASSWORD repo secrets.
+  # To add banner/icon assets later, place them in .wordpress-org/ and
+  # the action will sync them to the SVN assets/ directory automatically.
+  deploy-to-wporg:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Deploy to WordPress.org Plugin Directory
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # stable
+        with:
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+        env:
+          SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
+          SLUG: presence-api
 
   # When release-please's PR is merged, it tags + cuts the GitHub Release.
   # Build the distribution zip and attach it to the release.


### PR DESCRIPTION
Adds a `deploy-to-wporg` job that fires whenever release-please cuts a new release, pushing trunk and the version tag to the WordPress.org Plugin Directory via SVN.

Requires `WPORG_SVN_USERNAME` and `WPORG_SVN_PASSWORD` repo secrets (already configured).