### PR TITLE
docs: prompt for a parseable closing keyword in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,16 @@ If this is your first time contributing, the following may be helpful:
 
 <!-- Insert a description of your changes here -->
 
-Related: <!-- link a GitHub issue here, e.g. #12 -->
+Fixes #
+
+<!--
+Put the issue number directly after the keyword, e.g. "Fixes #12", so the issue
+closes when this Pull Request merges. GitHub only parses the keyword when the
+reference follows it on the same line, so "Resolves Issue: #12" and a "Fixes"
+line followed by a bulleted "- #12" both leave the issue open.
+
+If this Pull Request should not close an issue, use "Related: #12" instead.
+-->
 
 ## Use of AI Tools
 


### PR DESCRIPTION
### Description:
Three merged pull requests left their issues open because the template prompts with `Related:`, which is not a closing keyword, so contributors substituted forms GitHub does not parse.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting and implementation