### PR TITLE
fix: guard the presence table upgrade with a provisioning lock

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -510,6 +510,88 @@ function wp_presence_table_exists() {
 }
 
 /**
+ * Takes an exclusive lock, or reports that another request already holds it.
+ *
+ * Mirrors WP_Upgrader::create_lock(), which core uses to keep its own upgrade
+ * routines from running twice over, in WP_Core_Upgrader::upgrade() and in
+ * WP_Automatic_Updater::run(). The insert is the lock: option_name is unique,
+ * so exactly one concurrent caller can create the row. That also means it holds
+ * on sites with no persistent object cache, where wp_cache_add() is per request
+ * and would coordinate nothing.
+ *
+ * Written out here rather than calling WP_Upgrader::create_lock() so that
+ * provisioning does not have to load the whole upgrader stack on admin_init and
+ * cli_init for the sake of one static method.
+ *
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param string $lock_name       Name of the lock.
+ * @param int    $release_timeout Optional. Seconds after which an unreleased
+ *                                lock is treated as abandoned. Default
+ *                                MINUTE_IN_SECONDS.
+ * @return bool Whether the lock was taken.
+ */
+function wp_presence_create_lock( $lock_name, $release_timeout = null ) {
+	global $wpdb;
+
+	if ( ! $release_timeout ) {
+		$release_timeout = MINUTE_IN_SECONDS;
+	}
+
+	$lock_option = $lock_name . '.lock';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$lock_result = $wpdb->query(
+		$wpdb->prepare(
+			"INSERT IGNORE INTO `$wpdb->options` ( `option_name`, `option_value`, `autoload` ) VALUES (%s, %s, 'off') /* LOCK */",
+			$lock_option,
+			time()
+		)
+	);
+
+	if ( ! $lock_result ) {
+		$lock_result = get_option( $lock_option );
+
+		// No lock and no row to read means the insert failed for another reason.
+		if ( ! $lock_result ) {
+			return false;
+		}
+
+		// Someone else holds it and has not had long enough to be abandoned.
+		if ( $lock_result > ( time() - $release_timeout ) ) {
+			return false;
+		}
+
+		// A request died holding it. Clear it and take it, so one lost request
+		// cannot leave the site unprovisionable.
+		wp_presence_release_lock( $lock_name );
+
+		return wp_presence_create_lock( $lock_name, $release_timeout );
+	}
+
+	// The insert above bypassed the options cache, so bring it back in line.
+	update_option( $lock_option, time(), false );
+
+	return true;
+}
+
+/**
+ * Releases a lock taken by wp_presence_create_lock().
+ *
+ * @access private
+ *
+ * @see wp_presence_create_lock()
+ *
+ * @param string $lock_name Name of the lock.
+ * @return bool Whether the lock was released.
+ */
+function wp_presence_release_lock( $lock_name ) {
+	return delete_option( $lock_name . '.lock' );
+}
+
+/**
  * Creates or updates the presence table if needed.
  *
  * Feature plugin shim — in core, this table would be created by dbDelta()
@@ -530,6 +612,14 @@ function wp_maybe_create_presence_table() {
 	$provisioned = (int) get_option( 'wp_presence_db_version' ) === WP_PRESENCE_DB_VERSION;
 
 	if ( $provisioned && ( wp_doing_ajax() || wp_presence_table_exists() ) ) {
+		return;
+	}
+
+	// admin_init and cli_init have no confirmation step to serialize them the
+	// way wp-admin/upgrade.php does for core, so two requests can arrive here at
+	// once during a version bump. Whoever loses the race returns and lets the
+	// winner finish; the next request repairs anything left over.
+	if ( ! wp_presence_create_lock( 'wp_presence_table' ) ) {
 		return;
 	}
 
@@ -559,6 +649,8 @@ function wp_maybe_create_presence_table() {
 	// Autoloaded explicitly: wp_presence_has_table() reads this on every request
 	// that touches presence, so it must not cost a query.
 	update_option( 'wp_presence_db_version', WP_PRESENCE_DB_VERSION, true );
+
+	wp_presence_release_lock( 'wp_presence_table' );
 }
 
 /**

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -13,6 +13,11 @@
  */
 class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 
