### PR TITLE
fix: keyboard users can't reach non-link items in the admin bar presence flyout

### DIFF
--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -317,8 +317,6 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 					'id'     => 'presence-user-' . $entry->user_id,
 					'title'  => $item_title,
 					'href'   => $screen_url ? $screen_url : false,
-					// Non-link items need an explicit tabindex; WP_Admin_Bar only
-					// renders one when it's set, otherwise the item is skipped by Tab.
 					'meta'   => $screen_url ? array() : array( 'tabindex' => 0 ),
 				)
 			);
@@ -354,7 +352,8 @@ function wp_presence_admin_bar_assets() {
 		#wp-admin-bar-presence-online .presence-bar-you { color: #a7aaad; font-weight: normal; }
 		#wp-admin-bar-presence-online .presence-bar-screen { color: #a7aaad; font-size: 12px; }
 		#wp-admin-bar-presence-online .presence-bar-screen em { font-style: italic; }
-		#wp-admin-bar-presence-online .presence-bar-group-header > .ab-item { color: #a7aaad !important; font-size: 11px !important; text-transform: uppercase; letter-spacing: 0.5px; pointer-events: none; padding-bottom: 0 !important; }
+		#wp-admin-bar-presence-online .presence-bar-group-header > .ab-item { font-size: 11px !important; text-transform: uppercase; letter-spacing: 0.5px; pointer-events: none; padding-bottom: 0 !important; }
+		#wp-admin-bar-presence-online .presence-bar-group-header > .ab-item:not(:focus) { color: #a7aaad !important; }
 		#wp-admin-bar-presence-group-elsewhere > .ab-item { border-top: 1px solid #3c4043 !important; margin-top: 4px !important; padding-top: 8px !important; }
 		#wp-admin-bar-presence-view-all .ab-item { border-top: 1px solid #3c4043 !important; font-style: italic; }
 	';

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -181,7 +181,10 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 			'id'     => 'presence-group-here',
 			'title'  => '<span class="presence-bar-group-label">' . esc_html__( 'On this page', 'presence-api' ) . '</span>',
 			'href'   => false,
-			'meta'   => array( 'class' => 'presence-bar-group-header' ),
+			'meta'   => array(
+				'class'    => 'presence-bar-group-header',
+				'tabindex' => 0,
+			),
 		)
 	);
 
@@ -192,6 +195,7 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 			'id'     => 'presence-user-self',
 			'title'  => esc_html( $current_user ? $current_user->display_name : __( 'You', 'presence-api' ) ) . ' <span class="presence-bar-you">(' . esc_html__( 'you', 'presence-api' ) . ')</span>',
 			'href'   => false,
+			'meta'   => array( 'tabindex' => 0 ),
 		)
 	);
 
@@ -209,6 +213,7 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 					/* translators: %d: Number of additional online users. */
 					'title'  => '<span class="presence-bar-screen">' . esc_html( sprintf( __( '+%d more', 'presence-api' ), $remaining ) ) . '</span>',
 					'href'   => false,
+					'meta'   => array( 'tabindex' => 0 ),
 				)
 			);
 			break;
@@ -224,6 +229,7 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 				'id'     => 'presence-user-' . $entry->user_id,
 				'title'  => esc_html( $user->display_name ),
 				'href'   => false,
+				'meta'   => array( 'tabindex' => 0 ),
 			)
 		);
 		++$shown;
@@ -236,7 +242,10 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 				'id'     => 'presence-group-elsewhere',
 				'title'  => '<span class="presence-bar-group-label">' . esc_html__( 'Elsewhere', 'presence-api' ) . '</span>',
 				'href'   => false,
-				'meta'   => array( 'class' => 'presence-bar-group-header' ),
+				'meta'   => array(
+					'class'    => 'presence-bar-group-header',
+					'tabindex' => 0,
+				),
 			)
 		);
 
@@ -308,6 +317,9 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 					'id'     => 'presence-user-' . $entry->user_id,
 					'title'  => $item_title,
 					'href'   => $screen_url ? $screen_url : false,
+					// Non-link items need an explicit tabindex; WP_Admin_Bar only
+					// renders one when it's set, otherwise the item is skipped by Tab.
+					'meta'   => $screen_url ? array() : array( 'tabindex' => 0 ),
 				)
 			);
 			++$shown;

--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -112,4 +112,30 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 
 		$this->assertStringContainsString( 'Secret Draft', $markup );
 	}
+
+	/**
+	 * WP_Admin_Bar only renders a `tabindex` attribute on a non-link node
+	 * when `meta.tabindex` is explicitly set — otherwise it's a `<div>`
+	 * outside the tab order entirely.
+	 */
+	public function test_non_link_nodes_are_keyboard_reachable() {
+		$this->put_editor_on_post( self::$post_id );
+
+		wp_set_current_user( self::$contributor_id );
+
+		$bar = new WP_Admin_Bar();
+		wp_presence_admin_bar_node( $bar );
+
+		foreach ( $bar->get_nodes() as $node ) {
+			if ( ! empty( $node->href ) ) {
+				continue;
+			}
+
+			$this->assertSame(
+				0,
+				$node->meta['tabindex'] ?? null,
+				"Node '{$node->id}' has no href and needs meta.tabindex => 0 to stay reachable by Tab."
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Description

Fixes #264

Non-link flyout items (group headers, self row, per-user rows without a screen link) had no `tabindex`, so Tab skipped them and jumped straight to the last real link.

- Add `meta.tabindex => 0` to every non-link node.
- Adjust the group-header CSS so focus color is visible instead of being overridden.
- Add a PHPUnit test asserting every href-less node stays keyboard reachable.

## Screencast

https://github.com/user-attachments/assets/9c8b0cd3-7ec6-41b3-b588-3dea051d0d14

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Investigating the root cause and drafting the fix.