### PR TITLE
ci: housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/playground-preview-cleanup.yml
+++ b/.github/workflows/playground-preview-cleanup.yml
@@ -12,13 +12,12 @@ on:
   pull_request_target:
     types: [closed]
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   cleanup:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     steps:
       - name: Delete preview release and tag

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -24,14 +24,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: write
+  actions: read
+  pull-requests: write
 
 jobs:
   publish:
-    permissions:
-      contents: write
-      actions: read
-      pull-requests: write
     if: >
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'pull_request'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,8 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
-
 jobs:
   release-please:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Running list of minor CI housekeeping items too small to warrant their own PR.

- `ci.yml`: standardize concurrency group to `${{ github.workflow }}-${{ github.ref }}` (was `ci-${{ github.ref }}`, inconsistent with every other workflow)
- Revert `permissions: {}` on `release-please.yml`, `playground-preview-cleanup.yml`, and `playground-preview-publish.yml` introduced in #126 -- these workflows require a workflow-level permissions grant to initialize (see #125)

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-sonnet-4-6
Used for: Drafting and implementation