### PR TITLE
ci: fix YAML block scalar broken by unindented comment continuation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,9 +98,8 @@ jobs:
             for ISSUE in $ISSUES; do
               if printf '%s\n' "${CLOSED[@]:-}" | grep -qx "$ISSUE"; then continue; fi
               CLOSED+=("$ISSUE")
-              gh issue close "$ISSUE" --comment ":tada: Resolved in [**${TAG}**](${RELEASE_URL}).
-
-**[Try it on WordPress Playground →](${PLAYGROUND_URL})**"
+              printf -v COMMENT ':tada: Resolved in [**%s**](%s).\n\n**[Try it on WordPress Playground →](%s)**' "$TAG" "$RELEASE_URL" "$PLAYGROUND_URL"
+              gh issue close "$ISSUE" --comment "$COMMENT"
             done
           done
 


### PR DESCRIPTION
The release-please workflow has returned a workflow file issue on every run since 857da01 introduced a multiline shell string whose second paragraph sat at column 0, terminating the YAML block scalar early.

Related: <!-- none -->

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Root cause analysis and fix