### PR TITLE
fix: enforce per-room authorization checks for presence rooms

### DIFF
--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -102,9 +102,9 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 	$user_editing_post = array();
 	$post_entries      = wp_get_presence_by_room_prefix( 'postType/' );
 	foreach ( $post_entries as $pe ) {
-		// Room format: postType/{type}:{id}.
-		if ( preg_match( '/^postType\/[^:]+:(\d+)$/', $pe->room, $m ) ) {
-			$user_editing_post[ (int) $pe->user_id ] = (int) $m[1];
+		$parsed = wp_presence_parse_room( $pe->room );
+		if ( $parsed ) {
+			$user_editing_post[ (int) $pe->user_id ] = $parsed['post_id'];
 		}
 	}
 	if ( ! empty( $user_editing_post ) ) {

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -557,7 +557,30 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 		$per_page = $request->get_param( 'per_page' );
 		$page     = $request->get_param( 'page' );
 
-		$rooms = wp_get_active_rooms();
+		$rooms           = wp_get_active_rooms();
+		$current_user_id = get_current_user_id();
+
+		// Prime post caches to avoid N+1 queries during the wp_can_access_presence_room filtering loop.
+		$post_ids = array();
+		foreach ( $rooms as $room ) {
+			$parsed = wp_presence_parse_room( $room['room'] );
+			if ( $parsed ) {
+				$post_ids[] = $parsed['post_id'];
+			}
+		}
+		if ( ! empty( $post_ids ) ) {
+			_prime_post_caches( array_unique( $post_ids ) );
+		}
+
+		$rooms = array_values(
+			array_filter(
+				$rooms,
+				function ( $room ) use ( $current_user_id ) {
+					return wp_can_access_presence_room( $room['room'], $current_user_id );
+				}
+			)
+		);
+
 		$total = count( $rooms );
 
 		// Rooms are aggregated in PHP (GROUP BY + user hydration), so paginate the result.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -132,6 +132,25 @@ function wp_remove_user_presence( $user_id ) {
 }
 
 /**
+ * Parses a room identifier.
+ *
+ * Room format: `postType/{post_type}:{post_id}`
+ *
+ * @param string $room The room identifier.
+ * @return array|false An array containing 'post_type' and 'post_id' on success, false otherwise.
+ */
+function wp_presence_parse_room( $room ) {
+	if ( preg_match( '#^postType/([^:]+):(\d+)$#', $room, $matches ) ) {
+		return array(
+			'post_type' => $matches[1],
+			'post_id'   => (int) $matches[2],
+		);
+	}
+
+	return false;
+}
+
+/**
  * Checks if a user can access a presence room.
  *
  * @param string $room    The room identifier.
@@ -145,6 +164,11 @@ function wp_can_access_presence_room( $room, $user_id = 0 ) {
 
 	if ( ! $user_id ) {
 		return false;
+	}
+
+	$parsed = wp_presence_parse_room( $room );
+	if ( $parsed ) {
+		return user_can( $user_id, 'edit_post', $parsed['post_id'] );
 	}
 
 	return user_can( $user_id, 'edit_posts' );

--- a/includes/post-list.php
+++ b/includes/post-list.php
@@ -76,13 +76,12 @@ function wp_presence_render_editors_column( $column_name, $post_id ) {
 		$entries      = wp_get_presence_by_room_prefix( 'postType/' );
 
 		foreach ( $entries as $entry ) {
-			$room_parts = explode( ':', $entry->room, 2 );
-
-			if ( count( $room_parts ) < 2 ) {
+			$parsed = wp_presence_parse_room( $entry->room );
+			if ( ! $parsed ) {
 				continue;
 			}
 
-			$pid = (int) $room_parts[1];
+			$pid = $parsed['post_id'];
 
 			if ( ! isset( $presence_map[ $pid ] ) ) {
 				$presence_map[ $pid ] = array();

--- a/includes/widgets/class-wp-presence-widget-active-posts.php
+++ b/includes/widgets/class-wp-presence-widget-active-posts.php
@@ -283,9 +283,9 @@ JS,
 		// Prime post caches to avoid N+1 queries from get_post() in the loop.
 		$post_ids = array();
 		foreach ( $entries as $entry ) {
-			$parts = explode( ':', $entry->room, 2 );
-			if ( count( $parts ) >= 2 ) {
-				$post_ids[] = (int) $parts[1];
+			$parsed = wp_presence_parse_room( $entry->room );
+			if ( $parsed ) {
+				$post_ids[] = $parsed['post_id'];
 			}
 		}
 		if ( ! empty( $post_ids ) ) {
@@ -300,14 +300,14 @@ JS,
 			}
 
 			/* Parse room format: postType/{type}:{id} */
-			$room_parts = explode( ':', $entry->room, 2 );
+			$parsed = wp_presence_parse_room( $entry->room );
 
-			if ( count( $room_parts ) < 2 ) {
+			if ( ! $parsed ) {
 				continue;
 			}
 
-			$post_id   = (int) $room_parts[1];
-			$post_type = str_replace( 'postType/', '', $room_parts[0] );
+			$post_id   = $parsed['post_id'];
+			$post_type = $parsed['post_type'];
 
 			if ( ! post_type_supports( $post_type, 'presence' ) ) {
 				continue;

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -158,6 +158,24 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 	public function test_logged_out_user_cannot_access_room() {
 		$this->assertFalse( wp_can_access_presence_room( 'test/room', 0 ) );
 	}
+	/**
+	 * @covers ::wp_can_access_presence_room
+	 */
+	public function test_wp_can_access_presence_room_checks_post_type_capabilities() {
+		$author_1 = self::factory()->user->create( array( 'role' => 'author' ) );
+		$author_2 = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$post_id = self::factory()->post->create( array(
+			'post_author' => $author_1,
+			'post_status' => 'draft',
+		) );
+
+		$room = 'postType/post:' . $post_id;
+
+		$this->assertTrue( wp_can_access_presence_room( $room, $author_1 ) );
+		$this->assertFalse( wp_can_access_presence_room( $room, $author_2 ) );
+		$this->assertTrue( wp_can_access_presence_room( $room, self::$editor_id ) );
+	}
 
 	/**
 	 * @covers ::wp_delete_expired_presence_data

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -93,14 +93,17 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	 * @covers WP_REST_Presence_Controller::delete_item_permissions_check
 	 */
 	public function test_rest_delete_allows_own_lock_entries() {
+		$post_id = self::factory()->post->create();
+		$room    = 'postType/post:' . $post_id;
+
 		// Editor sets a lock entry.
-		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
+		wp_set_presence( $room, 'lock-' . self::$editor_id, array(), self::$editor_id );
 
 		// Same editor tries to delete it.
 		wp_set_current_user( self::$editor_id );
 
 		$request = new WP_REST_Request( 'DELETE', '/wp-presence/v1/presence' );
-		$request->set_param( 'room', 'postType/post:1' );
+		$request->set_param( 'room', $room );
 		$request->set_param( 'client_id', 'lock-' . self::$editor_id );
 
 		$controller = new WP_REST_Presence_Controller();
@@ -210,9 +213,12 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	 * @covers WP_REST_Presence_Controller::get_rooms
 	 */
 	public function test_get_rooms_returns_data() {
+		$post_id = self::factory()->post->create();
+		$room    = 'postType/post:' . $post_id;
+
 		wp_set_current_user( self::$editor_id );
 		wp_set_presence( 'admin/online', 'client-1', array(), self::$editor_id );
-		wp_set_presence( 'postType/post:1', 'client-2', array(), self::$editor_2_id );
+		wp_set_presence( $room, 'client-2', array(), self::$editor_2_id );
 
 		$request  = new WP_REST_Request( 'GET', '/wp-presence/v1/presence/rooms' );
 		$response = rest_get_server()->dispatch( $request );
@@ -374,5 +380,40 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$this->assertSame( 'rest_invalid_screen_key', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::get_rooms
+	 */
+	public function test_get_rooms_filters_unauthorized_rooms() {
+		// Create two author users.
+		$author_1 = self::factory()->user->create( array( 'role' => 'author' ) );
+		$author_2 = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		// Create a draft post owned by author 1.
+		$post_id = self::factory()->post->create( array(
+			'post_author' => $author_1,
+			'post_status' => 'draft',
+		) );
+
+		// Set presence for Author 1 in that post room.
+		$room = 'postType/post:' . $post_id;
+		wp_set_presence( $room, 'client-author1', array(), $author_1 );
+
+		// Also set presence in standard admin/online room for Author 2.
+		wp_set_presence( 'admin/online', 'client-author2', array(), $author_2 );
+
+		// Query /presence/rooms as Author 2.
+		wp_set_current_user( $author_2 );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-presence/v1/presence/rooms' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data     = $response->get_data();
+
+		// Author 2 should see 'admin/online' but NOT see the draft post room.
+		$this->assertCount( 1, $data );
+		$this->assertSame( 'admin/online', $data[0]['room'] );
 	}
 }


### PR DESCRIPTION
### Description

Currently, room authorization is not enforced per room in the REST API.
1. `wp_can_access_presence_room()` ignores the `$room` parameter completely and checks a flat `edit_posts` capability. On sites where post types register custom capabilities, any user with `edit_posts` can read or write presence for rooms they shouldn't access.
2. The `/presence/rooms` list endpoint returned all active rooms with occupant details without filtering by room access permissions, disclosing post IDs and active editors of draft/private posts.

This Pull Request resolves both issues by checking specific post edit capabilities for post type rooms and filtering active rooms based on user authorization.

To ensure performance scales with room count:
- Introduced a shared helper function `wp_presence_parse_room()` to DRY up room parsing across the codebase.
- Parsed the post IDs from the active rooms list in `get_rooms()` and primed the post caches with a single `_prime_post_caches()` call prior to filtering, preventing N+1 queries.
- Recomputed the paginated `$total` count from the filtered set to prevent pagination leakage.

Fixes 
- #128 

### How to Test / Verification

Run the test suite in `wp-env`:
```bash
npm run test
```
Verify that all tests pass successfully.

### Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.5 Flash
Used for: Centralizing room parsing logic into `wp_presence_parse_room()`, batch-priming post caches with `_prime_post_caches()` to avoid N+1 queries, filtering the REST `/rooms` endpoint, and writing unit tests to cover unauthorized rooms filtering.