### PR TITLE
fix: use inline script to load aggregate-props from workspace

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,7 +70,9 @@ jobs:
           PROPS_SORT_LAST: ${{ vars.PROPS_SORT_LAST }}
           PR_NUMBER: ${{ fromJSON(needs.release-please.outputs.pr).number }}
         with:
-          script-path: .github/scripts/aggregate-props.js
+          script: |
+            const run = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/aggregate-props.js`);
+            await run({ github, context, core });
 
   # When release-please's PR is merged, it tags + cuts the GitHub Release.
   # Build the distribution zip and attach it to the release.


### PR DESCRIPTION
actions/github-script@v8 does not support script-path; switches to require() via the script: input so actionlint passes and the aggregate-props job actually runs.