### PR TITLE
ci: extract WP.org deploy into standalone reusable workflow

### DIFF
--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -3,9 +3,18 @@ name: Deploy to WordPress.org
 on:
   workflow_call:
     inputs:
+      tag:
+        type: string
+        description: 'Git tag to deploy (e.g. v0.1.4)'
+        required: false
       dry-run:
         type: boolean
         default: false
+    secrets:
+      WPORG_SVN_PASSWORD:
+        required: true
+      WPORG_SVN_USERNAME:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -29,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag || github.sha }}
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.sha }}
       - name: Deploy to WordPress.org Plugin Directory
         # To add banner/icon assets later, place them in .wordpress-org/ and
         # the action will sync them to the SVN assets/ directory automatically.

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -1,0 +1,42 @@
+name: Deploy to WordPress.org
+
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: 'Git tag to deploy (e.g. v0.1.4)'
+        required: true
+      dry-run:
+        type: boolean
+        description: 'Dry run (deploy without publishing to WordPress.org).'
+        default: false
+
+# Disable permissions for all available scopes.
+# The deploy job only needs read access to clone the repo.
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.sha }}
+      - name: Deploy to WordPress.org Plugin Directory
+        # To add banner/icon assets later, place them in .wordpress-org/ and
+        # the action will sync them to the SVN assets/ directory automatically.
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # stable
+        with:
+          dry-run: ${{ inputs.dry-run || false }}
+        env:
+          SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
+          SLUG: presence-api

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -114,7 +114,10 @@ jobs:
     uses: ./.github/workflows/deploy-wporg.yml
     with:
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
-    secrets: inherit
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets:
+      WPORG_SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+      WPORG_SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
 
   # When release-please's PR is merged, it tags + cuts the GitHub Release.
   # Build the distribution zip and attach it to the release.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,23 +107,14 @@ jobs:
           echo "Closed: ${CLOSED[*]:-none}"
 
   # Push the release to the WordPress.org Plugin Directory via SVN.
-  # Requires WPORG_SVN_USERNAME and WPORG_SVN_PASSWORD repo secrets.
-  # To add banner/icon assets later, place them in .wordpress-org/ and
-  # the action will sync them to the SVN assets/ directory automatically.
+  # Deploy logic lives in deploy-wporg.yml — edit it there to avoid drift.
   deploy-to-wporg:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Deploy to WordPress.org Plugin Directory
-        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # stable
-        with:
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
-        env:
-          SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
-          SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
-          SLUG: presence-api
+    uses: ./.github/workflows/deploy-wporg.yml
+    with:
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+    secrets: inherit
 
   # When release-please's PR is merged, it tags + cuts the GitHub Release.
   # Build the distribution zip and attach it to the release.


### PR DESCRIPTION
Moves the WordPress.org deploy step into a dedicated reusable workflow so it can be triggered manually for any existing tag — useful for backfilling releases like 0.1.4 — without duplicating any configuration.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Workflow authoring and DRY refactor; implementation reviewed and approved by me.