### PR TITLE
test: add coverage for cron scheduling

### DIFF
--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -77,7 +77,7 @@ class WP_Test_Presence_Cron extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The guard on line 16 of includes/cron.php must prevent a second event.
+	 * The guard in wp_presence_schedule_cleanup() must prevent a second event.
 	 *
 	 * @covers ::wp_presence_schedule_cleanup
 	 */

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -74,6 +74,7 @@ class WP_Test_Presence_Cron extends WP_UnitTestCase {
 		wp_presence_schedule_cleanup();
 
 		$this->assertNotFalse( wp_next_scheduled( self::HOOK ), 'The cleanup event should be scheduled.' );
+		$this->assertSame( 'wp_presence_every_minute', wp_get_schedule( self::HOOK ), 'Cleanup should run on the one-minute interval.' );
 	}
 
 	/**

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for cron scheduling (includes/cron.php).
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group cron
+ */
+class WP_Test_Presence_Cron extends WP_UnitTestCase {
+
+	const HOOK = 'wp_delete_expired_presence_data';
+
+	public function set_up() {
+		parent::set_up();
+		// Bootstrap and other tests may have scheduled the cleanup event; start clean.
+		wp_clear_scheduled_hook( self::HOOK );
+	}
+
+	public function tear_down() {
+		wp_clear_scheduled_hook( self::HOOK );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::wp_presence_cron_schedules
+	 */
+	public function test_cron_schedules_adds_every_minute_interval() {
+		$schedules = wp_presence_cron_schedules( array() );
+
+		$this->assertArrayHasKey( 'wp_presence_every_minute', $schedules );
+		$this->assertSame( 60, $schedules['wp_presence_every_minute']['interval'] );
+		$this->assertArrayHasKey( 'display', $schedules['wp_presence_every_minute'] );
+		$this->assertNotEmpty( $schedules['wp_presence_every_minute']['display'], 'The interval should have a display string.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_cron_schedules
+	 */
+	public function test_cron_schedules_preserves_existing_schedules() {
+		$existing = array(
+			'hourly' => array(
+				'interval' => HOUR_IN_SECONDS,
+				'display'  => 'Once Hourly',
+			),
+		);
+
+		$schedules = wp_presence_cron_schedules( $existing );
+
+		$this->assertArrayHasKey( 'hourly', $schedules, 'Existing schedules should be preserved.' );
+		$this->assertSame( HOUR_IN_SECONDS, $schedules['hourly']['interval'] );
+		$this->assertArrayHasKey( 'wp_presence_every_minute', $schedules );
+	}
+
+	/**
+	 * The plugin registers wp_presence_cron_schedules() on the cron_schedules
+	 * filter at load, so the interval is visible through the public API.
+	 *
+	 * @covers ::wp_presence_cron_schedules
+	 */
+	public function test_interval_is_registered_via_filter() {
+		$schedules = wp_get_schedules();
+
+		$this->assertArrayHasKey( 'wp_presence_every_minute', $schedules, 'The filter should register the interval.' );
+		$this->assertSame( 60, $schedules['wp_presence_every_minute']['interval'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_schedule_cleanup
+	 */
+	public function test_schedule_cleanup_schedules_the_event() {
+		$this->assertFalse( wp_next_scheduled( self::HOOK ), 'No event should be scheduled to begin with.' );
+
+		wp_presence_schedule_cleanup();
+
+		$this->assertNotFalse( wp_next_scheduled( self::HOOK ), 'The cleanup event should be scheduled.' );
+	}
+
+	/**
+	 * The guard on line 16 of includes/cron.php must prevent a second event.
+	 *
+	 * @covers ::wp_presence_schedule_cleanup
+	 */
+	public function test_schedule_cleanup_does_not_double_schedule() {
+		wp_presence_schedule_cleanup();
+		$first = wp_next_scheduled( self::HOOK );
+
+		wp_presence_schedule_cleanup();
+		$second = wp_next_scheduled( self::HOOK );
+
+		$this->assertSame( $first, $second, 'Scheduling twice should not move or duplicate the event.' );
+		$this->assertSame( 1, $this->count_scheduled_events( self::HOOK ), 'Exactly one cleanup event should be scheduled.' );
+	}
+
+	/**
+	 * Counts how many cron events are registered for a hook across all timestamps.
+	 *
+	 * @param string $hook The hook name.
+	 * @return int Number of scheduled events for the hook.
+	 */
+	private function count_scheduled_events( $hook ) {
+		$crons = _get_cron_array();
+		if ( ! is_array( $crons ) ) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ( $crons as $events ) {
+			if ( isset( $events[ $hook ] ) ) {
+				$count += count( $events[ $hook ] );
+			}
+		}
+		return $count;
+	}
+}


### PR DESCRIPTION
Adds `tests/test-cron.php` covering `includes/cron.php`, following the suggested direction in #220.

### Covers
- `wp_presence_cron_schedules()` registers `wp_presence_every_minute` (60s interval + non-empty display) and preserves the schedules already in the array.
- The interval is visible through `wp_get_schedules()` — the filter is registered at load.
- `wp_presence_schedule_cleanup()` schedules `wp_delete_expired_presence_data` when nothing is scheduled.
- Calling it twice does not double-schedule (the guard on line 16).

Tests are isolated via `wp_clear_scheduled_hook()` in `set_up()`/`tear_down()`, since bootstrap may already have scheduled the event.

Fixes #220

### Testing
Tests only — no production code changed. I don't have a local `wp-env` PHP/MySQL environment, so I couldn't run PHPUnit/PHPCS locally; CI is the authoritative check.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Writing the test file following the suggested direction in #220. I have reviewed it and take responsibility for it.
