### PR TITLE
feat: move inline heartbeat JS to a standalone enqueued script

### DIFF
--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -1,0 +1,105 @@
+(function ($) {
+	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+		return;
+	}
+
+	const config = window.wpPresenceConfig || {};
+	const entries = Array.isArray(config.entries) ? config.entries : [];
+	const frontContext = config.frontContext || null;
+	const editorPostId = parseInt(config.editorPostId, 10) || 0;
+	const restUrl = config.restUrl || '';
+	const nonce = config.nonce || '';
+
+	// Guards against duplicate leave() invocations.
+	let hasLeft = false;
+
+	// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
+	$(function () {
+		$(document).on('heartbeat-send', function (event, data) {
+			// Skip while the document is hidden (background tab, minimized
+			// window, app switched away) so the existing entries expire via
+			// the default TTL. One early-return suppresses both presence-ping
+			// and presence-editor-ping, since the consolidated handler emits
+			// both.
+			if (document.visibilityState === 'hidden') {
+				delete data['wp-refresh-post-lock'];
+				return;
+			}
+
+			const ping = { screen: window.pagenow || 'front' };
+			if (frontContext) {
+				if (frontContext.title) {
+					ping.title = frontContext.title;
+				}
+				if (frontContext.post_id) {
+					ping.post_id = frontContext.post_id;
+				}
+			}
+			data['presence-ping'] = ping;
+
+			if (editorPostId) {
+				data['presence-editor-ping'] = { post_id: editorPostId };
+			}
+
+			hasLeft = false;
+		});
+	});
+
+	function leave() {
+		if (hasLeft || !restUrl || !entries.length) {
+			return;
+		}
+		hasLeft = true;
+
+		// keepalive lets the DELETE outlive the unload; sendBeacon is POST-only.
+		if (typeof window.fetch !== 'function') {
+			return;
+		}
+
+		entries.forEach(function (entry) {
+			if (!entry || !entry.room || !entry.client_id) {
+				return;
+			}
+			const url = new URL(restUrl);
+			url.searchParams.set('room', entry.room);
+			url.searchParams.set('client_id', entry.client_id);
+			try {
+				window.fetch(url, {
+					method: 'DELETE',
+					credentials: 'same-origin',
+					keepalive: true,
+					headers: { 'X-WP-Nonce': nonce }
+				});
+			} catch {
+				// Best-effort: TTL cleanup will catch entries we couldn't remove.
+			}
+		});
+	}
+
+	// Re-establish presence on every page load so in-admin navigation doesn't
+	// leave a gap between the unload DELETE and the heartbeat's first tick.
+	function tickNow() {
+		if (typeof wp?.heartbeat?.connectNow === 'function') {
+			wp.heartbeat.connectNow();
+		}
+	}
+	$(tickNow);
+	// bfcache restore: DOMContentLoaded won't fire.
+	window.addEventListener('pageshow', function (event) {
+		if (event.persisted) {
+			tickNow();
+		}
+	});
+
+	// When the tab becomes visible again, re-establish presence so the user
+	// does not sit out the next heartbeat interval.
+	document.addEventListener('visibilitychange', function () {
+		if (document.visibilityState === 'visible') {
+			tickNow();
+		}
+	});
+
+	window.addEventListener('pagehide', function () {
+		leave();
+	});
+})(jQuery);

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -125,121 +125,18 @@ function wp_presence_enqueue_heartbeat_ping() {
 		'nonce'        => wp_create_nonce( 'wp_rest' ),
 	);
 
