### PR TITLE
fix: suppress props-bot on release-please PRs

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -68,7 +68,8 @@ jobs:
         'props-bot' == github.event.label.name
       ) &&
       ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' ) &&
-      ! startsWith( github.event.pull_request.head.ref, 'docs/add-' )
+      ! startsWith( github.event.pull_request.head.ref, 'docs/add-' ) &&
+      ! startsWith( github.event.pull_request.head.ref, 'release-please--' )
 
     steps:
       - name: Gather a list of contributors


### PR DESCRIPTION
Release PRs are automated and have no direct code contributors, so props-bot running on them produces noise.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Drafting and implementation