### PR TITLE
ci: credit contributors who link their WordPress.org account after merge

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,9 @@ Props are tied to WordPress.org profiles, not GitHub accounts. Props-bot comment
 1. **A commit email tied to your GitHub account.** Your `@users.noreply.github.com` address works and keeps your real one out of public history.
 2. **Your GitHub account [linked to your WordPress.org profile](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/).** Until then you appear under "Unlinked Accounts" and cannot be propped in a release.
 
-Do both before your first pull request is ready. Add the `props-bot` label to refresh the list.
+Do both before your first pull request is ready. Add the `props-bot` label to refresh the list, on an open or an already merged pull request.
+
+Linking late still counts. Release props are assembled when the release goes out, and anyone listed under "Unlinked Accounts" is checked again at that point, so a profile linked between your merge and the release picks up the credit.
 
 ## Releases
 

--- a/.github/scripts/aggregate-props.js
+++ b/.github/scripts/aggregate-props.js
@@ -6,6 +6,12 @@ const RELEASE_BRANCH = 'release-please--';
 // preview releases (preview-pr-N) and release-please drafts, neither of which
 // may set the cutoff.
 const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
+const WPORG_LOOKUP = 'https://profiles.wordpress.org/wp-json/wporg-github/v1/lookup/';
+// props-bot writes this sentence under an "## Unlinked Accounts" heading for
+// every contributor with no WordPress.org account linked to their GitHub one.
+// See commentProps() in WordPress/props-bot-action, src/github.js. Logins
+// cannot contain a period, so the sentence ends at the first one.
+const UNLINKED = /^The following contributors have not linked their GitHub and WordPress\.org accounts: ([^.]+)\./m;
 
 function findCutoff(releases) {
   return releases
@@ -19,6 +25,45 @@ function parsePropsNames(body) {
   const match = body.match(/Props ([^.]+)\./);
   if (!match) return [];
   return match[1].split(', ').map(n => n.trim()).filter(Boolean);
+}
+
+// props-bot omits the SVN block entirely when nobody on the pull request is
+// linked yet, so a props comment is not always a comment containing "Props ".
+// Matching only on that would skip exactly the pull requests this recovery
+// exists for: the ones whose only contributor had not linked at merge time.
+function isPropsBotComment(comment) {
+  return (
+    comment.user.login === 'github-actions[bot]' &&
+    (comment.body.includes('Props ') || UNLINKED.test(comment.body))
+  );
+}
+
+function parseUnlinkedLogins(body) {
+  const match = body.match(UNLINKED);
+  if (!match) return [];
+  return match[1].split(',').map(n => n.trim().replace(/^@/, '')).filter(Boolean);
+}
+
+// Asks WordPress.org which of these GitHub logins now have a linked profile.
+// Same endpoint props-bot uses, so a login resolves here exactly when it would
+// have resolved there.
+async function resolveWPOrgLogins(logins, { userAgent, fetchImpl = fetch }) {
+  if (logins.length === 0) return [];
+
+  const response = await fetchImpl(WPORG_LOOKUP, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': userAgent },
+    body: JSON.stringify({ github_user: logins }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`WordPress.org lookup responded ${response.status}.`);
+  }
+
+  const data = await response.json();
+
+  // An unlinked login comes back as `false` rather than an object.
+  return logins.map(login => data?.[login]?.slug).filter(Boolean);
 }
 
 function sortProps(names, sortLast) {
@@ -41,7 +86,7 @@ function buildComment(names) {
   ].join('\n');
 }
 
-async function run({ github, context, core, env = process.env }) {
+async function run({ github, context, core, env = process.env, fetchImpl = fetch }) {
   const { owner, repo } = context.repo;
   const sortLast = env.PROPS_SORT_LAST || '';
 
@@ -74,29 +119,58 @@ async function run({ github, context, core, env = process.env }) {
     (!cutoff || pr.merged_at >= cutoff)
   );
 
-  // 4. Collect props from each merged PR's latest props-bot comment.
-  const allNames = (
+  // 4. Collect each merged PR's latest props-bot comment.
+  const propsBodies = (
     await Promise.all(
       mergedPRs.map(pr =>
         github.rest.issues.listComments({ owner, repo, issue_number: pr.number, per_page: 100 })
       )
     )
-  ).flatMap(({ data: comments }) => {
-    const propsComment = comments.findLast(
-      c => c.user.login === 'github-actions[bot]' && c.body.includes('Props ')
-    );
-    return propsComment ? parsePropsNames(propsComment.body) : [];
-  });
+  )
+    .map(({ data: comments }) => comments.findLast(isPropsBotComment))
+    .filter(Boolean)
+    .map(c => c.body);
 
-  if (allNames.length === 0) {
+  const propped = propsBodies.flatMap(parsePropsNames);
+  const unlinked = [...new Set(propsBodies.flatMap(parseUnlinkedLogins))];
+
+  if (propped.length === 0 && unlinked.length === 0) {
     core.info('No props found across merged PRs; skipping comment.');
     return;
   }
 
-  // 5. Deduplicate and sort.
+  // 5. Re-resolve anyone props-bot recorded as unlinked. That comment is a
+  //    snapshot taken while the pull request was open, and every trigger in
+  //    props-bot.yml requires an open pull request, so nothing refreshes it
+  //    after merge. Without this, linking a WordPress.org account any time
+  //    after your own pull request merges drops you from the release props
+  //    permanently. Checking here moves the deadline to the release.
+  let recovered = [];
+  try {
+    recovered = await resolveWPOrgLogins(unlinked, {
+      userAgent: `${owner}/${repo}`,
+      fetchImpl,
+    });
+  } catch (error) {
+    // Losing a late linker is better than losing the whole props comment.
+    core.warning(`Could not re-check unlinked accounts: ${error.message}`);
+  }
+
+  if (recovered.length > 0) {
+    core.info(`Contributors linked since their pull request merged: ${recovered.join(', ')}.`);
+  }
+
+  const allNames = [...propped, ...recovered];
+
+  if (allNames.length === 0) {
+    core.info('Every contributor since the last release is still unlinked; skipping comment.');
+    return;
+  }
+
+  // 6. Deduplicate and sort.
   const sorted = sortProps(allNames, sortLast);
 
-  // 6. Find or create sticky comment on the release PR.
+  // 7. Find or create sticky comment on the release PR.
   const { data: releaseComments } = await github.rest.issues.listComments({
     owner, repo, issue_number: prNumber,
   });
@@ -113,6 +187,9 @@ async function run({ github, context, core, env = process.env }) {
 module.exports = run;
 module.exports.findCutoff = findCutoff;
 module.exports.parsePropsNames = parsePropsNames;
+module.exports.parseUnlinkedLogins = parseUnlinkedLogins;
+module.exports.isPropsBotComment = isPropsBotComment;
+module.exports.resolveWPOrgLogins = resolveWPOrgLogins;
 module.exports.sortProps = sortProps;
 module.exports.buildComment = buildComment;
 module.exports.MARKER = MARKER;

--- a/.github/scripts/aggregate-props.test.js
+++ b/.github/scripts/aggregate-props.test.js
@@ -130,24 +130,13 @@ test('parsePropsNames: trims whitespace around names', () => {
 // parseUnlinkedLogins
 // ---------------------------------------------------------------------------
 
-test('parseUnlinkedLogins: reads a real props-bot comment', () => {
-  const body = propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] });
-  assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh']);
-});
-
-test('parseUnlinkedLogins: extracts several logins and strips the @', () => {
-  const body = propsBotBody({ unlinked: ['alice-gh', 'bob', 'carol99'] });
+test('parseUnlinkedLogins: extracts the logins, stripping the @ and ignoring the period in WordPress.org', () => {
+  const body = propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh', 'bob', 'carol99'] });
   assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh', 'bob', 'carol99']);
 });
 
 test('parseUnlinkedLogins: returns empty array when there is no unlinked section', () => {
   assert.deepEqual(parseUnlinkedLogins(propsBotBody({ svn: ['alice'] })), []);
-});
-
-test('parseUnlinkedLogins: is not confused by the period in WordPress.org', () => {
-  const body = propsBotBody({ unlinked: ['alice-gh'] });
-  assert.ok(body.includes('WordPress.org accounts'));
-  assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh']);
 });
 
 // ---------------------------------------------------------------------------
@@ -162,38 +151,16 @@ test('isPropsBotComment: matches a comment that only has an unlinked section', (
   assert.ok(isPropsBotComment(propsComment(body)));
 });
 
-test('isPropsBotComment: ignores comments from other users', () => {
-  assert.ok(!isPropsBotComment({ user: { login: 'someone' }, body: 'Props alice.' }));
-});
-
-test('isPropsBotComment: ignores bot comments that are not props comments', () => {
-  assert.ok(!isPropsBotComment(propsComment('Thanks for the pull request!')));
-});
-
 // ---------------------------------------------------------------------------
 // resolveWPOrgLogins
 // ---------------------------------------------------------------------------
 
-test('resolveWPOrgLogins: returns slugs for logins that now resolve', async () => {
-  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
-  assert.deepEqual(
-    await resolveWPOrgLogins(['alice-gh'], { userAgent: 'test', fetchImpl }),
-    ['alice']
-  );
-});
-
-test('resolveWPOrgLogins: drops logins that are still unlinked', async () => {
+test('resolveWPOrgLogins: returns slugs for logins that resolve and drops the rest', async () => {
   const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
   assert.deepEqual(
     await resolveWPOrgLogins(['alice-gh', 'bob'], { userAgent: 'test', fetchImpl }),
     ['alice']
   );
-});
-
-test('resolveWPOrgLogins: makes no request when nothing is unlinked', async () => {
-  const fetchImpl = fakeLookup();
-  assert.deepEqual(await resolveWPOrgLogins([], { userAgent: 'test', fetchImpl }), []);
-  assert.equal(fetchImpl.mock.calls.length, 0);
 });
 
 test('resolveWPOrgLogins: throws when the endpoint fails', async () => {
@@ -476,22 +443,6 @@ test('run: credits a contributor whose pull request had no props line at all', a
   assert.ok(body.includes('Props alice.'));
 });
 
-test('run: leaves out contributors who are still unlinked', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
-
-  await run({ github, context, core, env: makeEnv(), fetchImpl: fakeLookup() });
-
-  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
-  assert.ok(body.includes('Props joefusco.'));
-});
-
 test('run: posts nothing when every contributor is still unlinked', async () => {
   const github = buildGithub({
     prs: [makePR(10, 'feature/foo')],
@@ -545,27 +496,6 @@ test('run: still posts known props when the WordPress.org lookup fails', async (
   assert.equal(core.setFailed.mock.calls.length, 0);
   const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
   assert.ok(body.includes('Props joefusco.'));
-});
-
-test('run: deduplicates a recovered contributor already propped elsewhere', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo'), makePR(11, 'feature/bar')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
-      11: [propsComment(propsBotBody({ svn: ['joefusco', 'alice'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
-
-  await run({
-    github, context, core,
-    env: makeEnv({ PROPS_SORT_LAST: 'joefusco' }),
-    fetchImpl: fakeLookup({ 'alice-gh': 'alice' }),
-  });
-
-  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
-  assert.ok(body.includes('Props alice, joefusco.'));
 });
 
 test('run: asks WordPress.org about each unlinked login only once', async () => {

--- a/.github/scripts/aggregate-props.test.js
+++ b/.github/scripts/aggregate-props.test.js
@@ -4,7 +4,16 @@ const { test, mock } = require('node:test');
 const assert = require('node:assert/strict');
 
 const run = require('./aggregate-props.js');
-const { findCutoff, parsePropsNames, sortProps, buildComment, MARKER } = run;
+const {
+  findCutoff,
+  parsePropsNames,
+  parseUnlinkedLogins,
+  resolveWPOrgLogins,
+  isPropsBotComment,
+  sortProps,
+  buildComment,
+  MARKER,
+} = run;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -46,6 +55,46 @@ function makeEnv(overrides = {}) {
   return { PR_NUMBER: String(RELEASE_PR), PROPS_SORT_LAST: '', ...overrides };
 }
 
+// Reproduces the layout commentProps() emits in WordPress/props-bot-action,
+// including its habit of dropping the SVN block when nobody is linked.
+function propsBotBody({ svn = [], unlinked = [] } = {}) {
+  let body =
+    'The following accounts have interacted with this PR and/or linked issues.' +
+    ' I will continue to update these lists as activity occurs. You can also' +
+    ' manually ask me to refresh this list by adding the `props-bot` label.\n\n';
+
+  if (unlinked.length > 0) {
+    body +=
+      '## Unlinked Accounts\n\n' +
+      'The following contributors have not linked their GitHub and WordPress.org accounts: @' +
+      unlinked.join(', @') +
+      '.\n\n' +
+      'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/)' +
+      ' to ensure your work is properly credited in WordPress releases.\n\n';
+  }
+
+  if (svn.length > 0) {
+    body +=
+      'Core Committers: Use this line as a base for the props when committing in SVN:\n' +
+      '```\nProps ' + svn.join(', ') + '.\n```\n\n';
+  }
+
+  return body;
+}
+
+// `slugs` maps a GitHub login to the WordPress.org slug it now resolves to.
+// Anything absent comes back as `false`, which is what the real endpoint sends
+// for an account that is still unlinked.
+function fakeLookup(slugs = {}, { ok = true, status = 200 } = {}) {
+  return mock.fn(async (_url, options) => {
+    const { github_user: logins } = JSON.parse(options.body);
+    const data = Object.fromEntries(
+      logins.map(login => [login, slugs[login] ? { slug: slugs[login] } : false])
+    );
+    return { ok, status, json: async () => data };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // parsePropsNames
 // ---------------------------------------------------------------------------
@@ -75,6 +124,84 @@ test('parsePropsNames: handles Props line embedded in a longer comment body', ()
 
 test('parsePropsNames: trims whitespace around names', () => {
   assert.deepEqual(parsePropsNames('Props  alice ,  bob .'), ['alice', 'bob']);
+});
+
+// ---------------------------------------------------------------------------
+// parseUnlinkedLogins
+// ---------------------------------------------------------------------------
+
+test('parseUnlinkedLogins: reads a real props-bot comment', () => {
+  const body = propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] });
+  assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh']);
+});
+
+test('parseUnlinkedLogins: extracts several logins and strips the @', () => {
+  const body = propsBotBody({ unlinked: ['alice-gh', 'bob', 'carol99'] });
+  assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh', 'bob', 'carol99']);
+});
+
+test('parseUnlinkedLogins: returns empty array when there is no unlinked section', () => {
+  assert.deepEqual(parseUnlinkedLogins(propsBotBody({ svn: ['alice'] })), []);
+});
+
+test('parseUnlinkedLogins: is not confused by the period in WordPress.org', () => {
+  const body = propsBotBody({ unlinked: ['alice-gh'] });
+  assert.ok(body.includes('WordPress.org accounts'));
+  assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh']);
+});
+
+// ---------------------------------------------------------------------------
+// isPropsBotComment
+// ---------------------------------------------------------------------------
+
+test('isPropsBotComment: matches a comment that only has an unlinked section', () => {
+  // props-bot omits the SVN block when nobody is linked, so there is no
+  // "Props " anywhere in the body.
+  const body = propsBotBody({ unlinked: ['alice-gh'] });
+  assert.ok(!body.includes('Props '));
+  assert.ok(isPropsBotComment(propsComment(body)));
+});
+
+test('isPropsBotComment: ignores comments from other users', () => {
+  assert.ok(!isPropsBotComment({ user: { login: 'someone' }, body: 'Props alice.' }));
+});
+
+test('isPropsBotComment: ignores bot comments that are not props comments', () => {
+  assert.ok(!isPropsBotComment(propsComment('Thanks for the pull request!')));
+});
+
+// ---------------------------------------------------------------------------
+// resolveWPOrgLogins
+// ---------------------------------------------------------------------------
+
+test('resolveWPOrgLogins: returns slugs for logins that now resolve', async () => {
+  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+  assert.deepEqual(
+    await resolveWPOrgLogins(['alice-gh'], { userAgent: 'test', fetchImpl }),
+    ['alice']
+  );
+});
+
+test('resolveWPOrgLogins: drops logins that are still unlinked', async () => {
+  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+  assert.deepEqual(
+    await resolveWPOrgLogins(['alice-gh', 'bob'], { userAgent: 'test', fetchImpl }),
+    ['alice']
+  );
+});
+
+test('resolveWPOrgLogins: makes no request when nothing is unlinked', async () => {
+  const fetchImpl = fakeLookup();
+  assert.deepEqual(await resolveWPOrgLogins([], { userAgent: 'test', fetchImpl }), []);
+  assert.equal(fetchImpl.mock.calls.length, 0);
+});
+
+test('resolveWPOrgLogins: throws when the endpoint fails', async () => {
+  const fetchImpl = fakeLookup({}, { ok: false, status: 503 });
+  await assert.rejects(
+    () => resolveWPOrgLogins(['alice-gh'], { userAgent: 'test', fetchImpl }),
+    /503/
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -306,6 +433,158 @@ test('run: falls back to the open release PR when PR_NUMBER is absent', async ()
     github.rest.issues.createComment.mock.calls[0].arguments[0].issue_number,
     RELEASE_PR
   );
+});
+
+// ---------------------------------------------------------------------------
+// run(): recovering contributors who linked after their pull request merged
+// ---------------------------------------------------------------------------
+
+test('run: credits a contributor who linked after their pull request merged', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+
+  await run({ github, context, core, env: makeEnv(), fetchImpl });
+
+  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
+  assert.ok(body.includes('Props joefusco, alice.'));
+});
+
+test('run: credits a contributor whose pull request had no props line at all', async () => {
+  // Nobody on the pull request was linked at merge time, so props-bot wrote an
+  // unlinked section and no SVN block.
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ unlinked: ['alice-gh'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+
+  await run({ github, context, core, env: makeEnv(), fetchImpl });
+
+  assert.equal(github.rest.issues.createComment.mock.calls.length, 1);
+  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
+  assert.ok(body.includes('Props alice.'));
+});
+
+test('run: leaves out contributors who are still unlinked', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+
+  await run({ github, context, core, env: makeEnv(), fetchImpl: fakeLookup() });
+
+  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
+  assert.ok(body.includes('Props joefusco.'));
+});
+
+test('run: posts nothing when every contributor is still unlinked', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ unlinked: ['alice-gh'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+
+  await run({ github, context, core, env: makeEnv(), fetchImpl: fakeLookup() });
+
+  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
+  assert.equal(github.rest.issues.updateComment.mock.calls.length, 0);
+});
+
+test('run: does not call WordPress.org when nobody is unlinked', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ svn: ['alice'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+  const fetchImpl = fakeLookup();
+
+  await run({ github, context, core, env: makeEnv(), fetchImpl });
+
+  assert.equal(fetchImpl.mock.calls.length, 0);
+  assert.equal(github.rest.issues.createComment.mock.calls.length, 1);
+});
+
+test('run: still posts known props when the WordPress.org lookup fails', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+
+  await run({
+    github, context, core,
+    env: makeEnv(),
+    fetchImpl: fakeLookup({}, { ok: false, status: 503 }),
+  });
+
+  assert.equal(core.warning.mock.calls.length, 1);
+  assert.equal(core.setFailed.mock.calls.length, 0);
+  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
+  assert.ok(body.includes('Props joefusco.'));
+});
+
+test('run: deduplicates a recovered contributor already propped elsewhere', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo'), makePR(11, 'feature/bar')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
+      11: [propsComment(propsBotBody({ svn: ['joefusco', 'alice'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+
+  await run({
+    github, context, core,
+    env: makeEnv({ PROPS_SORT_LAST: 'joefusco' }),
+    fetchImpl: fakeLookup({ 'alice-gh': 'alice' }),
+  });
+
+  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
+  assert.ok(body.includes('Props alice, joefusco.'));
+});
+
+test('run: asks WordPress.org about each unlinked login only once', async () => {
+  const github = buildGithub({
+    prs: [makePR(10, 'feature/foo'), makePR(11, 'feature/bar')],
+    commentsByPR: {
+      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
+      11: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
+      [RELEASE_PR]: [],
+    },
+  });
+  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+
+  await run({ github, context, core, env: makeEnv(), fetchImpl });
+
+  assert.equal(fetchImpl.mock.calls.length, 1);
+  const sent = JSON.parse(fetchImpl.mock.calls[0].arguments[1].body);
+  assert.deepEqual(sent.github_user, ['alice-gh']);
 });
 
 test('run: skips when PR_NUMBER is absent and no release PR is open', async () => {

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -60,6 +60,12 @@ jobs:
     # - A review is created or commented on (unless PR originates from a fork).
     # - The pull request is opened, synchronized, marked ready for review, or reopened.
     # - The `props-bot` label is added to the pull request.
+    #
+    # The `props-bot` label is also honoured on a closed pull request. The
+    # comment is a snapshot, and a contributor who links their WordPress.org
+    # account after their own pull request merges has no other way to have it
+    # redrawn. Applying a label needs write access and this job only posts a
+    # comment, so the open-state gate is not carrying security weight there.
     if: |
       (
         github.event_name == 'issue_comment' && github.event.issue.pull_request ||
@@ -67,7 +73,11 @@ jobs:
         github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
         'props-bot' == github.event.label.name
       ) &&
-      ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' ) &&
+      (
+        'props-bot' == github.event.label.name ||
+        ! github.event.pull_request.draft && github.event.pull_request.state == 'open' ||
+        ! github.event.issue.draft && github.event.issue.state == 'open'
+      ) &&
       ! startsWith( github.event.pull_request.head.ref, 'docs/add-' ) &&
       ! startsWith( github.event.pull_request.head.ref, 'release-please--' )
 


### PR DESCRIPTION
The props-bot comment is a snapshot taken while a pull request is open, and every trigger in `props-bot.yml` requires an open pull request, so a contributor who linked their WordPress.org account after their own merge could never be picked up again.

Closes #237

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with investigation, implementation, and tests