-	wp_add_inline_script(
-		'heartbeat',
-		sprintf( 'window.wpPresenceConfig = %s;', wp_json_encode( $config, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
-		'before'
+	wp_enqueue_script(
+		'wp-presence-ping',
+		WP_PRESENCE_PLUGIN_URL . 'assets/js/presence-ping.js',
+		array( 'jquery', 'heartbeat' ),
+		WP_PRESENCE_VERSION,
+		true
 	);
 
 	wp_add_inline_script(
-		'heartbeat',
-		<<<'JS'
-		(function ($) {
-			if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
-				return;
-			}
-
-			const config = window.wpPresenceConfig || {};
-			const entries = Array.isArray(config.entries) ? config.entries : [];
-			const frontContext = config.frontContext || null;
-			const editorPostId = parseInt(config.editorPostId, 10) || 0;
-			const restUrl = config.restUrl || '';
-			const nonce = config.nonce || '';
-
-			// Guards against duplicate leave() invocations.
-			let hasLeft = false;
-
-			// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
-			$(function () {
-				$(document).on('heartbeat-send', function (event, data) {
-					// Skip while the document is hidden (background tab, minimized
-					// window, app switched away) so the existing entries expire via
-					// the default TTL. One early-return suppresses both presence-ping
-					// and presence-editor-ping, since the consolidated handler emits
-					// both.
-					if (document.visibilityState === 'hidden') {
-						delete data['wp-refresh-post-lock'];
-						return;
-					}
-
-					const ping = { screen: window.pagenow || 'front' };
-					if (frontContext) {
-						if (frontContext.title) {
-							ping.title = frontContext.title;
-						}
-						if (frontContext.post_id) {
-							ping.post_id = frontContext.post_id;
-						}
-					}
-					data['presence-ping'] = ping;
-
-					if (editorPostId) {
-						data['presence-editor-ping'] = { post_id: editorPostId };
-					}
-
-					hasLeft = false;
-				});
-			});
-
-			function leave() {
-				if (hasLeft || !restUrl || !entries.length) {
-					return;
-				}
-				hasLeft = true;
-
-				// keepalive lets the DELETE outlive the unload; sendBeacon is POST-only.
-				if (typeof window.fetch !== 'function') {
-					return;
-				}
-
-				entries.forEach(function (entry) {
-					if (!entry || !entry.room || !entry.client_id) {
-						return;
-					}
-					const url = new URL(restUrl);
-					url.searchParams.set('room', entry.room);
-					url.searchParams.set('client_id', entry.client_id);
-					try {
-						window.fetch(url, {
-							method: 'DELETE',
-							credentials: 'same-origin',
-							keepalive: true,
-							headers: { 'X-WP-Nonce': nonce }
-						});
-					} catch {
-						// Best-effort: TTL cleanup will catch entries we couldn't remove.
-					}
-				});
-			}
-
-			// Re-establish presence on every page load so in-admin navigation doesn't
-			// leave a gap between the unload DELETE and the heartbeat's first tick.
-			function tickNow() {
-				if (typeof wp?.heartbeat?.connectNow === 'function') {
-					wp.heartbeat.connectNow();
-				}
-			}
-			$(tickNow);
-			// bfcache restore: DOMContentLoaded won't fire.
-			window.addEventListener('pageshow', function (event) {
-				if (event.persisted) {
-					tickNow();
-				}
-			});
-
-			// When the tab becomes visible again, re-establish presence so the user
-			// does not sit out the next heartbeat interval.
-			document.addEventListener('visibilitychange', function () {
-				if (document.visibilityState === 'visible') {
-					tickNow();
-				}
-			});
-
-			window.addEventListener('pagehide', function () {
-				leave();
-			});
-		})(jQuery);
-		JS
+		'wp-presence-ping',
+		sprintf( 'window.wpPresenceConfig = %s;', wp_json_encode( $config, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ),
+		'before'
 	);
 }
 

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -145,4 +145,34 @@ class WP_Test_Presence_Heartbeat extends WP_UnitTestCase {
 			has_filter( 'heartbeat_received', 'wp_presence_admin_heartbeat_received' )
 		);
 	}
+
+	/**
+	 * @covers ::wp_presence_enqueue_heartbeat_ping
+	 */
+	public function test_wp_presence_enqueue_heartbeat_ping() {
+		wp_set_current_user( self::$editor_id );
+
+		// Reset enqueued scripts.
+		$wp_scripts = wp_scripts();
+		$wp_scripts->queue = array();
+		$wp_scripts->done  = array();
+
+		wp_presence_enqueue_heartbeat_ping();
+
+		$this->assertTrue( wp_script_is( 'wp-presence-ping', 'enqueued' ) );
+
+		$wp_scripts = wp_scripts();
+		$this->assertArrayHasKey( 'wp-presence-ping', $wp_scripts->registered );
+		$extra = $wp_scripts->registered['wp-presence-ping']->extra;
+		$this->assertArrayHasKey( 'before', $extra );
+
+		$found_config = false;
+		foreach ( $extra['before'] as $script ) {
+			if ( $script && strpos( $script, 'window.wpPresenceConfig =' ) !== false ) {
+				$found_config = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_config );
+	}
 }


### PR DESCRIPTION
### Description

Currently, the script handling heartbeat pings is outputted directly as a multi-line HEREDOC string inside `wp_presence_enqueue_heartbeat_ping()` via `wp_add_inline_script()`. This brings a few challenges:
1. It shows up as an anonymous inline script in browser DevTools, making setting breakpoints or debugging in the Sources panel extremely difficult.
2. The script cannot be cached independently by browsers.
3. Code linters and formatters cannot easily lint or clean the script.

This PR addresses this by:
- Moving the core JavaScript out of `includes/heartbeat.php` to a new standalone file `assets/js/presence-ping.js`.
- Registering and enqueuing the script using `wp_enqueue_script()` with `jquery` and `heartbeat` as dependencies.
- Passing the dynamic PHP-side configuration object `wpPresenceConfig` via `wp_add_inline_script()` attached to the script as a `before` dependency.

Fixes 
- #135 

### Proposed Changes

* `assets/js/presence-ping.js`
  * Created a new JS file containing the heartbeat presence check-in script logic.
* `includes/heartbeat.php`
  * Replaced the multi-line HEREDOC `wp_add_inline_script()` block with `wp_enqueue_script()` pointing to the new standalone assets file.
  * Attached the configuration `wpPresenceConfig` to the script handle instead.
* `tests/test-heartbeat.php`
  * Added `test_wp_presence_enqueue_heartbeat_ping()` unit test to verify that the script is enqueued and the inline configuration data is attached properly.

### How to Test / Verification

Run the test suite in `wp-env`: `npm run test`
Verify that all unit tests pass successfully.

### Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.5 Flash
Used for: Extracting inline HEREDOC JavaScript into `assets/js/presence-ping.js`, and writing unit tests to cover script enqueuing.
