### PR TITLE
ci: sync the "Needs WP.org Link" label from the props-bot comment

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           format: 'svn'
 
-      - name: Sort props
+      - name: Sort props and sync the "Needs WP.org Link" label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PROPS_SORT_LAST: ${{ vars.PROPS_SORT_LAST }}
@@ -157,13 +157,43 @@ jobs:
               );
             }
 
-            if (body === propsComment.body) return;
-            await github.rest.issues.updateComment({
+            if (body !== propsComment.body) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: propsComment.id,
+                body,
+              });
+            }
+
+            // Keep a label in sync with whether anyone here still needs to
+            // link a WordPress.org account, so unlinked PRs are visible
+            // without opening the props comment. This is repo-specific and
+            // not something the upstream props-bot-action does.
+            const LINK_LABEL = 'Needs WP.org Link';
+            const needsLink = body.includes('## Unlinked Accounts');
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: propsComment.id,
-              body,
+              issue_number: context.issue.number,
             });
+            const hasLabel = labels.some(l => l.name === LINK_LABEL);
+
+            if (needsLink && !hasLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [LINK_LABEL],
+              });
+            } else if (!needsLink && hasLabel) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: LINK_LABEL,
+              });
+            }
 
       - name: Remove the props-bot label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           format: 'svn'
 
-      - name: Sort props and sync the "Needs WP.org Link" label
+      - name: Sort props and sync the WP.org link label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PROPS_SORT_LAST: ${{ vars.PROPS_SORT_LAST }}
@@ -172,27 +172,16 @@ jobs:
             // not something the upstream props-bot-action does.
             const LINK_LABEL = 'Needs WP.org Link';
             const needsLink = body.includes('## Unlinked Accounts');
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number });
             const hasLabel = labels.some(l => l.name === LINK_LABEL);
 
             if (needsLink && !hasLabel) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: [LINK_LABEL],
-              });
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [LINK_LABEL] });
             } else if (!needsLink && hasLabel) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: LINK_LABEL,
-              });
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: LINK_LABEL });
             }
 
       - name: Remove the props-bot label


### PR DESCRIPTION
## Summary

Keeps the `Needs WP.org Link` label in sync with whether the props-bot comment still has an `## Unlinked Accounts` section, so unlinked PRs are visible in the PR list without opening each props comment.

The Sort props step already fetches the props comment and already determines whether the Unlinked Accounts section survives its own rewrite, so this reuses that instead of adding a separate step with a second API round-trip. Repo-specific behavior on top of the upstream `props-bot-action`, so it lives here rather than upstream.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with implementation and verifying the label add/remove logic against comment-body fixtures