### PR TITLE
fix: render release props in a code block like props-bot

### DIFF
--- a/.github/scripts/aggregate-props.js
+++ b/.github/scripts/aggregate-props.js
@@ -27,8 +27,18 @@ function sortProps(names, sortLast) {
   return [...unique.filter(n => n !== sortLast), ...(unique.includes(sortLast) ? [sortLast] : [])];
 }
 
+// Mirrors the props-bot comment layout so the props line is a copyable code
+// block rather than prose.
 function buildComment(names) {
-  return `${MARKER}\n\nProps ${names.join(', ')}.`;
+  return [
+    MARKER,
+    '',
+    'Core Committers: Use this line as a base for the props when committing in SVN:',
+    '',
+    '```',
+    `Props ${names.join(', ')}.`,
+    '```',
+  ].join('\n');
 }
 
 async function run({ github, context, core, env = process.env }) {

--- a/.github/scripts/aggregate-props.test.js
+++ b/.github/scripts/aggregate-props.test.js
@@ -158,6 +158,14 @@ test('buildComment: formats the Props line correctly', () => {
   assert.ok(buildComment(['alice', 'bob']).includes('Props alice, bob.'));
 });
 
+test('buildComment: wraps the Props line in a fenced code block', () => {
+  assert.ok(buildComment(['alice', 'bob']).includes('```\nProps alice, bob.\n```'));
+});
+
+test('buildComment: keeps the props line parseable by parsePropsNames', () => {
+  assert.deepEqual(parsePropsNames(buildComment(['alice', 'bob'])), ['alice', 'bob']);
+});
+
 // ---------------------------------------------------------------------------
 // run()
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The release props comment renders as plain prose while props-bot renders the same line as a copyable code block.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting and implementation