### PR TITLE
ci: enforce that debug-tool exclusion lists agree across three files

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Check debug-tool exclusion lists stay in sync
+        run: bash scripts/check-debug-exclusions.sh
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,7 +26,8 @@ coverage:
         informational: true
 
 # Files excluded here are also excluded from PHPUnit's coverage measurement in
-# phpunit.xml.dist. Keep the two lists in sync.
+# phpunit.xml.dist and from the distributed zip in .distignore. All three lists
+# are checked for agreement by scripts/check-debug-exclusions.sh in CI.
 ignore:
   # WP_DEBUG-only developer tools, not part of the distributed zip (.distignore).
   - "includes/db-viewer.php"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,9 @@
 		<exclude>
 			<!--
 			WP_DEBUG-only developer tools. Excluded from the distributed zip via
-			.distignore, so they are not measured as shipped product code either.
+			.distignore and from codecov.yml, so they are not measured as shipped
+			product code either. scripts/check-debug-exclusions.sh checks all three
+			lists agree.
 			-->
 			<file>includes/db-viewer.php</file>
 			<file>includes/debugger-widget.php</file>

--- a/scripts/check-debug-exclusions.sh
+++ b/scripts/check-debug-exclusions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# includes/db-viewer.php and includes/debugger-widget.php are WP_DEBUG-only
+# developer tools, excluded from measurement/distribution in three places:
+#
+#   - .distignore        keeps them out of the distributed zip
+#   - phpunit.xml.dist   keeps them out of PHPUnit coverage
+#   - codecov.yml        keeps them out of the Codecov report
+#
+# Nothing enforces that the three lists agree. If phpunit.xml.dist excludes a
+# file that codecov.yml does not, Codecov reports it as 0% covered and drags
+# the project total down for a file deliberately left unmeasured. This script
+# parses the includes/*.php entries out of all three and fails if they differ.
+#
+# Called from .github/workflows/phpcs.yml. Also runnable locally:
+#
+#   bash scripts/check-debug-exclusions.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+distignore=$(grep -E '^includes/.*\.php$' .distignore | sort)
+phpunit=$(grep -oE '<file>includes/[^<]+\.php</file>' phpunit.xml.dist | sed -E 's#<file>(.*)</file>#\1#' | sort)
+codecov=$(grep -oE '"includes/[^"]+\.php"' codecov.yml | tr -d '"' | sort)
+
+if [[ -z "$distignore" || -z "$phpunit" || -z "$codecov" ]]; then
+	echo "One of the three exclusion lists is empty — check the grep patterns still match." >&2
+	exit 1
+fi
+
+status=0
+
+if [[ "$distignore" != "$phpunit" ]]; then
+	echo "includes/*.php entries differ between .distignore and phpunit.xml.dist:" >&2
+	diff <(echo "$distignore") <(echo "$phpunit") >&2 || true
+	status=1
+fi
+
+if [[ "$distignore" != "$codecov" ]]; then
+	echo "includes/*.php entries differ between .distignore and codecov.yml:" >&2
+	diff <(echo "$distignore") <(echo "$codecov") >&2 || true
+	status=1
+fi
+
+if [[ $status -eq 0 ]]; then
+	echo "Debug-tool exclusion lists agree across .distignore, phpunit.xml.dist, and codecov.yml."
+fi
+
+exit $status


### PR DESCRIPTION
`includes/db-viewer.php` and `includes/debugger-widget.php` are named in `.distignore`, `phpunit.xml.dist`, and `codecov.yml`, with nothing but a comment in each keeping them in sync. Added `scripts/check-debug-exclusions.sh`, which parses the `includes/*.php` entries out of all three and fails with a diff if they disagree, wired into the existing phpcs job.

Fixes #228

### Testing
- `bash scripts/check-debug-exclusions.sh`
- `shellcheck scripts/check-debug-exclusions.sh`
- Manually removed an entry from one list to confirm the script fails with a useful diff, then restored it.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with implementation and PR description