### PR TITLE
fix: replace GROUP_CONCAT session mutations with PHP aggregation

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -462,7 +462,7 @@ function wp_get_active_rooms( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 
 		++$rooms_by_name[ $row->room ]['entry_count'];
 		$rooms_by_name[ $row->room ]['user_ids'][ $user_id ] = true;
-		$all_user_ids[ $user_id ] = true;
+		$all_user_ids[ $user_id ]                            = true;
 	}
 
 	// Prime the user object cache in a single query.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -307,22 +307,13 @@ function wp_get_presence_summary( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 	$timeout = wp_presence_get_timeout( $timeout );
 	$cutoff  = gmdate( 'Y-m-d H:i:s', time() - $timeout );
 
-	// Increase GROUP_CONCAT limit to prevent silent truncation with many users per room.
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$wpdb->query( 'SET SESSION group_concat_max_len = 1000000' );
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$rows = $wpdb->get_results(
+	$rows    = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT room, COUNT(*) AS entries, COUNT(DISTINCT user_id) AS users, GROUP_CONCAT(DISTINCT user_id) AS user_ids FROM {$wpdb->presence} WHERE date_gmt > %s GROUP BY room",
+			"SELECT room, user_id FROM {$wpdb->presence} WHERE date_gmt > %s ORDER BY room ASC",
 			$cutoff
 		)
 	);
-
-	// Always reset GROUP_CONCAT limit regardless of query success.
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$wpdb->query( 'SET SESSION group_concat_max_len = DEFAULT' );
-
 	$summary = array(
 		'total_entries' => 0,
 		'total_users'   => 0,
@@ -349,22 +340,20 @@ function wp_get_presence_summary( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 			$prefix_user_ids[ $prefix ]      = array();
 		}
 
-		$summary['by_prefix'][ $prefix ]['entries'] += (int) $row->entries;
-		$summary['total_entries']                   += (int) $row->entries;
+		$user_id = (int) $row->user_id;
 
-		if ( ! empty( $row->user_ids ) ) {
-			$room_user_ids              = explode( ',', $row->user_ids );
-			$all_user_ids               = array_merge( $all_user_ids, $room_user_ids );
-			$prefix_user_ids[ $prefix ] = array_merge( $prefix_user_ids[ $prefix ], $room_user_ids );
-		}
+		++$summary['by_prefix'][ $prefix ]['entries'];
+		++$summary['total_entries'];
+
+		$all_user_ids[ $user_id ]               = true;
+		$prefix_user_ids[ $prefix ][ $user_id ] = true;
 	}
 
 	foreach ( $prefix_user_ids as $prefix => $user_ids ) {
-		$summary['by_prefix'][ $prefix ]['users'] = count( array_unique( $user_ids ) );
+		$summary['by_prefix'][ $prefix ]['users'] = count( $user_ids );
 	}
 
-	$summary['total_users'] = count( array_unique( $all_user_ids ) );
-
+	$summary['total_users'] = count( $all_user_ids );
 	return $summary;
 }
 
@@ -443,43 +432,58 @@ function wp_get_active_rooms( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 	$timeout = wp_presence_get_timeout( $timeout );
 	$cutoff  = gmdate( 'Y-m-d H:i:s', time() - $timeout );
 
-	// Increase GROUP_CONCAT limit to prevent silent truncation with many users per room.
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$wpdb->query( 'SET SESSION group_concat_max_len = 1000000' );
-
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$rows = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT room, GROUP_CONCAT(DISTINCT user_id ORDER BY user_id ASC) AS user_ids
+			"SELECT room, user_id
 			FROM {$wpdb->presence}
 			WHERE date_gmt > %s
-			GROUP BY room
-			ORDER BY COUNT(*) DESC",
+			ORDER BY room ASC, user_id ASC",
 			$cutoff
 		)
 	);
-
-	// Always reset GROUP_CONCAT limit regardless of query success.
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$wpdb->query( 'SET SESSION group_concat_max_len = DEFAULT' );
-
 	if ( ! $rows ) {
 		return array();
 	}
 
-	// Prime the user object cache in a single query.
-	$all_user_ids = array();
-	foreach ( $rows as $row ) {
-		$all_user_ids = array_merge( $all_user_ids, array_map( 'intval', explode( ',', $row->user_ids ) ) );
-	}
-	cache_users( array_unique( $all_user_ids ) );
+	$rooms_by_name = array();
+	$all_user_ids  = array();
 
