### PR TITLE
ci: remove --no-audit from phpunit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Authenticate composer to GitHub
         run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
       - name: Install Composer dependencies
-        run: composer install --no-interaction --no-audit
+        run: composer install --no-interaction
       - run: npx wp-env start ${{ matrix.coverage && '--xdebug=coverage' || '' }}
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
`phpunit.yml` was missed in #199 and still carries `--no-audit`, which does not exist on the Composer version the pinned `setup-php` SHA installs. The advisory is already suppressed via `audit.ignore` in `composer.json`.

## AI Tools

Model(s): Claude Sonnet 4.6
Used for: Drafting and implementation