### PR TITLE
fix: delete expired presence rows by key in bounded passes

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -421,6 +421,15 @@ function wp_get_presence_summary( $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 /**
  * Deletes stale presence entries older than the default TTL.
  *
+ * Runs on the every-minute cron event. Rather than looping without a ceiling
+ * over the MySQL-only `DELETE ... LIMIT` construct, this selects a bounded
+ * page of primary keys older than the cutoff and deletes them by key, for a
+ * fixed number of passes per invocation. Any remaining backlog is left for the
+ * next cron run, so a single request cannot run until `max_execution_time`
+ * when a site returns from a cron outage with a large backlog. Deleting by
+ * primary key also keeps the query portable to non-MySQL backends, such as the
+ * SQLite integration Playground uses to run the demo blueprints.
+ *
  * @access private
  */
 function wp_delete_expired_presence_data() {
@@ -433,16 +442,53 @@ function wp_delete_expired_presence_data() {
 	$timeout = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
 	$cutoff  = gmdate( 'Y-m-d H:i:s', time() - $timeout );
 
-	// Delete in batches to avoid locking the table on large datasets.
-	do {
+	/**
+	 * Filters the number of expired rows deleted per pass.
+	 *
+	 * @param int $batch_size Rows per pass. Default 1000.
+	 */
+	$batch_size = (int) apply_filters( 'wp_presence_cleanup_batch_size', 1000 );
+
+	/**
+	 * Filters the maximum number of delete passes per cron invocation.
+	 *
+	 * The remainder is left for the next scheduled run, bounding the work a
+	 * single request performs.
+	 *
+	 * @param int $max_passes Passes per invocation. Default 10.
+	 */
+	$max_passes = (int) apply_filters( 'wp_presence_cleanup_max_passes', 10 );
+
+	if ( $batch_size < 1 || $max_passes < 1 ) {
+		return;
+	}
+
+	for ( $pass = 0; $pass < $max_passes; $pass++ ) {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$deleted = $wpdb->query(
+		$ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->presence} WHERE date_gmt < %s LIMIT 1000",
-				$cutoff
+				"SELECT id FROM {$wpdb->presence} WHERE date_gmt < %s ORDER BY id ASC LIMIT %d",
+				$cutoff,
+				$batch_size
 			)
 		);
-	} while ( $deleted > 0 );
+
+		if ( empty( $ids ) ) {
+			break;
+		}
+
+		$ids          = array_map( 'intval', $ids );
+		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+
+		// IDs are cast to integers above and passed to prepare() as %d
+		// replacements, so the interpolated placeholder list is safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->presence} WHERE id IN ( $placeholders )", $ids ) );
+
+		if ( count( $ids ) < $batch_size ) {
+			break;
+		}
+	}
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -482,7 +482,7 @@ function wp_delete_expired_presence_data() {
 
 		// IDs are cast to integers above and passed to prepare() as %d
 		// replacements, so the interpolated placeholder list is safe.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->presence} WHERE id IN ( $placeholders )", $ids ) );
 
 		if ( count( $ids ) < $batch_size ) {

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -219,6 +219,77 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * A single invocation deletes at most batch_size * max_passes rows and
+	 * leaves the remainder for the next scheduled run.
+	 *
+	 * @covers ::wp_delete_expired_presence_data
+	 */
+	public function test_cleanup_is_bounded_per_invocation() {
+		global $wpdb;
+
+		// Seed five expired entries.
+		for ( $i = 1; $i <= 5; $i++ ) {
+			wp_set_presence( 'test/room', "old-{$i}", array(), self::$editor_id );
+		}
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->presence} SET date_gmt = %s",
+				gmdate( 'Y-m-d H:i:s', time() - 120 )
+			)
+		);
+
+		// Two rows per pass, two passes per run: one run clears at most four.
+		$two = static function () {
+			return 2;
+		};
+		add_filter( 'wp_presence_cleanup_batch_size', $two );
+		add_filter( 'wp_presence_cleanup_max_passes', $two );
+
+		wp_delete_expired_presence_data();
+		$this->assertSame(
+			1,
+			(int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence}" ),
+			'One invocation should delete batch_size * max_passes (4) rows and leave the rest.'
+		);
+
+		// The next scheduled run clears the remainder.
+		wp_delete_expired_presence_data();
+		$this->assertSame(
+			0,
+			(int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence}" )
+		);
+
+		remove_filter( 'wp_presence_cleanup_batch_size', $two );
+		remove_filter( 'wp_presence_cleanup_max_passes', $two );
+	}
+
+	/**
+	 * Fresh entries are never removed, even with a batch size of one.
+	 *
+	 * @covers ::wp_delete_expired_presence_data
+	 */
+	public function test_cleanup_leaves_fresh_entries_untouched() {
+		global $wpdb;
+
+		wp_set_presence( 'test/room', 'fresh-1', array(), self::$editor_id );
+		wp_set_presence( 'test/room', 'fresh-2', array(), self::$editor_id );
+
+		$one = static function () {
+			return 1;
+		};
+		add_filter( 'wp_presence_cleanup_batch_size', $one );
+
+		wp_delete_expired_presence_data();
+
+		$this->assertSame(
+			2,
+			(int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence}" )
+		);
+
+		remove_filter( 'wp_presence_cleanup_batch_size', $one );
+	}
+
+	/**
 	 * @covers ::wp_set_presence
 	 */
 	public function test_multiple_clients_in_room() {


### PR DESCRIPTION
## What & why

Resolves #206. `wp_delete_expired_presence_data()` (`includes/functions.php`) batched deletions with a MySQL-only `DELETE ... LIMIT` inside a loop that had no iteration ceiling:

```php
do {
	$deleted = $wpdb->query(
		$wpdb->prepare( "DELETE FROM {$wpdb->presence} WHERE date_gmt < %s LIMIT 1000", $cutoff )
	);
} while ( $deleted > 0 );
```

Two divergences from core, both from #206:

1. **Portability** — `DELETE ... LIMIT` is MySQL-specific and appears nowhere in `wp-includes`, so it breaks on non-MySQL backends, including the SQLite integration Playground uses to run the demo blueprints.
2. **Unbounded work** — a site returning from a cron outage with a large backlog keeps looping until `max_execution_time`, committing an unpredictable fraction of the work.

## Change

Follows core's batching convention — *select a bounded set of primary keys, delete by key, a fixed number of passes per invocation, remainder to the next run*:

- Each pass `SELECT`s a page of `id`s older than the cutoff (`LIMIT %d`) and deletes them with a portable `WHERE id IN ( ... )` built from `%d` placeholders passed through `prepare()`.
- A fixed **max passes per invocation** bounds the work; the cron event fires every minute, so any remaining backlog drains over subsequent runs instead of in one long request.
- Batch size (default `1000`) and passes per run (default `10`) are filterable via `wp_presence_cleanup_batch_size` and `wp_presence_cleanup_max_passes`.

No schema change; behavior on a normally-drained table is unchanged.

## Tests

Added to `tests/test-functions.php` (`@covers ::wp_delete_expired_presence_data`):

- **`test_cleanup_is_bounded_per_invocation`** — with `batch_size` and `max_passes` filtered to `2`, seeds 5 expired rows and asserts one invocation deletes at most `2 × 2 = 4`, leaving the remainder; a second invocation clears it. This locks in the "remainder to the next run" guarantee.
- **`test_cleanup_leaves_fresh_entries_untouched`** — fresh rows survive cleanup even with a batch size of one.

The existing `test_cleanup_removes_expired_entries` continues to pass.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Investigating core's batching convention, implementing the fix, and writing tests