### PR TITLE
chore: track the latest WordPress release in blueprints and tests

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"core": "WordPress/WordPress",
+	"core": null,
 	"plugins": [ ".", "https://downloads.wordpress.org/plugin/classic-editor.zip" ],
 	"config": {
 		"WP_DEBUG": true,

--- a/blueprint-40.json
+++ b/blueprint-40.json
@@ -1,6 +1,6 @@
 {
 	"preferredVersions": {
-		"wp": "trunk"
+		"wp": "latest"
 	},
 	"landingPage": "/wp-admin/",
 	"login": true,

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,6 +1,6 @@
 {
 	"preferredVersions": {
-		"wp": "trunk"
+		"wp": "latest"
 	},
 	"landingPage": "/wp-admin/",
 	"login": true,


### PR DESCRIPTION
### Description:
The blueprints and the test environment were still aimed at the development branch from before 7.0 shipped, so neither matched the `Requires at least: 7.0` floor the plugin actually supports.

Verified locally against the resolved version, 7.0.3: PHPUnit `OK (115 tests, 240 assertions)` and Playwright `13 passed`.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting and implementation