### PR TITLE
chore: update plugin author to WordPress Core Team

### DIFF
--- a/presence-api.php
+++ b/presence-api.php
@@ -5,7 +5,8 @@
  * Version: 0.1.7
  * Requires at least: 7.0
  * Requires PHP: 7.4
- * Author: Joe Fusco
+ * Author: WordPress Core Team
+ * Author URI: https://make.wordpress.org/core/
  * Text Domain: presence-api
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Follows the same convention as Performance Lab, which uses the team name and Make WordPress URL rather than an individual or wordpress.org.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Drafting and implementation