### PR TITLE
REST API: Remove value sanitization from arbitrary data parameter

### DIFF
--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -206,10 +206,12 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Sanitizes the data parameter values recursively.
+	 * Sanitizes the data parameter structure recursively.
 	 *
-	 * Preserves scalar types (strings, integers, floats, booleans)
-	 * and recurses into nested arrays up to MAX_DATA_DEPTH levels.
+	 * Enforces a type allowlist (strings, integers, floats, booleans,
+	 * and nested arrays) and a depth limit of MAX_DATA_DEPTH levels.
+	 * String values are passed through untouched; output-time encoding
+	 * (e.g. wp_json_encode, esc_html) is responsible for escaping.
 	 *
 	 * @param mixed $value The data parameter value.
 	 * @return array Sanitized data array.
@@ -223,11 +225,15 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Recursively sanitizes data values with a depth limit.
+	 * Recursively enforces the type allowlist and depth limit on data values.
 	 *
-	 * @param array $data  The data to sanitize.
+	 * Keys are sanitized via sanitize_text_field(). Scalar values
+	 * (strings, integers, floats, booleans) are preserved as-is;
+	 * unsupported types are silently dropped.
+	 *
+	 * @param array $data  The data to process.
 	 * @param int   $depth Current nesting depth.
-	 * @return array Sanitized data.
+	 * @return array Processed data.
 	 */
 	private static function sanitize_data_recursive( $data, $depth ) {
 		if ( $depth >= self::MAX_DATA_DEPTH ) {
@@ -242,7 +248,7 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 			if ( is_array( $value ) ) {
 				$sanitized[ $key ] = self::sanitize_data_recursive( $value, $depth + 1 );
 			} elseif ( is_string( $value ) ) {
-				$sanitized[ $key ] = sanitize_text_field( $value );
+				$sanitized[ $key ] = $value;
 			} elseif ( is_int( $value ) || is_float( $value ) || is_bool( $value ) ) {
 				$sanitized[ $key ] = $value;
 			}

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -227,6 +227,7 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 
 	/**
 	 * @covers WP_REST_Presence_Controller::sanitize_data_param
+	 * @covers WP_REST_Presence_Controller::sanitize_data_recursive
 	 */
 	public function test_sanitize_data_does_not_strip_html_or_whitespace() {
 		$controller = new WP_REST_Presence_Controller();

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -228,14 +228,19 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	/**
 	 * @covers WP_REST_Presence_Controller::sanitize_data_param
 	 */
-	public function test_sanitize_data_strips_html() {
+	public function test_sanitize_data_does_not_strip_html_or_whitespace() {
 		$controller = new WP_REST_Presence_Controller();
 
-		$input  = array( 'msg' => '<script>alert("xss")</script>' );
+		$input  = array(
+			'html'      => '<script>alert("xss")</script>',
+			'multiline' => "line 1\nline 2",
+			'spaced'    => '  hello world  ',
+		);
 		$result = $controller->sanitize_data_param( $input );
 
-		$this->assertStringNotContainsString( '<script>', $result['msg'] );
-		$this->assertStringNotContainsString( '</script>', $result['msg'] );
+		$this->assertSame( '<script>alert("xss")</script>', $result['html'] );
+		$this->assertSame( "line 1\nline 2", $result['multiline'] );
+		$this->assertSame( '  hello world  ', $result['spaced'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR fixes an issue where multiline strings, leading/trailing whitespace, and HTML tags are silently corrupted or stripped when saving the arbitrary `data` parameter in a presence payload.

Currently, `WP_REST_Presence_Controller::sanitize_data_recursive()` runs `sanitize_text_field()` on every string value in the `data` array. Since the REST API encodes responses as JSON, and all output contexts (like the dashboard widget) escape values on render, this write-time sanitization is redundant and destructive.

This change removes `sanitize_text_field()` on the values, passing strings through untouched (similar to integer, float, and boolean values), and updates documentation and unit tests.

Fixes 
- #129 

## Verification

* **PHPUnit tests**: Run `npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit --testdox`

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for - investigating and identifying usage of the function, updating test cases