### PR TITLE
ci: restore the deps changelog section so Dependabot bumps appear

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
 		{ "type": "fix",      "section": "Bug Fixes" },
 		{ "type": "perf",     "section": "Performance Improvements" },
 		{ "type": "revert",   "section": "Reverts" },
+		{ "type": "deps",     "section": "Dependencies" },
 		{ "type": "build",    "section": "Dependencies" },
 		{ "type": "docs",     "section": "Documentation",          "hidden": true },
 		{ "type": "style",    "section": "Styles",                 "hidden": true },


### PR DESCRIPTION
Dependabot bumps stopped appearing in the changelog at 0.1.6, when f145815 introduced an explicit `changelog-sections` array that replaced release-please's defaults and dropped the `deps` entry those defaults included.

Related: #179

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with diagnosis and implementation.