### PR TITLE
ci: close issues only after successful WordPress.org deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,8 +62,8 @@ jobs:
   # Close issues that were fixed in this release and leave a comment with a
   # Playground link so reporters can verify the fix without a local install.
   close-issues:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please, deploy-to-wporg]
+    if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,7 +63,7 @@ jobs:
   # Playground link so reporters can verify the fix without a local install.
   close-issues:
     needs: [release-please, deploy-to-wporg]
-    if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' }}
+if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Moves issue-closing to depend on a successful WP.org deploy rather than GitHub Release creation, so issues are only marked resolved once the fix is actually available to users.

Related: <!-- n/a -->

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Identifying the dependency change needed and writing it; reviewed and approved by me.