### PR TITLE
ci: ignore phpcs advisory in composer.json, revert --no-audit flag

### DIFF
--- a/.github/workflows/multisite.yml
+++ b/.github/workflows/multisite.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Authenticate composer to GitHub
         run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
       - name: Install Composer dependencies
-        run: composer install --no-interaction --no-audit
+        run: composer install --no-interaction
       - run: npx wp-env start
       - run: npx wp-env run tests-cli -- wp core multisite-convert --title="Test Network"
       - run: npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           path: ~/.composer/cache
           key: composer-${{ hashFiles('composer.json') }}
-      - run: composer install --no-interaction --no-audit
+      - run: composer install --no-interaction
       - run: ./vendor/bin/phpcs --standard=phpcs.xml.dist

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           path: ~/.composer/cache
           key: composer-${{ hashFiles('composer.json') }}
-      - run: composer install --no-interaction --no-audit
+      - run: composer install --no-interaction
       # `--error-format=github` renders findings as inline PR annotations
       # on the diff, the same shape PHPCS uses via its own GitHub formatter.
       - run: ./vendor/bin/phpstan analyse --no-progress --error-format=github

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -45,7 +45,7 @@ jobs:
 
       # `--no-scripts` prevents a hostile fork PR from running arbitrary
       # PHP via composer.json's `scripts` block during install.
-      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-scripts --no-audit
+      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-scripts
 
       - name: Build presence-api.zip
         run: |

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -19,7 +19,7 @@ jobs:
           php-version: '8.3'
           tools: composer
 
-      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-scripts --no-audit
+      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-scripts
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           php-version: '8.3'
           tools: composer
-      - run: composer install --no-dev --no-interaction --optimize-autoloader --no-audit
+      - run: composer install --no-dev --no-interaction --optimize-autoloader
       - name: Build plugin zip
         run: |
           mkdir -p build/presence-api

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,13 @@
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},
-		"lock": false
+		"lock": false,
+		"audit": {
+			"ignore": {
+				"PKSA-rdkp-vv9z-mjkg": "XSS in PHPCS HTML report output; not triggered by CI linting use",
+				"PKSA-6vdd-n4sx-knhy": "XSS in PHPCS HTML report output; not triggered by CI linting use"
+			}
+		}
 	},
 	"scripts": {
 		"phpcs": "@php ./vendor/bin/phpcs",


### PR DESCRIPTION
--no-audit does not exist on the Composer version the pinned setup-php SHA installs, causing all composer install steps to fail. Moves the fix into composer.json where the audit.ignore config suppresses the advisory regardless of Composer version.

## AI Tools

Model(s): Claude Sonnet 4.6
Used for: Drafting and implementation