### PR TITLE
build: pin the Dependabot commit prefix so bumps reach the changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@
 # flow rely on the corresponding toggles under Settings → Code security
 # and analysis.
 #
+# Every ecosystem pins commit-message. Dependabot otherwise infers the
+# prefix from recent history, and it drifted from `build` to `chore`
+# after 0.1.5. `chore` is hidden in release-please-config.json, so the
+# bumps silently dropped out of the changelog.
+#
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
@@ -14,16 +19,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
+      prefix-development: "build"
+      include: "scope"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
+      prefix-development: "build"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
+      include: "scope"
     # codeql-action steps must share a version, so bump them together.
     groups:
       codeql-action:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
 		{ "type": "fix",      "section": "Bug Fixes" },
 		{ "type": "perf",     "section": "Performance Improvements" },
 		{ "type": "revert",   "section": "Reverts" },
-		{ "type": "deps",     "section": "Dependencies" },
 		{ "type": "build",    "section": "Dependencies" },
 		{ "type": "docs",     "section": "Documentation",          "hidden": true },
 		{ "type": "style",    "section": "Styles",                 "hidden": true },


### PR DESCRIPTION
Dependabot infers its commit prefix from recent history rather than using a fixed one, and it drifted from `build` to `chore` after 0.1.5, which is why dependency bumps stopped appearing under Dependencies in the changelog. This also reverts the `deps` section added in #188, which turned out to be inert since release-please does not map `chore(deps)` onto a `deps` type.

Related: #179

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.6
Used for: Assisting with diagnosis and implementation.