### PR TITLE
fix: guard CLI cleanup and DB viewer with wp_presence_has_table()

### DIFF
--- a/includes/cli/class-wp-presence-cli-command.php
+++ b/includes/cli/class-wp-presence-cli-command.php
@@ -202,6 +202,12 @@ class WP_Presence_CLI_Command extends WP_CLI_Command {
 	public function cleanup( $args, $assoc_args ) {
 		global $wpdb;
 
+		if ( ! wp_presence_has_table() ) {
+			/* translators: %d: Number of deleted entries. */
+			WP_CLI::success( sprintf( __( '%d entries deleted.', 'presence-api' ), 0 ) );
+			return;
+		}
+
 		if ( ! WP_CLI\Utils\get_flag_value( $assoc_args, 'yes', false ) ) {
 			WP_CLI::confirm( __( 'This will delete all presence data. Continue?', 'presence-api' ) );
 		}

--- a/includes/db-viewer.php
+++ b/includes/db-viewer.php
@@ -29,14 +29,22 @@ add_action(
 
 		global $wpdb;
 
-		// No user input in these queries; table name comes from $wpdb->presence (controlled).
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			"SELECT room, user_id, data, date_gmt FROM {$wpdb->presence} ORDER BY date_gmt DESC"
-		);
+		// The provisioning path runs before this can be reached, so the table
+		// normally exists. Guard anyway to match every other read path and
+		// degrade to an empty view instead of a raw wpdb error if it is missing.
+		if ( wp_presence_has_table() ) {
+			// No user input in these queries; table name comes from $wpdb->presence (controlled).
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_results(
+				"SELECT room, user_id, data, date_gmt FROM {$wpdb->presence} ORDER BY date_gmt DESC"
+			);
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence}" );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence}" );
+		} else {
+			$rows  = array();
+			$count = 0;
+		}
 
 		$ttl         = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
 		$now_ms      = (int) ( microtime( true ) * 1000 );


### PR DESCRIPTION
## What & why

Resolves #210. The WP-CLI `cleanup` command (`includes/cli/class-wp-presence-cli-command.php`) and the debug DB viewer (`includes/db-viewer.php`) were the only two paths that hit the presence table directly without a `wp_presence_has_table()` check. Every other read/write path in `functions.php` and the REST controller guards on it and degrades to an empty result, so these two were the last places that would surface a raw `wpdb` error if the table were ever missing.

As #210 notes, `cli_init` / `admin_init` provision the table before either can run, so this is a **consistency fix**, not a live bug — it was deliberately left out of #203 to keep that change scoped.

## Changes

- **`db-viewer.php`** — wrap the `SELECT` / `COUNT(*)` queries in the availability check; when the table is absent, fall back to an empty row set and a zero count. The template already renders an empty state (`No entries.`) and the timestamp `foreach` is `empty()`-guarded, so no markup changes are needed.
- **`cli` `cleanup()`** — short-circuit to a `0 entries deleted.` success before the destructive `DELETE` (and before the confirmation prompt, since there is nothing to delete).

No new strings, no schema changes, no behavior change on a provisioned site.

## Testing

WP-CLI is not loaded in the PHPUnit suite and CLI coverage is being handled separately (#218 / #256), so I've kept this change focused on the guards rather than adding CLI-invoking tests here. Happy to add coverage if you'd prefer a particular approach.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Investigating the guard pattern and drafting the change