### PR TITLE
ci: remove inputs context references that break push-triggered runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,7 +63,7 @@ jobs:
   # Playground link so reporters can verify the fix without a local install.
   close-issues:
     needs: [release-please, deploy-to-wporg]
-    if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
+    if: ${{ needs.release-please.outputs.release_created && needs.deploy-to-wporg.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -113,7 +113,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/deploy-wporg.yml
     with:
-      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+      dry-run: ${{ inputs.dry-run || false }}
       tag: ${{ needs.release-please.outputs.tag_name }}
     secrets:
       WPORG_SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}


### PR DESCRIPTION
The `inputs` context is only populated for `workflow_dispatch` and `workflow_call` events. Referencing `inputs.dry-run` in jobs triggered by `push` causes GitHub to reject the workflow file at parse time, resulting in zero jobs and no release PR being created.

Two fixes:
- `close-issues.if`: drop the `inputs.dry-run` guard — it is redundant because `release_created` is always false on dry-run dispatches.
- `deploy-to-wporg.with.dry-run`: simplify to `inputs.dry-run || false`, which is safe across all trigger types.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Identifying and authoring the fix