### PR TITLE
ci: fix missing indentation on close-issues if condition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,7 +63,7 @@ jobs:
   # Playground link so reporters can verify the fix without a local install.
   close-issues:
     needs: [release-please, deploy-to-wporg]
-if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
+    if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The `if:` key on the `close-issues` job was missing its two-space indent, causing the workflow YAML to fail parsing and preventing release-please from running on every push to main.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Identifying and authoring the fix