### PR TITLE
fix: remove top-level permissions block that broke release-please startup

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,8 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
-
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`permissions: {}` at the workflow level removes all permissions including the implicit `metadata: read` that GitHub Actions requires to initialize any workflow run.