### PR TITLE
fix: bound presence keys to the column width and validate REST args

### DIFF
--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -63,6 +63,9 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 						'room'     => array(
 							'required'          => true,
 							'type'              => 'string',
+							'minLength'         => 1,
+							'maxLength'         => WP_PRESENCE_MAX_KEY_LENGTH,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'per_page' => array(
@@ -70,12 +73,14 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 							'default'           => 100,
 							'minimum'           => 1,
 							'maximum'           => 100,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
 						),
 						'page'     => array(
 							'type'              => 'integer',
 							'default'           => 1,
 							'minimum'           => 1,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
 						),
 					),
@@ -88,11 +93,17 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 						'room'      => array(
 							'required'          => true,
 							'type'              => 'string',
+							'minLength'         => 1,
+							'maxLength'         => WP_PRESENCE_MAX_KEY_LENGTH,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'client_id' => array(
 							'required'          => true,
 							'type'              => 'string',
+							'minLength'         => 1,
+							'maxLength'         => WP_PRESENCE_MAX_KEY_LENGTH,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'data'      => array(
@@ -111,11 +122,17 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 						'room'      => array(
 							'required'          => true,
 							'type'              => 'string',
+							'minLength'         => 1,
+							'maxLength'         => WP_PRESENCE_MAX_KEY_LENGTH,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'client_id' => array(
 							'required'          => true,
 							'type'              => 'string',
+							'minLength'         => 1,
+							'maxLength'         => WP_PRESENCE_MAX_KEY_LENGTH,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
@@ -138,12 +155,14 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 							'default'           => 50,
 							'minimum'           => 1,
 							'maximum'           => 100,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
 						),
 						'page'     => array(
 							'type'              => 'integer',
 							'default'           => 1,
 							'minimum'           => 1,
+							'validate_callback' => 'rest_validate_request_arg',
 							'sanitize_callback' => 'absint',
 						),
 					),
@@ -163,8 +182,16 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 						'screen_key' => array(
 							'required'          => true,
 							'type'              => 'string',
+							'maxLength'         => WP_PRESENCE_SCREEN_KEY_LIMIT,
 							'sanitize_callback' => 'sanitize_text_field',
-							'validate_callback' => static function ( $value ) {
+							// A custom validate_callback replaces the default one, so run
+							// the schema check first or maxLength above is never applied.
+							'validate_callback' => static function ( $value, $request, $param ) {
+								$valid = rest_validate_request_arg( $value, $request, $param );
+								if ( is_wp_error( $valid ) ) {
+									return $valid;
+								}
+
 								return (bool) preg_match( '#^[a-z0-9/_-]+$#', $value );
 							},
 						),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -461,7 +461,7 @@ function wp_maybe_create_presence_table() {
 	global $wpdb;
 
 	$charset_collate  = $wpdb->get_charset_collate();
-	$max_index_length = 191;
+	$max_index_length = WP_PRESENCE_MAX_KEY_LENGTH;
 
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 

--- a/presence-api.php
+++ b/presence-api.php
@@ -49,6 +49,12 @@ define( 'WP_PRESENCE_VERSION', '0.1.16' );
 define( 'WP_PRESENCE_DB_VERSION', 2 );
 define( 'WP_PRESENCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WP_PRESENCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Width of the room and client_id columns, and therefore the longest value the
+// REST layer accepts. MySQL would otherwise truncate silently, which collapses
+// two distinct clients onto one UNIQUE KEY (room, client_id) row.
+define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );
+
 if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
 	define( 'WP_PRESENCE_DEFAULT_TTL', 60 );
 }

--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -5,6 +5,8 @@
  * @package Presence_API
  *
  * @group presence
+ *
+ * @covers ::wp_presence_admin_bar_node
  */
 class WP_Test_Presence_Admin_Bar extends WP_UnitTestCase {
 

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -83,13 +83,15 @@ class WP_Test_Presence_Cron extends WP_UnitTestCase {
 	 * @covers ::wp_presence_schedule_cleanup
 	 */
 	public function test_schedule_cleanup_does_not_double_schedule() {
-		wp_presence_schedule_cleanup();
-		$first = wp_next_scheduled( self::HOOK );
+		// Seed at an earlier timestamp. Calling the function twice in one second
+		// is not enough: the cron array keys on timestamp, hook and args hash, so
+		// the second write collapses onto the first even with no guard at all.
+		$seeded = time() - HOUR_IN_SECONDS;
+		wp_schedule_event( $seeded, 'wp_presence_every_minute', self::HOOK );
 
 		wp_presence_schedule_cleanup();
-		$second = wp_next_scheduled( self::HOOK );
 
-		$this->assertSame( $first, $second, 'Scheduling twice should not move or duplicate the event.' );
+		$this->assertSame( $seeded, wp_next_scheduled( self::HOOK ), 'The existing event should not move.' );
 		$this->assertSame( 1, $this->count_scheduled_events( self::HOOK ), 'Exactly one cleanup event should be scheduled.' );
 	}
 

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -70,8 +70,9 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 		global $wpdb;
 
 		wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
+		wp_set_presence( 'test/room', 'client-2', array(), self::$editor_id );
 
-		// Manually backdate the entry to simulate expiration.
+		// Manually backdate one entry to simulate expiration.
 		$wpdb->update(
 			$wpdb->presence,
 			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 120 ) ),
@@ -82,7 +83,8 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 
 		$entries = wp_get_presence( 'test/room', 60 );
 
-		$this->assertCount( 0, $entries );
+		$this->assertCount( 1, $entries, 'Only the current entry should survive the cutoff.' );
+		$this->assertSame( 'client-2', $entries[0]->client_id );
 	}
 
 	/**
@@ -103,11 +105,14 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 	 */
 	public function test_remove_presence() {
 		wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
+		wp_set_presence( 'test/room', 'client-2', array(), self::$editor_id );
+
 		wp_remove_presence( 'test/room', 'client-1' );
 
 		$entries = wp_get_presence( 'test/room' );
 
-		$this->assertCount( 0, $entries );
+		$this->assertCount( 1, $entries, 'Only the named client should be removed.' );
+		$this->assertSame( 'client-2', $entries[0]->client_id );
 	}
 
 	/**
@@ -125,10 +130,12 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 	public function test_remove_user_presence_clears_all_rooms() {
 		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
 		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$subscriber_id, array(), self::$subscriber_id );
 
 		wp_remove_user_presence( self::$editor_id );
 
 		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
+		$this->assertCount( 1, wp_get_user_presence( self::$subscriber_id ), 'Another user\'s entries should be left alone.' );
 	}
 
 	/**
@@ -247,9 +254,11 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_get_presence_by_room_prefix
 	 */
 	public function test_get_presence_by_room_prefix_empty() {
+		wp_set_presence( 'postType/post:1', 'client-1', array(), self::$editor_id );
+
 		$entries = wp_get_presence_by_room_prefix( 'nonexistent/' );
 
-		$this->assertCount( 0, $entries );
+		$this->assertCount( 0, $entries, 'A room under a different prefix should not match.' );
 	}
 
 	/**
@@ -259,6 +268,7 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 		global $wpdb;
 
 		wp_set_presence( 'postType/post:1', 'client-1', array(), self::$editor_id );
+		wp_set_presence( 'postType/post:2', 'client-2', array(), self::$editor_id );
 
 		$wpdb->update(
 			$wpdb->presence,
@@ -270,7 +280,8 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 
 		$entries = wp_get_presence_by_room_prefix( 'postType/', 60 );
 
-		$this->assertCount( 0, $entries );
+		$this->assertCount( 1, $entries, 'Only the current entry should survive the cutoff.' );
+		$this->assertSame( 'client-2', $entries[0]->client_id );
 	}
 
 	/**

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -53,10 +53,12 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 	public function test_logout_clears_all_rooms() {
 		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
 		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$subscriber_id, array(), self::$subscriber_id );
 
 		wp_presence_on_logout( self::$editor_id );
 
 		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
+		$this->assertCount( 1, wp_get_user_presence( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
 
 	/**
@@ -79,6 +81,7 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 	public function test_logout_clears_presence_without_current_user() {
 		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
 		wp_set_presence( 'postType/post:1', 'lock-' . self::$editor_id, array(), self::$editor_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$subscriber_id, array(), self::$subscriber_id );
 
 		// Simulate real wp_logout timing.
 		// Auth cookie has been cleared, so get_current_user_id() would return 0.
@@ -87,5 +90,6 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 		wp_presence_on_logout( self::$editor_id );
 
 		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
+		$this->assertCount( 1, wp_get_user_presence( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
 }

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -186,6 +186,78 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * room and client_id are varchar(191). Anything longer would be truncated by
+	 * MySQL, so two distinct clients could collapse onto one UNIQUE KEY row.
+	 *
+	 * @covers WP_REST_Presence_Controller::register_routes
+	 */
+	public function test_rest_create_rejects_keys_wider_than_the_column() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence' );
+		$request->set_param( 'room', str_repeat( 'a', WP_PRESENCE_MAX_KEY_LENGTH + 1 ) );
+		$request->set_param( 'client_id', 'client-1' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertCount( 0, wp_get_presence( str_repeat( 'a', WP_PRESENCE_MAX_KEY_LENGTH ) ), 'Nothing should have been written.' );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::register_routes
+	 */
+	public function test_rest_create_accepts_keys_at_the_column_width() {
+		wp_set_current_user( self::$editor_id );
+
+		$room = str_repeat( 'a', WP_PRESENCE_MAX_KEY_LENGTH );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence' );
+		$request->set_param( 'room', $room );
+		$request->set_param( 'client_id', str_repeat( 'b', WP_PRESENCE_MAX_KEY_LENGTH ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'The boundary itself must still be accepted.' );
+		$this->assertCount( 1, wp_get_presence( $room ) );
+	}
+
+	/**
+	 * @covers WP_REST_Presence_Controller::register_routes
+	 */
+	public function test_rest_create_rejects_an_empty_room() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence' );
+		$request->set_param( 'room', '' );
+		$request->set_param( 'client_id', 'client-1' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
+	 * The custom validate_callback on screen_key replaces the default one, so the
+	 * schema's maxLength only applies if that callback delegates to it.
+	 *
+	 * @covers WP_REST_Presence_Controller::register_routes
+	 */
+	public function test_rest_screen_key_is_bounded_by_the_schema() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence/screen-revisions/stale' );
+		$request->set_param( 'screen_key', str_repeat( 'a', WP_PRESENCE_SCREEN_KEY_LIMIT + 1 ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
 	 * @covers WP_REST_Presence_Controller::get_rooms_permissions_check
 	 */
 	public function test_get_rooms_requires_edit_posts() {

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -354,4 +354,28 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 		$this->assertSame( 'rest_presence_unavailable', $response->get_error_code() );
 		$this->assertSame( 503, $response->get_error_data()['status'] );
 	}
+
+	/**
+	 * The ownership lookup needs storage to read from, so a non-admin deleting
+	 * against a missing table has to short-circuit rather than query.
+	 *
+	 * @covers WP_REST_Presence_Controller::delete_item_permissions_check
+	 */
+	public function test_rest_delete_is_permitted_without_a_table() {
+		global $wpdb;
+
+		$this->drop_presence_table();
+		$wpdb->last_error = '';
+
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'DELETE', '/wp-presence/v1/presence' );
+		$request->set_param( 'room', 'admin/online' );
+		$request->set_param( 'client_id', 'user-' . self::$editor_id );
+
+		$controller = new WP_REST_Presence_Controller();
+
+		$this->assertTrue( $controller->delete_item_permissions_check( $request ) );
+		$this->assertSame( '', $wpdb->last_error, 'The ownership lookup should not have run.' );
+	}
 }

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -98,6 +98,8 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::wp_presence_activate
+	 * @covers ::wp_presence_provision_site
+	 * @covers ::wp_presence_schedule_cleanup
 	 */
 	public function test_activation_provisions_the_current_site() {
 		$this->drop_presence_table();
@@ -112,6 +114,8 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 
 	/**
 	 * @covers ::wp_presence_on_initialize_site
+	 * @covers ::wp_presence_provision_site
+	 * @covers ::wp_presence_schedule_cleanup
 	 */
 	public function test_new_site_is_provisioned_on_initialize_site() {
 		if ( ! is_multisite() ) {
@@ -141,6 +145,9 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 	 * fires wp_initialize_site for them, so activation is their only chance.
 	 *
 	 * @covers ::wp_presence_activate
+	 * @covers ::wp_presence_get_network_site_ids
+	 * @covers ::wp_presence_provision_site
+	 * @covers ::wp_presence_schedule_cleanup
 	 */
 	public function test_network_activation_provisions_every_site() {
 		if ( ! is_multisite() ) {
@@ -180,6 +187,7 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 	 * current one would leave every other site rescheduling a dead callback.
 	 *
 	 * @covers ::wp_presence_deactivate
+	 * @covers ::wp_presence_get_network_site_ids
 	 */
 	public function test_network_deactivation_clears_cleanup_on_every_site() {
 		if ( ! is_multisite() ) {

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -265,6 +265,15 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 	 * It must not raise a database error.
 	 *
 	 * @covers ::wp_presence_has_table
+	 * @covers ::wp_set_presence
+	 * @covers ::wp_remove_presence
+	 * @covers ::wp_remove_user_presence
+	 * @covers ::wp_get_presence
+	 * @covers ::wp_get_user_presence
+	 * @covers ::wp_get_presence_by_room_prefix
+	 * @covers ::wp_get_active_rooms
+	 * @covers ::wp_get_presence_summary
+	 * @covers ::wp_delete_expired_presence_data
 	 */
 	public function test_reads_and_writes_are_a_no_op_without_a_table() {
 		global $wpdb;
@@ -282,6 +291,7 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 		$this->assertSame( array(), wp_get_presence_by_room_prefix( 'postType/' ) );
 		$this->assertSame( array(), wp_get_active_rooms() );
 		$this->assertSame( 0, wp_get_presence_summary()['total_entries'] );
+		$this->assertNull( wp_delete_expired_presence_data() );
 
 		// The symptom this guards against: a wpdb error surfaced to the page.
 		$this->assertSame( '', $wpdb->last_error, 'No query should have reached the missing table.' );
@@ -308,6 +318,7 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 
 	/**
 	 * @covers WP_REST_Presence_Controller::get_items
+	 * @covers WP_REST_Presence_Controller::empty_collection_response
 	 */
 	public function test_rest_read_returns_an_empty_collection_without_a_table() {
 		$this->drop_presence_table();


### PR DESCRIPTION
Ensures feedback provided in individual pull requests is uniformly applied everywhere it is appropriate.

Fixes #246
Fixes #243

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with investigation, drafting and verification
