### PR TITLE
fix: check table availability in the CLI command and debug viewer

### DIFF
--- a/includes/cli/class-wp-presence-cli-command.php
+++ b/includes/cli/class-wp-presence-cli-command.php
@@ -202,6 +202,12 @@ class WP_Presence_CLI_Command extends WP_CLI_Command {
 	public function cleanup( $args, $assoc_args ) {
 		global $wpdb;
 
+		if ( ! wp_presence_has_table() ) {
+			/* translators: %d: Number of deleted entries. */
+			WP_CLI::success( sprintf( __( '%d entries deleted.', 'presence-api' ), 0 ) );
+			return;
+		}
+
 		if ( ! WP_CLI\Utils\get_flag_value( $assoc_args, 'yes', false ) ) {
 			WP_CLI::confirm( __( 'This will delete all presence data. Continue?', 'presence-api' ) );
 		}

--- a/includes/db-viewer.php
+++ b/includes/db-viewer.php
@@ -29,14 +29,15 @@ add_action(
 
 		global $wpdb;
 
-		// No user input in these queries; table name comes from $wpdb->presence (controlled).
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			"SELECT room, user_id, data, date_gmt FROM {$wpdb->presence} ORDER BY date_gmt DESC"
-		);
+		$rows = array();
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence}" );
+		if ( wp_presence_has_table() ) {
+			// No user input in this query; table name comes from $wpdb->presence (controlled).
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_results(
+				"SELECT room, user_id, data, date_gmt FROM {$wpdb->presence} ORDER BY date_gmt DESC"
+			);
+		}
 
 		$ttl         = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
 		$now_ms      = (int) ( microtime( true ) * 1000 );


### PR DESCRIPTION
Adds the `wp_presence_has_table()` check to the last two paths that queried the presence table without one - the WP-CLI `cleanup` command and the debug DB viewer. Both now degrade to an empty result like every other read path.

The viewer's `SELECT COUNT(*)` is removed rather than guarded as `$count` was never read - https://github.com/WordPress/presence-api/blob/1f3de12d576ec469e700ebd6c1bb522f18d58489/includes/db-viewer.php#L38-L39

No test for the CLI `tests/test-cli-command.php` yet. I'll add once WP #256 is merged.

Fixes #210

## Use of AI Tools

AI assistance: No