### PR TITLE
ci: include blueprint in the sync-versions commit so seeder URLs stay current

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,7 +65,7 @@ jobs:
           if ! git diff --quiet; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add presence-api.php readme.txt CHANGELOG.md
+            git add presence-api.php readme.txt CHANGELOG.md .wordpress-org/blueprints/blueprint.json
             git commit -m "chore: sync versions and remove duplicate changelog entries"
             gh auth setup-git
             git push

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -25,7 +25,7 @@
 			"path": "/wordpress/wp-content/plugins/presence-api/demo-seeder.php",
 			"data": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/WordPress/presence-api/v0.1.11/tests/e2e/demo-seeder.php"
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/v0.1.12/tests/e2e/demo-seeder.php"
 			}
 		},
 		{
@@ -33,7 +33,7 @@
 			"path": "/wordpress/wp-content/mu-plugins/screen-stale-demo-helper.php",
 			"data": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/WordPress/presence-api/v0.1.11/tests/e2e/screen-stale-demo-helper.php"
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/v0.1.12/tests/e2e/screen-stale-demo-helper.php"
 			}
 		},
 		{


### PR DESCRIPTION
The sync-versions job in release-please.yml updated presence-api.php, readme.txt, and CHANGELOG.md but left out .wordpress-org/blueprints/blueprint.json, so blueprint seeder URLs were never committed back to the release branch and stayed one version behind after every release. This also bumps the seeder URLs manually for 0.1.12, since sync-versions was skipped on that release run.

The preview-pr-78 Playground error in the screenshot is unrelated — that release was correctly cleaned up when PR #78 merged; the error is a stale bookmark.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.6
Used for: Assisting with diagnosis and implementation.