### PR TITLE
fix: pass VERSION env var to deploy action so SVN tag matches git tag

### DIFF
--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -36,9 +36,20 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          TAG="$(echo "${{ inputs.tag }}" | xargs)"
+          if [ -n "$TAG" ]; then
+            echo "ref=refs/tags/$TAG" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.sha }}
+          ref: ${{ steps.inputs.outputs.ref }}
       - name: Deploy to WordPress.org Plugin Directory
         # To add banner/icon assets later, place them in .wordpress-org/ and
         # the action will sync them to the SVN assets/ directory automatically.
@@ -49,3 +60,4 @@ jobs:
           SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
           SLUG: presence-api
+          VERSION: ${{ steps.inputs.outputs.version }}

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
+          # Normalize user-provided tag to avoid output injection and empty values.
           TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           if [ -z "$TAG" ]; then
             echo "::error::Input 'tag' cannot be empty or whitespace-only."

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -40,8 +40,7 @@ jobs:
         id: inputs
         run: |
           TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n')"
-          TAG="${TAG#"${TAG%%[![:space:]]*}"}"
-          TAG="${TAG%"${TAG##*[![:space:]]}"}"
+          TAG="$(printf '%s' "$TAG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           if [ -z "$TAG" ]; then
             echo "::error::Input 'tag' cannot be empty or whitespace-only."
             exit 1

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
-          TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n')"
+          TAG="${TAG#"${TAG%%[![:space:]]*}"}"
+          TAG="${TAG%"${TAG##*[![:space:]]}"}"
           if [ -z "$TAG" ]; then
-            echo "::error::Input 'tag' is required and cannot be empty."
+            echo "::error::Input 'tag' cannot be empty or whitespace-only."
             exit 1
           fi
           printf 'ref=refs/tags/%s\n' "$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -6,7 +6,7 @@ on:
       tag:
         type: string
         description: 'Git tag to deploy (e.g. v0.1.4)'
-        required: false
+        required: true
       dry-run:
         type: boolean
         default: false
@@ -39,14 +39,13 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
-          TAG="$(echo "${{ inputs.tag }}" | xargs)"
-          if [ -n "$TAG" ]; then
-            echo "ref=refs/tags/$TAG" >> "$GITHUB_OUTPUT"
-            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-            echo "version=" >> "$GITHUB_OUTPUT"
+          TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -z "$TAG" ]; then
+            echo "::error::Input 'tag' is required and cannot be empty."
+            exit 1
           fi
+          printf 'ref=refs/tags/%s\n' "$TAG" >> "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "${TAG#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         with:
           ref: ${{ steps.inputs.outputs.ref }}

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
-          TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n')"
-          TAG="$(printf '%s' "$TAG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          TAG="$(printf '%s' "${{ inputs.tag }}" | tr -d '\r\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           if [ -z "$TAG" ]; then
             echo "::error::Input 'tag' cannot be empty or whitespace-only."
             exit 1


### PR DESCRIPTION
Without `VERSION` set, the 10up deploy action falls back to `GITHUB_REF` (`refs/heads/main`) as the SVN tag name, producing an invalid SVN path and failing with `svn: E155010`.

Related: <!-- n/a — direct fix for failing deploy workflow -->

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Diagnosing the failure from workflow logs and writing the fix; reviewed and approved by me.