+	/**
+	 * The option backing the provisioning lock.
+	 */
+	private const LOCK_OPTION = 'wp_presence_table.lock';
+
 	private static $editor_id;
 
 	/**
@@ -35,6 +40,11 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 
+		// DDL commits the surrounding transaction, so a provisioning lock left
+		// behind by an earlier run survives into this one and would block every
+		// test that provisions. Start from a known-free lock.
+		delete_option( self::LOCK_OPTION );
+
 		// Network options survive the rolled-back transaction, so tests that
 		// pretend the plugin is network active have to put this back by hand.
 		if ( is_multisite() ) {
@@ -54,6 +64,7 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		// DDL commits the surrounding transaction, so clean up by hand. The
 		// truncate itself is handled by the parent tear_down.
 		wp_presence_register_table();
+		delete_option( self::LOCK_OPTION );
 		delete_option( 'wp_presence_db_version' );
 		wp_presence_provision_site();
 
@@ -131,6 +142,79 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
 
 		$this->assertCount( 1, wp_get_presence( 'admin/online' ), 'Presence should work again after the rebuild.' );
+	}
+
+	/**
+	 * Two admin requests can enter provisioning at the same time, and neither
+	 * has a confirmation step to serialize them the way wp-admin/upgrade.php
+	 * does for core. The one that arrives second has to return rather than run
+	 * a second, overlapping dbDelta().
+	 *
+	 * @covers ::wp_maybe_create_presence_table
+	 * @covers ::wp_presence_create_lock
+	 */
+	public function test_a_locked_request_does_not_run_the_schema_change() {
+		$this->drop_presence_table();
+
+		// Stand in for the request that got there first and is still working.
+		$this->assertTrue( wp_presence_create_lock( 'wp_presence_table' ), 'Precondition: the lock starts free.' );
+
+		wp_maybe_create_presence_table();
+
+		$this->assertFalse( $this->presence_table_exists(), 'The second request should not have run dbDelta().' );
+		$this->assertFalse( get_option( 'wp_presence_db_version' ), 'And it should not have claimed the site is provisioned.' );
+	}
+
+	/**
+	 * Holding the lock past the work would block provisioning for every later
+	 * request, which is a worse failure than the race it guards against.
+	 *
+	 * @covers ::wp_maybe_create_presence_table
+	 * @covers ::wp_presence_release_lock
+	 */
+	public function test_provisioning_releases_the_lock_for_the_next_request() {
+		$this->drop_presence_table();
+		wp_maybe_create_presence_table();
+		$this->assertTrue( $this->presence_table_exists(), 'Precondition: the first request provisions.' );
+
+		$this->drop_presence_table();
+		wp_maybe_create_presence_table();
+
+		$this->assertTrue( $this->presence_table_exists(), 'A later request should not be blocked by a lock nobody holds.' );
+	}
+
+	/**
+	 * A request that dies between taking the lock and releasing it would
+	 * otherwise leave the site unprovisionable. Core's upgrader lock reclaims
+	 * on age for the same reason.
+	 *
+	 * @covers ::wp_maybe_create_presence_table
+	 * @covers ::wp_presence_create_lock
+	 */
+	public function test_an_abandoned_lock_stops_blocking_once_it_ages_out() {
+		$this->drop_presence_table();
+
+		// A lock left behind by a request that never got to release it.
+		update_option( self::LOCK_OPTION, time() - ( 2 * MINUTE_IN_SECONDS ), false );
+
+		wp_maybe_create_presence_table();
+
+		$this->assertTrue( $this->presence_table_exists(), 'An expired lock should be reclaimed, not respected forever.' );
+	}
+
+	/**
+	 * The lock has to be exclusive, or it is not a lock.
+	 *
+	 * @covers ::wp_presence_create_lock
+	 * @covers ::wp_presence_release_lock
+	 */
+	public function test_only_one_caller_holds_the_lock_at_a_time() {
+		$this->assertTrue( wp_presence_create_lock( 'wp_presence_table' ), 'The first caller should take the lock.' );
+		$this->assertFalse( wp_presence_create_lock( 'wp_presence_table' ), 'The second should be refused while it is held.' );
+
+		wp_presence_release_lock( 'wp_presence_table' );
+
+		$this->assertTrue( wp_presence_create_lock( 'wp_presence_table' ), 'And it should be free again once released.' );
 	}
 
 	/**


### PR DESCRIPTION
`wp_maybe_create_presence_table()` runs on `admin_init` and `cli_init`. Neither has the manual confirmation step that narrows core's own upgrade routine on `wp-admin/upgrade.php`, so two requests arriving during a version bump could both pass the version check and both run `dbDelta()`.

This takes an exclusive lock before the schema change and releases it after `wp_presence_db_version` is written. The loser of the race returns rather than waiting, and the next request repairs anything left over.

## Why an options row rather than `wp_cache_add()`

`wp_cache_add()` only coordinates across requests on sites running a persistent object cache. Under the default non-persistent cache it is per request, so it would give no protection on exactly the cheap shared hosting #267 is about. The insert relies on the unique index on `option_name` instead, so it holds either way.

## Why inline rather than `WP_Upgrader::create_lock()`

Per the discussion on the issue. The implementation mirrors `WP_Upgrader::create_lock()` (`wp-admin/includes/class-wp-upgrader.php`, since 4.5.0), which core uses for the same purpose in `WP_Core_Upgrader::upgrade()` and `WP_Automatic_Updater::run()`. The second is the closest match, since it runs from cron with no confirmation step at all.

## Abandoned locks

A request that dies between taking the lock and releasing it would otherwise leave the site unprovisionable. The lock is reclaimed once it is older than a minute, the same age based recovery core's lock uses. A minute is short because `dbDelta()` on one table is fast.

## Portability

`INSERT IGNORE` is MySQL syntax, and the plugin cares about the SQLite backend Playground uses for the demo blueprints. The SQLite integration translates `INSERT IGNORE` to `OR IGNORE` and has test coverage for it, so the demos are unaffected.

## Testing

Four tests added to `tests/test-table-creation.php`:

- a request that cannot take the lock does not run `dbDelta()` and does not claim the site is provisioned
- provisioning releases the lock so a later request is not blocked
- a lock older than the timeout is reclaimed rather than respected forever
- the lock is exclusive while held and free after release

The two that are regression guards rather than drivers were checked by mutation: removing the release call fails the second, disabling the age check fails the third.

`set_up()` now clears the lock option. DDL commits the surrounding transaction, so a lock left behind by an earlier run survives into the next one and would block every test that provisions.

Full suite: 190 tests, 424 assertions, 5 skipped (multisite only). PHPCS and PHPStan clean.

Fixes #209

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating core's locking precedent, implementing the lock, and writing the tests. I verified the behavior against a local wp-env install, confirmed each test fails before the change and passes after, mutation checked the two regression guards, and ran the full suite plus PHPCS and PHPStan.
