### PR TITLE
ci: restrict permissions on the deploy-to-wporg job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -132,6 +132,8 @@ jobs:
   deploy-to-wporg:
     needs: [release-please, build-release-asset]
     if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/deploy-wporg.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary

Every other job in release-please.yml declares explicit `permissions`; `deploy-to-wporg` called the reusable deploy workflow without any, leaving it to the default GITHUB_TOKEN scope. The called workflow only needs `contents: read`.

Fixes the CodeQL alert at https://github.com/WordPress/presence-api/security/code-scanning/110

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with investigation and drafting the fix