### PR TITLE
ci: remove push trigger, run release-please only on workflow_dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,6 @@
 name: Release Please
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       dry-run:
@@ -112,7 +110,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/deploy-wporg.yml
     with:
-      dry-run: ${{ inputs.dry-run == true }}
+      dry-run: ${{ inputs.dry-run }}
       tag: ${{ needs.release-please.outputs.tag_name }}
     secrets:
       WPORG_SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}


### PR DESCRIPTION
The push-triggered workflow has been broken since July 9. Removing it restores the manual dispatch process already in use for releases, and ensures inputs context is always defined so the dry-run flag passes cleanly to the deploy job.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Root cause analysis and fix