### PR TITLE
fix: check entry ownership before enforcing per-user presence limit

### DIFF
--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -353,26 +353,8 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 
 		$current_user_id = get_current_user_id();
 
-		// Enforce per-user entry limit (only count non-expired entries).
-		$cutoff = gmdate( 'Y-m-d H:i:s', time() - wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$user_entry_count = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->presence} WHERE user_id = %d AND date_gmt > %s",
-				$current_user_id,
-				$cutoff
-			)
-		);
-
-		if ( (int) $user_entry_count >= self::MAX_ENTRIES_PER_USER ) {
-			return new WP_Error(
-				'rest_presence_limit_exceeded',
-				__( 'You have reached the maximum number of presence entries.', 'presence-api' ),
-				array( 'status' => 429 )
-			);
-		}
-
-		// Prevent overwriting another user's presence entry.
+		// Prevent overwriting another user's presence entry, and determine whether
+		// this request is an update to an existing entry or a new insertion.
 		//
 		// A narrow race window exists between the SELECT and INSERT below.
 		// This is acceptable because:
@@ -396,6 +378,28 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 				__( 'This client_id is already in use by another user.', 'presence-api' ),
 				array( 'status' => 409 )
 			);
+		}
+
+		// Enforce per-user entry limit only for new entries. Refreshing an existing
+		// entry owned by this user must always succeed regardless of the cap.
+		if ( null === $existing_user_id ) {
+			$cutoff = gmdate( 'Y-m-d H:i:s', time() - wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$user_entry_count = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->presence} WHERE user_id = %d AND date_gmt > %s",
+					$current_user_id,
+					$cutoff
+				)
+			);
+
+			if ( (int) $user_entry_count >= self::MAX_ENTRIES_PER_USER ) {
+				return new WP_Error(
+					'rest_presence_limit_exceeded',
+					__( 'You have reached the maximum number of presence entries.', 'presence-api' ),
+					array( 'status' => 429 )
+				);
+			}
 		}
 
 		$result = wp_set_presence( $room, $client_id, $data, $current_user_id );

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -352,9 +352,12 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 		}
 
 		$current_user_id = get_current_user_id();
+		$cutoff          = gmdate( 'Y-m-d H:i:s', time() - wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
 
 		// Prevent overwriting another user's presence entry, and determine whether
-		// this request is an update to an existing entry or a new insertion.
+		// this request is an update to an existing active entry or a new insertion.
+		// Expired rows (date_gmt <= cutoff) are treated as absent: reactivating one
+		// counts against the cap the same as creating a brand-new entry.
 		//
 		// A narrow race window exists between the SELECT and INSERT below.
 		// This is acceptable because:
@@ -366,9 +369,10 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$existing_user_id = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT user_id FROM {$wpdb->presence} WHERE room = %s AND client_id = %s",
+				"SELECT user_id FROM {$wpdb->presence} WHERE room = %s AND client_id = %s AND date_gmt > %s",
 				$room,
-				$client_id
+				$client_id,
+				$cutoff
 			)
 		);
 
@@ -381,9 +385,8 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 		}
 
 		// Enforce per-user entry limit only for new entries. Refreshing an existing
-		// entry owned by this user must always succeed regardless of the cap.
+		// active entry owned by this user must always succeed regardless of the cap.
 		if ( null === $existing_user_id ) {
-			$cutoff = gmdate( 'Y-m-d H:i:s', time() - wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$user_entry_count = $wpdb->get_var(
 				$wpdb->prepare(

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -275,6 +275,30 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	/**
 	 * @covers WP_REST_Presence_Controller::create_item
 	 */
+	public function test_rest_update_existing_entry_succeeds_at_limit() {
+		wp_set_current_user( self::$editor_id );
+
+		// Fill exactly to the limit (50), including one entry we'll try to refresh.
+		wp_set_presence( 'room/target', 'client-target', array(), self::$editor_id );
+		for ( $i = 0; $i < 49; $i++ ) {
+			wp_set_presence( 'room/test-' . $i, 'client-' . $i, array(), self::$editor_id );
+		}
+
+		// Now at exactly 50 entries — refreshing an existing (room, client_id) should succeed.
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence' );
+		$request->set_param( 'room', 'room/target' );
+		$request->set_param( 'client_id', 'client-target' );
+		$request->set_param( 'data', array( 'screen' => 'updated' ) );
+
+		$controller = new WP_REST_Presence_Controller();
+		$response   = $controller->create_item( $request );
+
+		$this->assertNotWPError( $response );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::create_item
+	 */
 	public function test_rest_create_enforces_entry_limit() {
 		wp_set_current_user( self::$editor_id );
 


### PR DESCRIPTION
A user at exactly 50 active presence entries could not refresh any of their own existing entries — the per-user cap check fired before the code determined whether the request was a new insertion or an update, returning 429 and silently causing presence to go stale.

Related: #88

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Assistance with reproduction of issue and co-authoring of proposed solution