### PR TITLE
ci: DRY deploy workflows — reusable assets job called from main deploy

### DIFF
--- a/.github/workflows/deploy-wporg-assets.yml
+++ b/.github/workflows/deploy-wporg-assets.yml
@@ -1,0 +1,81 @@
+name: Deploy Assets to WordPress.org
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        type: string
+        description: 'Git ref to source assets from.'
+        required: true
+      dry-run:
+        type: boolean
+        default: false
+    secrets:
+      WPORG_SVN_USERNAME:
+        required: true
+      WPORG_SVN_PASSWORD:
+        required: true
+  workflow_dispatch:
+    inputs:
+      checkout-ref:
+        type: string
+        description: 'Git ref to source assets from (branch or SHA). Defaults to main.'
+        required: false
+        default: main
+      dry-run:
+        type: boolean
+        description: 'Dry run — show what would be committed without pushing to SVN.'
+        default: false
+
+permissions: {}
+
+jobs:
+  deploy-assets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout-ref || 'main' }}
+
+      - name: Skip if no assets directory
+        id: check
+        run: |
+          if [ ! -d .wordpress-org ] || [ -z "$(ls -A .wordpress-org 2>/dev/null)" ]; then
+            echo "No assets to sync — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install SVN
+        if: steps.check.outputs.skip != 'true'
+        run: sudo apt-get install -y subversion
+
+      - name: Check out SVN assets directory
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          svn checkout \
+            "https://plugins.svn.wordpress.org/presence-api/assets/" \
+            /tmp/svn-assets \
+            --username "${{ secrets.WPORG_SVN_USERNAME }}" \
+            --password "${{ secrets.WPORG_SVN_PASSWORD }}" \
+            --no-auth-cache \
+            --non-interactive
+
+      - name: Sync .wordpress-org/ into SVN assets
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          cp -v .wordpress-org/* /tmp/svn-assets/
+          svn add --force /tmp/svn-assets/* 2>/dev/null || true
+          svn status /tmp/svn-assets | grep '^!' | awk '{print $2}' | xargs -r svn delete
+          svn status /tmp/svn-assets
+
+      - name: Commit to SVN
+        if: steps.check.outputs.skip != 'true' && !inputs.dry-run
+        run: |
+          svn commit /tmp/svn-assets \
+            --message "Update plugin directory assets from GitHub" \
+            --username "${{ secrets.WPORG_SVN_USERNAME }}" \
+            --password "${{ secrets.WPORG_SVN_PASSWORD }}" \
+            --no-auth-cache \
+            --non-interactive

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -21,10 +21,6 @@ on:
         type: string
         description: 'Git tag to deploy (e.g. v0.1.4)'
         required: true
-      checkout-ref:
-        type: string
-        description: 'Git ref to check out (defaults to tag). Override to deploy assets from a branch without cutting a new release.'
-        required: false
       dry-run:
         type: boolean
         description: 'Dry run (deploy without publishing to WordPress.org).'
@@ -39,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      ref: ${{ steps.inputs.outputs.ref }}
     steps:
       - name: Resolve inputs
         id: inputs
@@ -49,19 +47,12 @@ jobs:
             echo "::error::Input 'tag' cannot be empty or whitespace-only."
             exit 1
           fi
-          CHECKOUT_REF="${{ inputs.checkout-ref }}"
-          if [ -n "$CHECKOUT_REF" ]; then
-            printf 'ref=%s\n' "$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
-          else
-            printf 'ref=refs/tags/%s\n' "$TAG" >> "$GITHUB_OUTPUT"
-          fi
+          printf 'ref=refs/tags/%s\n' "$TAG" >> "$GITHUB_OUTPUT"
           printf 'version=%s\n' "${TAG#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         with:
           ref: ${{ steps.inputs.outputs.ref }}
       - name: Deploy to WordPress.org Plugin Directory
-        # To add banner/icon assets later, place them in .wordpress-org/ and
-        # the action will sync them to the SVN assets/ directory automatically.
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # stable
         with:
           dry-run: ${{ inputs.dry-run || false }}
@@ -70,3 +61,13 @@ jobs:
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
           SLUG: presence-api
           VERSION: ${{ steps.inputs.outputs.version }}
+
+  assets:
+    needs: deploy
+    uses: ./.github/workflows/deploy-wporg-assets.yml
+    with:
+      checkout-ref: ${{ needs.deploy.outputs.ref }}
+      dry-run: ${{ inputs.dry-run == true }}
+    secrets:
+      WPORG_SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
+      WPORG_SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}


### PR DESCRIPTION
Consolidates the two deploy workflows: `deploy-wporg-assets.yml` is now a reusable `workflow_call` that `deploy-wporg.yml` invokes automatically after each version deploy. Dispatching it manually still works for assets-only updates. Removes the `checkout-ref` override from the main deploy (no longer needed).

Related: #86

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Drafting and implementation