### PR TITLE
refactor: replace hardcoded admin/online room string with helper

### DIFF
--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -19,7 +19,7 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 		return;
 	}
 
-	$entries     = wp_get_presence( 'admin/online' );
+	$entries     = wp_get_presence( wp_presence_admin_room() );
 	$current_uid = get_current_user_id();
 
 	// Only show the admin bar node when other users are online.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2,13 +2,14 @@
 /**
  * Presence API functions.
  *
- * Public API (6 functions):
+ * Public API (7 functions):
  *   wp_get_presence()
  *   wp_set_presence()
  *   wp_remove_presence()
  *   wp_remove_user_presence()
  *   wp_can_access_presence_room()
  *   wp_presence_post_room()
+ *   wp_presence_admin_room()
  *
  * @package Presence_API
  */
@@ -195,6 +196,15 @@ function wp_presence_post_room( $post ) {
 	}
 
 	return 'postType/' . $post->post_type . ':' . $post->ID;
+}
+
+/**
+ * Returns the presence room identifier for the admin "who's online" list.
+ *
+ * @return string The room identifier.
+ */
+function wp_presence_admin_room() {
+	return 'admin/online';
 }
 
 /*

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -29,7 +29,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 	// Every page where the ping is enqueued occupies the admin/online room.
 	$entries = array(
 		array(
-			'room'      => 'admin/online',
+			'room'      => wp_presence_admin_room(),
 			'client_id' => 'user-' . $user_id,
 		),
 	);
@@ -100,7 +100,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 			$admin_state['post_id'] = $front_context['post_id'];
 		}
 	}
-	wp_set_presence( 'admin/online', 'user-' . $user_id, $admin_state, $user_id );
+	wp_set_presence( wp_presence_admin_room(), 'user-' . $user_id, $admin_state, $user_id );
 
 	if ( $editor_post_id ) {
 		$editor_room = wp_presence_post_room( $editor_post_id );
@@ -307,7 +307,7 @@ function wp_presence_admin_heartbeat_received( $response, $data, $screen_id ) { 
 		}
 	}
 
-	wp_set_presence( 'admin/online', 'user-' . $user_id, $state, $user_id );
+	wp_set_presence( wp_presence_admin_room(), 'user-' . $user_id, $state, $user_id );
 
 	return $response;
 }

--- a/includes/lifecycle.php
+++ b/includes/lifecycle.php
@@ -21,7 +21,7 @@ function wp_presence_on_login( $user_login, $user ) {
 	}
 
 	wp_set_presence(
-		'admin/online',
+		wp_presence_admin_room(),
 		'user-' . $user->ID,
 		array(
 			'screen' => 'login',

--- a/includes/user-list.php
+++ b/includes/user-list.php
@@ -23,7 +23,7 @@ function wp_presence_users_views( $views ) {
 		return $views;
 	}
 
-	$entries         = wp_get_presence( 'admin/online' );
+	$entries         = wp_get_presence( wp_presence_admin_room() );
 	$online_ids      = array_map( 'intval', array_unique( wp_list_pluck( $entries, 'user_id' ) ) );
 	$current_user_id = get_current_user_id();
 
@@ -71,7 +71,7 @@ function wp_presence_filter_online_users( $query ) {
 		return;
 	}
 
-	$entries         = wp_get_presence( 'admin/online' );
+	$entries         = wp_get_presence( wp_presence_admin_room() );
 	$online_ids      = array_map( 'intval', array_unique( wp_list_pluck( $entries, 'user_id' ) ) );
 	$current_user_id = get_current_user_id();
 

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -15,13 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WP_Presence_Widget_Whos_Online {
 
 	/**
-	 * The presence room used by this widget.
-	 *
-	 * @var string
-	 */
-	const ROOM = 'admin/online';
-
-	/**
 	 * Maximum number of users shown as full rows before collapsing.
 	 *
 	 * @var int
@@ -572,7 +565,7 @@ JS,
 	 * Renders the dashboard widget.
 	 */
 	public static function render() {
-		$entries     = wp_get_presence( self::ROOM );
+		$entries     = wp_get_presence( wp_presence_admin_room() );
 		$current_uid = get_current_user_id();
 		$entries     = array_values(
 			array_filter(
@@ -701,7 +694,7 @@ JS,
 			return $response;
 		}
 
-		$entries = wp_get_presence( self::ROOM );
+		$entries = wp_get_presence( wp_presence_admin_room() );
 		$online  = array();
 
 		cache_users( wp_list_pluck( $entries, 'user_id' ) );


### PR DESCRIPTION
### Description:
Adds `wp_presence_admin_room()`, mirroring `wp_presence_post_room()`, and uses it in place of the 'admin/online' literal across `heartbeat.php`, `user-list.php`, `admin-bar.php`, `lifecycle.php`, and the Who's Online widget (which also drops its own ROOM constant, since a class constant can't hold a function call's return value).

Related: 
- #154

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation across all six files; reviewed and verified by me.