### PR TITLE
ci: restore push trigger on release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,8 @@
 name: Release Please
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Restores the push trigger removed in #96. The underlying cause of the startup_failure (the close-issues and deploy-to-wporg jobs) was removed in #97, so the trigger is safe again. Merging this will also fire the workflow and refresh the open v0.1.5 release PR.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Drafting and review