### PR TITLE
ci: wait for both coverage uploads before Codecov posts a status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,11 @@
 codecov:
   notify:
-    # Each PHP 8.3 run uploads two reports for the same commit: the standard
-    # suite (flag: phpunit) and the multisite suite (flag: multisite), a few
-    # seconds apart. Without this, Codecov can finalize the status check after
-    # the first upload lands, computing project coverage from half the data
-    # and reporting a large, spurious drop.
+    # The coverage job uploads two reports per commit: the standard suite
+    # (flag: phpunit) and the multisite suite (flag: multisite), a few
+    # seconds apart. Without this, Codecov can finalize the status check
+    # after the first upload lands, computing project coverage from half
+    # the data and reporting a large, spurious drop. Keep this equal to the
+    # number of `codecov-action` uploads in phpunit.yml.
     after_n_builds: 2
 
 comment:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,12 @@
+codecov:
+  notify:
+    # Each PHP 8.3 run uploads two reports for the same commit: the standard
+    # suite (flag: phpunit) and the multisite suite (flag: multisite), a few
+    # seconds apart. Without this, Codecov can finalize the status check after
+    # the first upload lands, computing project coverage from half the data
+    # and reporting a large, spurious drop.
+    after_n_builds: 2
+
 comment:
   layout: "condensed_header, diff, flags, components"
   require_changes: true


### PR DESCRIPTION
The PHP 8.3 job uploads two reports per commit (\`phpunit\` and \`multisite\` flags), a few seconds apart. Without \`after_n_builds\`, Codecov can finalize and post the status check off the first upload alone.

This is what just happened on \`main\`: commit c46692f (a version-bump-only release merge, no code changes) shows a spurious project coverage drop to 71.19% from 72.51%, because Codecov's report for that commit merged only 1 of the 2 expected sessions before marking it complete. Three other recent commits checked via the Codecov API all correctly merged both sessions — this looks like a one-off timing race, not something structurally broken in the test suite.

\`after_n_builds: 2\` tells Codecov to wait for both uploads before computing and posting status, closing the race.

Fixes the false failure on main (rerun of the PHP 8.3 job requested separately to clear the current bad status).

### Testing
- Validated the YAML against Codecov's \`/validate\` endpoint

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with diagnosis, implementation, and PR description