+	foreach ( $rows as $row ) {
+		if ( ! isset( $rooms_by_name[ $row->room ] ) ) {
+			$rooms_by_name[ $row->room ] = array(
+				'room'        => $row->room,
+				'entry_count' => 0,
+				'user_ids'    => array(),
+			);
+		}
+
+		$user_id = (int) $row->user_id;
+
+			++$rooms_by_name[ $row->room ]['entry_count'];
+		$rooms_by_name[ $row->room ]['user_ids'][ $user_id ] = true;
+			$all_user_ids[ $user_id ]                        = true;
+	}
+
+	// Prime the user object cache in a single query.
+	cache_users( array_keys( $all_user_ids ) );
+
+	uasort(
+		$rooms_by_name,
+		function ( $room_a, $room_b ) {
+
+			if ( $room_a['entry_count'] === $room_b['entry_count'] ) {
+				return strcmp( $room_a['room'], $room_b['room'] );
+			}
+
+			return $room_b['entry_count'] <=> $room_a['entry_count'];
+		}
+	);
 	$rooms = array();
 
-	foreach ( $rows as $row ) {
-		$user_ids = array_map( 'intval', explode( ',', $row->user_ids ) );
+	foreach ( $rooms_by_name as $room ) {
+		$user_ids = array_keys( $room['user_ids'] );
 		$users    = array();
-
 		foreach ( $user_ids as $uid ) {
 			$user = get_userdata( $uid );
 
@@ -495,7 +499,7 @@ function wp_get_active_rooms( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 		}
 
 		$rooms[] = array(
-			'room'       => $row->room,
+			'room'       => $room['room'],
 			'user_count' => count( $users ),
 			'users'      => $users,
 		);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -460,9 +460,9 @@ function wp_get_active_rooms( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 
 		$user_id = (int) $row->user_id;
 
-			++$rooms_by_name[ $row->room ]['entry_count'];
+		++$rooms_by_name[ $row->room ]['entry_count'];
 		$rooms_by_name[ $row->room ]['user_ids'][ $user_id ] = true;
-			$all_user_ids[ $user_id ]                        = true;
+		$all_user_ids[ $user_id ] = true;
 	}
 
 	// Prime the user object cache in a single query.

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -339,6 +339,25 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_get_active_rooms
 	 */
+	public function test_get_active_rooms_orders_by_entry_count_and_deduplicates_users() {
+		$editor2_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'client-1', array(), self::$editor_id );
+		wp_set_presence( 'postType/post:1', 'client-2', array(), self::$editor_id );
+		wp_set_presence( 'postType/post:1', 'client-3', array(), self::$editor_id );
+		wp_set_presence( 'postType/post:1', 'client-4', array(), $editor2_id );
+
+		$rooms = wp_get_active_rooms();
+
+		$this->assertCount( 2, $rooms );
+		$this->assertSame( 'postType/post:1', $rooms[0]['room'] );
+		$this->assertSame( 2, $rooms[0]['user_count'] );
+		$this->assertSame( 'admin/online', $rooms[1]['room'] );
+	}
+
+	/**
+	 * @covers ::wp_get_active_rooms
+	 */
 	public function test_get_active_rooms_empty() {
 		$rooms = wp_get_active_rooms();
 


### PR DESCRIPTION
## Summary

- replace the `GROUP_CONCAT()` queries and `SET SESSION group_concat_max_len` mutations with raw `room, user_id` queries
- aggregate entry and distinct-user counts in PHP for presence summaries and active rooms
- preserve active-room ordering by entry count with a deterministic room-name tie-breaker
- add regression coverage for room ordering and user deduplication

## Why

Managed and proxied database environments do not reliably preserve session variables and may restrict `SET SESSION` privileges. Aggregating the raw rows in PHP removes that dependency while also avoiding silent `GROUP_CONCAT()` truncation.

Fixes #133.

## Validation

- `vendor/bin/phpcs includes/functions.php tests/test-functions.php`
- `composer phpstan`
- `php -l includes/functions.php`
- `php -l tests/test-functions.php`

The full PHPUnit suite could not be started locally because Docker had exhausted its predefined network address pools. The repository CI can provide the complete integration test run.
