### PR TITLE
docs: credit wp24horas in the readme contributors list

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Presence API ===
-Contributors: joefusco, intenzi, ashishjii, iamchitti, iqbal1hossain
+Contributors: joefusco, intenzi, ashishjii, iamchitti, iqbal1hossain, wp24horas
 Tags: presence, awareness, heartbeat, real-time
 Requires at least: 7.0
 Tested up to: 7.0


### PR DESCRIPTION
wp24horas contributed to #169 and was missing from the readme contributors list that renders on the WordPress.org plugin page.