### PR TITLE
build: bump php_codesniffer to 3.13.6 for CVE-2026-67434

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": ">=7.4"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "3.13.5",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"wp-coding-standards/wpcs": "~3.4.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"phpstan/phpstan": "2.2.7",


### PR DESCRIPTION
CVE-2026-67434 was published against php_codesniffer last night, and since `lock: false` makes every job re-resolve from scratch, Composer's advisory blocking is failing `composer install` on main and on every open PR.

3.13.6 is the first unaffected release in the 3.x line. Local phpcs run is clean against it.

Worth revisiting the reasoning in #30, which was closed on the basis that Dependabot would cover advisories. It does eventually, but it has not opened a PR for this one 15 hours in, and the blocking failure is immediate.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with diagnosis and implementation

