### PR TITLE
build: declare PHPUnit and Polyfills as composer dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,23 +12,22 @@ Dashboard: [localhost:8888/wp-admin/](http://localhost:8888/wp-admin/) (admin / 
 ## Running tests
 
 ```bash
-# Coding standards
+# PHP dependencies (PHPCS, PHPStan, PHPUnit, Polyfills)
 composer install
+
+# Coding standards
 ./vendor/bin/phpcs --standard=phpcs.xml.dist
 
 # Static analysis
 ./vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=2G
 
 # Unit tests (requires wp-env running)
-npx wp-env run tests-cli -- composer require --dev phpunit/phpunit:^9.6 yoast/phpunit-polyfills:^2.0 --working-dir=/var/www/html --update-with-all-dependencies
 npm test
 
 # E2E tests (requires wp-env running)
 npx playwright install chromium
 npm run test:e2e
 ```
-
-The PHPUnit install step only needs to be run once per `wp-env start`.
 
 ## Pull requests
 

--- a/.github/workflows/multisite.yml
+++ b/.github/workflows/multisite.yml
@@ -24,7 +24,8 @@ jobs:
       - run: npm ci
       - name: Authenticate composer to GitHub
         run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
+      - name: Install Composer dependencies
+        run: composer install --no-interaction
       - run: npx wp-env start
-      - run: npx wp-env run tests-cli -- composer require --dev phpunit/phpunit:^9.6 yoast/phpunit-polyfills:^2.0 --working-dir=/var/www/html --update-with-all-dependencies
       - run: npx wp-env run tests-cli -- wp core multisite-convert --title="Test Network"
-      - run: npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- /var/www/html/vendor/bin/phpunit
+      - run: npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -35,11 +35,12 @@ jobs:
       - run: npm ci
       - name: Authenticate composer to GitHub
         run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
+      - name: Install Composer dependencies
+        run: composer install --no-interaction
       - run: npx wp-env start ${{ matrix.coverage && '--xdebug=coverage' || '' }}
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
-      - run: npx wp-env run tests-cli -- composer require --dev phpunit/phpunit:^9.6 yoast/phpunit-polyfills:^2.0 --working-dir=/var/www/html --update-with-all-dependencies
-      - run: npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- /var/www/html/vendor/bin/phpunit ${{ matrix.coverage && '--coverage-clover coverage.xml' || '' }}
+      - run: npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit ${{ matrix.coverage && '--coverage-clover coverage.xml' || '' }}
       - name: Upload coverage to Codecov
         if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,6 +4,6 @@
 	"config": {
 		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true,
-		"WP_TESTS_PHPUNIT_POLYFILLS_PATH": "/var/www/html/vendor/yoast/phpunit-polyfills"
+		"WP_TESTS_PHPUNIT_POLYFILLS_PATH": "/var/www/html/wp-content/plugins/presence-api/vendor/yoast/phpunit-polyfills"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"phpstan/phpstan": "2.2.5",
 		"php-stubs/wordpress-stubs": "^6.9",
-		"php-stubs/wp-cli-stubs": "^2.12"
+		"php-stubs/wp-cli-stubs": "^2.12",
+		"phpunit/phpunit": "^9.6",
+		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php-stubs/wordpress-stubs": "^6.9",
 		"php-stubs/wp-cli-stubs": "^2.12",
 		"phpunit/phpunit": "^9.6",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"env:start": "wp-env start",
 		"env:stop": "wp-env stop",
 		"env:cli": "wp-env run cli wp",
-		"test": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- /var/www/html/vendor/bin/phpunit --testdox",
+		"test": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit --testdox",
 		"test:scripts": "node --test .github/scripts/*.test.js"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Description

Currently, running tests locally via `npm run test` fails for local developers with a fatal error on a fresh install:

```
Error: The PHPUnit Polyfills library is a requirement for running the WP test suite.
The PHPUnit Polyfills autoload file was not found in "/var/www/html/vendor/yoast/phpunit-polyfills"
```

This occurs because:
1. `yoast/phpunit-polyfills` and `phpunit` are not declared in `composer.json`.
2. The core tests container setup expects these to be in `/var/www/html/vendor/`, which is only installed on-the-fly during CI runs.

This PR cleans up the local development and CI testing environments by:
- Adding `phpunit/phpunit` and `yoast/phpunit-polyfills` as dev dependencies inside `composer.json`.
- Pointing `.wp-env.json` to look inside the mounted plugin's vendor folder for the polyfills.
- Updating `package.json` to execute `./vendor/bin/phpunit` (PHPUnit 9) instead of the WordPress core vendor path. `wp-env` starts with a standard WordPress ZIP download by default, which does not contain a vendor/ directory inside /var/www/html .
- Aligning both GitHub Action workflows (`phpunit.yml` and `multisite.yml`) to run a standard `composer install --no-interaction` and run `./vendor/bin/phpunit`. This removes the slow and redundant container-level `composer require` run.

Fixes 
- #148 

### How to Test / Verification

1. Install dependencies:
   ```bash
   composer install
   ```
2. Execute the tests:
   ```bash
   npm run test
   ```
3. Verify that the tests boot correctly and all unit tests run and pass.

### Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.5 Flash
Used for: Identifying the local test suite provisioning failure, and find regression issue like adjusting the GitHub Action workflows to use standard composer install. Each change has been humanly reviewed by me.