### PR TITLE
Use $user_id from wp_logout hook instead of get_current_user_id()

### DIFF
--- a/includes/lifecycle.php
+++ b/includes/lifecycle.php
@@ -32,10 +32,10 @@ function wp_presence_on_login( $user_login, $user ) {
 
 /**
  * Removes all presence entries when a user logs out.
+ *
+ * @param int $user_id The ID of the user who just logged out.
  */
-function wp_presence_on_logout() {
-	$user_id = get_current_user_id();
-
+function wp_presence_on_logout( $user_id ) {
 	if ( $user_id && user_can( $user_id, 'edit_posts' ) ) {
 		wp_remove_user_presence( $user_id );
 	}

--- a/presence-api.php
+++ b/presence-api.php
@@ -152,7 +152,7 @@ add_action( 'edited_term', 'wp_presence_on_edited_term', 10, 3 );
 add_action( 'edit_comment', 'wp_presence_on_edit_comment' );
 
 add_action( 'wp_login', 'wp_presence_on_login', 10, 2 );
-add_action( 'wp_logout', 'wp_presence_on_logout' );
+add_action( 'wp_logout', 'wp_presence_on_logout', 10, 1 );
 
 add_action( 'admin_bar_menu', 'wp_presence_admin_bar_node', 80 );
 add_action( 'admin_enqueue_scripts', 'wp_presence_admin_bar_assets' );

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -80,7 +80,7 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
 		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
 
-		// Simulate real wp_logout timing
+		// Simulate real wp_logout timing.
 		// Auth cookie has been cleared, so get_current_user_id() would return 0.
 		wp_set_current_user( 0 );
 

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -54,8 +54,7 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
 		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
 
-		wp_set_current_user( self::$editor_id );
-		wp_presence_on_logout();
+		wp_presence_on_logout( self::$editor_id );
 
 		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
 	}
@@ -67,11 +66,26 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 		// Manually insert a presence entry for the subscriber (bypassing cap check).
 		wp_set_presence( 'admin/online', 'user-' . self::$subscriber_id, array(), self::$subscriber_id );
 
-		wp_set_current_user( self::$subscriber_id );
-		wp_presence_on_logout();
+		wp_presence_on_logout( self::$subscriber_id );
 
 		// Entry should remain because logout skips users without edit_posts.
 		$entries = wp_get_user_presence( self::$subscriber_id );
 		$this->assertCount( 1, $entries );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_logout
+	 */
+	public function test_logout_clears_presence_without_current_user() {
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
+		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
+
+		// Simulate real wp_logout timing
+		// Auth cookie has been cleared, so get_current_user_id() would return 0.
+		wp_set_current_user( 0 );
+
+		wp_presence_on_logout( self::$editor_id );
+
+		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
 	}
 }


### PR DESCRIPTION
Fixes a bug where logging out fails to remove the user's presence data from the database.

Closes #110 

`get_current_user_id()` returns `0` by the time `wp_logout` fires because `wp_clear_auth_cookie()` has already run. The existing guard then short-circuits the function before `wp_remove_user_presence()` is ever called.

Since WordPress 5.5, `wp_logout` passes the logged-out user's ID as its first argument. This PR uses that argument directly. [reference](https://developer.wordpress.org/reference/hooks/wp_logout/)

### Changes

- **`includes/lifecycle.php`** — Updated `wp_presence_on_logout()` to accept `$user_id` as a parameter; removed the broken `get_current_user_id()` call.
- **`presence-api.php`** — Made the `add_action()` registration explicit with `10, 1` for readability.
- **`tests/test-lifecycle.php`** — Updated two existing logout tests to pass `$user_id` directly. Added a regression test that calls `wp_set_current_user( 0 )` before invoking the callback, explicitly simulating the real logout timing.

### Testing

```
OK (81 tests, 165 assertions)
```
