### PR TITLE
test: simulate declining the cleanup confirmation prompt

### DIFF
--- a/tests/stubs/wp-cli.php
+++ b/tests/stubs/wp-cli.php
@@ -25,9 +25,12 @@ namespace {
 
 		public static $formatted = array();
 
+		public static $confirm_declines = false;
+
 		public static function reset() {
-			self::$calls     = array();
-			self::$formatted = array();
+			self::$calls            = array();
+			self::$formatted        = array();
+			self::$confirm_declines = false;
 		}
 
 		public static function success( $message ) {
@@ -38,8 +41,15 @@ namespace {
 			self::record( 'log', $message );
 		}
 
+		/**
+		 * @throws WP_Presence_CLI_Halt Standing in for the process exit, when $confirm_declines is set.
+		 */
 		public static function confirm( $question ) {
 			self::record( 'confirm', $question );
+
+			if ( self::$confirm_declines ) {
+				throw new WP_Presence_CLI_Halt( $question );
+			}
 		}
 
 		/**

--- a/tests/test-cli-command.php
+++ b/tests/test-cli-command.php
@@ -27,12 +27,12 @@ class WP_Test_Presence_CLI_Command extends WP_Presence_UnitTestCase {
 		$this->command = new WP_Presence_CLI_Command();
 	}
 
-	private function assert_halts_with( callable $run, $expected ) {
+	private function assert_halts_with( callable $run, $expected, $type = 'error' ) {
 		try {
 			$run();
 		} catch ( WP_Presence_CLI_Halt $e ) {
 			$this->assertSame( $expected, $e->getMessage() );
-			$this->assertSame( array( $expected ), WP_CLI::messages( 'error' ) );
+			$this->assertSame( array( $expected ), WP_CLI::messages( $type ) );
 			return;
 		}
 
@@ -321,6 +321,25 @@ class WP_Test_Presence_CLI_Command extends WP_Presence_UnitTestCase {
 
 		$this->assertSame( array( 'This will delete all presence data. Continue?' ), WP_CLI::messages( 'confirm' ) );
 		$this->assertSame( 0, $this->presence_row_count(), 'Confirming should carry on into the delete.' );
+	}
+
+	/**
+	 * @covers WP_Presence_CLI_Command::cleanup
+	 */
+	public function test_cleanup_leaves_the_table_untouched_when_the_prompt_is_declined() {
+		wp_set_presence( 'admin/online', 'cli-1', array(), self::$user_id );
+
+		WP_CLI::$confirm_declines = true;
+
+		$this->assert_halts_with(
+			function () {
+				$this->command->cleanup( array(), array() );
+			},
+			'This will delete all presence data. Continue?',
+			'confirm'
+		);
+
+		$this->assertSame( 1, $this->presence_row_count(), 'Declining the prompt should leave the table untouched.' );
 	}
 
 	/**


### PR DESCRIPTION
Closes #260.

Extends `WP_CLI::confirm()` in the test stub to throw `WP_Presence_CLI_Halt` when `WP_CLI::$confirm_declines` is set, and adds a test asserting the presence table is untouched when the prompt is declined.

## Test
- [x] `npm run test`

## AI Usage

None