### PR TITLE
test: extract shared tear_down into a WP_Presence_UnitTestCase base class

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
 			<directory suffix=".php">tests/</directory>
 			<exclude>tests/e2e</exclude>
 			<exclude>tests/bootstrap.php</exclude>
+			<exclude>tests/class-wp-presence-unittestcase.php</exclude>
 		</testsuite>
 	</testsuites>
 	<coverage>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,9 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
 
+// Shared base test case, extended by the plugin's test classes.
+require __DIR__ . '/class-wp-presence-unittestcase.php';
+
 // The suite reinstalls WordPress on every run, which empties the options table
 // but leaves the plugin's own table in place. Provision the site the way
 // activation does so tests start from the state a real site is in, rather than

--- a/tests/class-wp-presence-unittestcase.php
+++ b/tests/class-wp-presence-unittestcase.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Shared base test case for the Presence API test suite.
+ *
+ * @package Presence_API
+ */
+
+/**
+ * Base test case that truncates the presence table after every test.
+ */
+abstract class WP_Presence_UnitTestCase extends WP_UnitTestCase {
+
+	public function tear_down() {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
+		parent::tear_down();
+	}
+}

--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -8,7 +8,7 @@
  *
  * @covers ::wp_presence_admin_bar_node
  */
-class WP_Test_Presence_Admin_Bar extends WP_UnitTestCase {
+class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $contributor_id;
@@ -30,13 +30,6 @@ class WP_Test_Presence_Admin_Bar extends WP_UnitTestCase {
 		parent::set_up();
 		// Only loaded on requests that actually render the bar.
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -11,7 +11,7 @@
  * @covers ::wp_presence_parse_room
  * @covers ::wp_presence_admin_room
  */
-class WP_Test_Presence_Functions extends WP_UnitTestCase {
+class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $subscriber_id;
@@ -19,13 +19,6 @@ class WP_Test_Presence_Functions extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -6,7 +6,7 @@
  *
  * @group presence
  */
-class WP_Test_Presence_Heartbeat extends WP_UnitTestCase {
+class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $subscriber_id;
@@ -14,13 +14,6 @@ class WP_Test_Presence_Heartbeat extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -6,7 +6,7 @@
  *
  * @group presence
  */
-class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
+class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $subscriber_id;
@@ -14,13 +14,6 @@ class WP_Test_Presence_Lifecycle extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-post-list.php
+++ b/tests/test-post-list.php
@@ -11,7 +11,7 @@
  * @covers ::wp_presence_render_editors_column
  * @covers ::wp_presence_editors_column_css
  */
-class WP_Test_Presence_Post_List extends WP_UnitTestCase {
+class WP_Test_Presence_Post_List extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $subscriber_id;
@@ -19,13 +19,6 @@ class WP_Test_Presence_Post_List extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-post-lock-bridge.php
+++ b/tests/test-post-lock-bridge.php
@@ -6,7 +6,7 @@
  *
  * @group presence
  */
-class WP_Test_Presence_Post_Lock_Bridge extends WP_UnitTestCase {
+class WP_Test_Presence_Post_Lock_Bridge extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $subscriber_id;
@@ -14,13 +14,6 @@ class WP_Test_Presence_Post_Lock_Bridge extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -8,7 +8,7 @@
  *
  * @covers WP_REST_Presence_Controller
  */
-class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
+class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $editor_2_id;
@@ -21,10 +21,7 @@ class WP_Test_Presence_REST_Controller extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		global $wpdb;
 		delete_option( 'wp_presence_screen_revisions' );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
 		parent::tear_down();
 	}
 

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -11,7 +11,7 @@
  *
  * @group presence
  */
-class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
+class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 
@@ -43,8 +43,6 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		global $wpdb;
-
 		if ( is_multisite() ) {
 			if ( false === $this->network_plugins ) {
 				delete_site_option( 'active_sitewide_plugins' );
@@ -53,12 +51,11 @@ class WP_Test_Presence_Table_Creation extends WP_UnitTestCase {
 			}
 		}
 
-		// DDL commits the surrounding transaction, so clean up by hand.
+		// DDL commits the surrounding transaction, so clean up by hand. The
+		// truncate itself is handled by the parent tear_down.
 		wp_presence_register_table();
 		delete_option( 'wp_presence_db_version' );
 		wp_presence_provision_site();
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
 
 		parent::tear_down();
 	}

--- a/tests/test-user-list.php
+++ b/tests/test-user-list.php
@@ -9,7 +9,7 @@
  * @covers ::wp_presence_users_views
  * @covers ::wp_presence_filter_online_users
  */
-class WP_Test_Presence_User_List extends WP_UnitTestCase {
+class WP_Test_Presence_User_List extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $subscriber_id;
@@ -20,9 +20,6 @@ class WP_Test_Presence_User_List extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
 		unset( $_GET['presence_status'], $_GET['_wpnonce'] );
 		parent::tear_down();
 	}

--- a/tests/widgets/test-widget-active-posts.php
+++ b/tests/widgets/test-widget-active-posts.php
@@ -8,7 +8,7 @@
  *
  * @covers WP_Presence_Widget_Active_Posts
  */
-class WP_Test_Presence_Widget_Active_Posts extends WP_UnitTestCase {
+class WP_Test_Presence_Widget_Active_Posts extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 	private static $editor2_id;
@@ -25,13 +25,6 @@ class WP_Test_Presence_Widget_Active_Posts extends WP_UnitTestCase {
 				'post_type'  => 'post',
 			)
 		);
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -8,19 +8,12 @@
  *
  * @covers WP_Presence_Widget_Whos_Online
  */
-class WP_Test_Presence_Widget_Whos_Online extends WP_UnitTestCase {
+class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 	private static $editor_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
-	}
-
-	public function tear_down() {
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
-		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
Nine (now eleven, after #251) test classes carried a byte-identical `tear_down()`. Extracted into a shared `WP_Presence_UnitTestCase` base class; the two files with extra cleanup keep a thin override that calls `parent::tear_down()`, and `test-table-creation.php` keeps its custom provisioning logic on top of it.

Fixes #222

### Testing
- `npm run test`
- `phpcs`
- `phpstan`

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with implementation and PR description