### PR TITLE
ci: use == true to produce an unambiguous boolean for dry-run input

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -112,7 +112,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/deploy-wporg.yml
     with:
-      dry-run: ${{ inputs.dry-run || false }}
+      dry-run: ${{ inputs.dry-run == true }}
       tag: ${{ needs.release-please.outputs.tag_name }}
     secrets:
       WPORG_SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}


### PR DESCRIPTION
Every push-triggered release-please run has resulted in a startup_failure because GitHub's startup validator cannot confirm inputs.dry-run || false always evaluates to boolean when inputs is empty on push events.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Root cause analysis and fix