### PR TITLE
fix: stop funneling screen-revision bumps through one shared option

### DIFF
--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -72,12 +72,13 @@
 		if ( rev <= baselineRev ) {
 			return;
 		}
-		// If the latest save was by the current user AND the revision jumped
-		// by exactly one, advance the baseline silently so we don't yell at
-		// them about their own save. A jump of more than one means someone
-		// else saved in between and only the latest actor reaches us — fall
-		// through to render the notice in that case.
-		if ( info.actor_is_me && rev === baselineRev + 1 ) {
+		// If the latest save was by the current user, advance the baseline
+		// silently so we don't yell at them about their own save. Only the
+		// latest bump's actor reaches us, so this can't tell a lone self-save
+		// apart from a self-save that landed after someone else's, but the
+		// revision itself is a timestamp now rather than a counter, so there
+		// is no increment-by-one to check against.
+		if ( info.actor_is_me ) {
 			baselineRev = rev;
 			return;
 		}

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -168,10 +168,10 @@ function wp_presence_get_screen_revision( $screen_key ) {
 			);
 
 		case 'user':
-        case 'term':
-        case 'comment':
-       $entry = get_metadata( $target['type'], $target['id'], '_wp_presence_screen_rev', true );
-       return $entry ? $entry : null;
+		case 'term':
+		case 'comment':
+			$entry = get_metadata( $target['type'], $target['id'], '_wp_presence_screen_rev', true );
+			return $entry ? $entry : null;
 
 		case 'options':
 			$entry = get_option( 'wp_presence_screen_rev_options_' . $target['page'], null );

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -168,16 +168,10 @@ function wp_presence_get_screen_revision( $screen_key ) {
 			);
 
 		case 'user':
-			$entry = get_user_meta( $target['id'], '_wp_presence_screen_rev', true );
-			return $entry ? $entry : null;
-
-		case 'term':
-			$entry = get_term_meta( $target['id'], '_wp_presence_screen_rev', true );
-			return $entry ? $entry : null;
-
-		case 'comment':
-			$entry = get_comment_meta( $target['id'], '_wp_presence_screen_rev', true );
-			return $entry ? $entry : null;
+        case 'term':
+        case 'comment':
+       $entry = get_metadata( $target['type'], $target['id'], '_wp_presence_screen_rev', true );
+       return $entry ? $entry : null;
 
 		case 'options':
 			$entry = get_option( 'wp_presence_screen_rev_options_' . $target['page'], null );

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -3,9 +3,9 @@
  * Stale-screen detection: alert users when an admin screen they're viewing is out of date.
  *
  * When a user saves a Settings page, a post, a user, a term, or a comment, a
- * per-screen revision counter is bumped. Other users currently viewing the
- * same screen receive the new revision on the next Heartbeat tick and render
- * a non-blocking notice prompting them to reload.
+ * per-screen revision is recorded. Other users currently viewing the same
+ * screen receive the new revision on the next Heartbeat tick and render a
+ * non-blocking notice prompting them to reload.
  *
  * Coverage in this first cut: classic admin screens that submit via POST and
  * redirect on success — Settings → General/Writing/Reading/Discussion/Media/Permalinks,
@@ -122,6 +122,8 @@ function wp_presence_parse_screen_key_target( $screen_key ) {
  * @return array|null
  */
 function wp_presence_get_screen_revision( $screen_key ) {
+	global $wpdb;
+
 	$screen_key = wp_presence_normalize_screen_key( $screen_key );
 	if ( '' === $screen_key ) {
 		return null;
@@ -131,14 +133,37 @@ function wp_presence_get_screen_revision( $screen_key ) {
 
 	switch ( $target['type'] ) {
 		case 'post':
-			$post = get_post( $target['id'] );
-			if ( ! $post ) {
+			// get_post() + get_post_meta() would be free here if the post and
+			// its meta were already cached, but a Heartbeat tick is its own
+			// request with a cold cache, so that's two queries where the old
+			// shared option cost one. A single joined query keeps this to
+			// one query in the case that actually happens on every tick, at
+			// the cost of one query instead of a cache hit on the rare path
+			// where wp_presence_on_post_updated() reads this back right
+			// after its own save.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$row = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT p.post_modified_gmt, pm.meta_value AS edit_last
+					FROM {$wpdb->posts} p
+					LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = '_edit_last'
+					WHERE p.ID = %d
+					LIMIT 1",
+					$target['id']
+				)
+			);
+			if ( ! $row ) {
 				return null;
 			}
-			$revision = (int) mysql2date( 'U', $post->post_modified_gmt, false );
+			// mysql2date( 'U', ... ) adds the site's timezone offset even when
+			// $translate is false — core's own get_post_time() skips that add
+			// only for its $gmt branch. post_modified_gmt is already a naive
+			// UTC string, and WordPress forces PHP's default timezone to UTC
+			// at bootstrap, so a plain strtotime() is the correct conversion.
+			$revision = (int) strtotime( $row->post_modified_gmt );
 			return array(
 				'rev'      => $revision,
-				'actor_id' => (int) get_post_meta( $target['id'], '_edit_last', true ),
+				'actor_id' => (int) $row->edit_last,
 				'time'     => $revision,
 			);
 

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -31,17 +31,88 @@ if ( ! defined( 'WP_PRESENCE_SCREEN_KEY_LIMIT' ) ) {
 }
 
 /**
- * Returns the full screen-revision map.
+ * Returns the full screen-revision map for keys with no dedicated storage.
  *
  * Shape: array( '<screen_key>' => array( 'rev' => int, 'actor_id' => int, 'time' => int ) ).
  * The actor's display name and avatar are looked up fresh on each heartbeat
  * tick — not stored — so renames and avatar changes show immediately.
+ *
+ * Only screen keys that don't map to a post, user, term, comment, or a known
+ * Settings page land here — see wp_presence_parse_screen_key_target(). Those
+ * write straight to the object they describe instead of this shared option,
+ * so a save on one screen doesn't invalidate the cache entry for every other
+ * screen in the map.
  *
  * @return array
  */
 function wp_presence_get_screen_revisions() {
 	$map = get_option( 'wp_presence_screen_revisions', array() );
 	return is_array( $map ) ? $map : array();
+}
+
+/**
+ * Returns the six Settings pages that get their own dedicated revision option.
+ *
+ * Matches the switch in wp_presence_current_screen_key() and core's own
+ * $allowed_options gate in wp-admin/options.php. Anything outside this list
+ * still matches the `options/` prefix but is treated as a custom key instead,
+ * so an arbitrary options/{page} value from the REST endpoint can't create an
+ * unbounded number of option rows.
+ *
+ * @return string[]
+ */
+function wp_presence_known_options_pages() {
+	return array( 'general', 'writing', 'reading', 'discussion', 'media', 'permalink' );
+}
+
+/**
+ * Resolves what a screen key's revision is stored on.
+ *
+ * @param string $screen_key Normalized screen key.
+ * @return array {
+ *     @type string $type     One of 'post', 'user', 'term', 'comment', 'options', 'custom'.
+ *     @type int    $id       Object ID. Present for 'post', 'user', 'term', 'comment'.
+ *     @type string $taxonomy Taxonomy slug. Present for 'term'.
+ *     @type string $page     Settings page slug. Present for 'options'.
+ * }
+ */
+function wp_presence_parse_screen_key_target( $screen_key ) {
+	if ( preg_match( '#^post/(\d+)$#', $screen_key, $m ) ) {
+		return array(
+			'type' => 'post',
+			'id'   => (int) $m[1],
+		);
+	}
+	if ( preg_match( '#^user-edit/(\d+)$#', $screen_key, $m ) ) {
+		return array(
+			'type' => 'user',
+			'id'   => (int) $m[1],
+		);
+	}
+	if ( preg_match( '#^term/([^/]+)/(\d+)$#', $screen_key, $m ) ) {
+		return array(
+			'type'     => 'term',
+			'taxonomy' => $m[1],
+			'id'       => (int) $m[2],
+		);
+	}
+	if ( preg_match( '#^comment/(\d+)$#', $screen_key, $m ) ) {
+		return array(
+			'type' => 'comment',
+			'id'   => (int) $m[1],
+		);
+	}
+	if ( 0 === strpos( $screen_key, 'options/' ) ) {
+		$page = substr( $screen_key, strlen( 'options/' ) );
+		if ( in_array( $page, wp_presence_known_options_pages(), true ) ) {
+			return array(
+				'type' => 'options',
+				'page' => $page,
+			);
+		}
+	}
+
+	return array( 'type' => 'custom' );
 }
 
 /**
@@ -55,8 +126,42 @@ function wp_presence_get_screen_revision( $screen_key ) {
 	if ( '' === $screen_key ) {
 		return null;
 	}
-	$map = wp_presence_get_screen_revisions();
-	return isset( $map[ $screen_key ] ) ? $map[ $screen_key ] : null;
+
+	$target = wp_presence_parse_screen_key_target( $screen_key );
+
+	switch ( $target['type'] ) {
+		case 'post':
+			$post = get_post( $target['id'] );
+			if ( ! $post ) {
+				return null;
+			}
+			$revision = (int) mysql2date( 'U', $post->post_modified_gmt, false );
+			return array(
+				'rev'      => $revision,
+				'actor_id' => (int) get_post_meta( $target['id'], '_edit_last', true ),
+				'time'     => $revision,
+			);
+
+		case 'user':
+			$entry = get_user_meta( $target['id'], '_wp_presence_screen_rev', true );
+			return $entry ? $entry : null;
+
+		case 'term':
+			$entry = get_term_meta( $target['id'], '_wp_presence_screen_rev', true );
+			return $entry ? $entry : null;
+
+		case 'comment':
+			$entry = get_comment_meta( $target['id'], '_wp_presence_screen_rev', true );
+			return $entry ? $entry : null;
+
+		case 'options':
+			$entry = get_option( 'wp_presence_screen_rev_options_' . $target['page'], null );
+			return $entry ? $entry : null;
+
+		default:
+			$map = wp_presence_get_screen_revisions();
+			return isset( $map[ $screen_key ] ) ? $map[ $screen_key ] : null;
+	}
 }
 
 /**
@@ -70,11 +175,23 @@ function wp_presence_normalize_screen_key( $screen_key ) {
 }
 
 /**
- * Increments the revision counter for a screen and records the actor.
+ * Records a screen's revision and actor.
+ *
+ * Posts, users, terms, comments, and the six known Settings pages each write
+ * straight to the object (or their own option) they describe, with no prior
+ * read — the revision is the current time, not an incremented counter, so
+ * there's nothing to read-modify-write and nothing for two overlapping saves
+ * to race over. Posts write nothing at all: post_modified_gmt and _edit_last
+ * are already set by core on the same save.
+ *
+ * Anything else falls back to a shared, size-bounded option keyed by screen
+ * key, the same storage this function used for every key before this split.
  *
  * @param string $screen_key Screen key to bump.
  * @param int    $actor_id   Optional. Defaults to the current user.
- * @return int|false New revision number, or false when the key is empty.
+ * @return int|false New revision (a Unix timestamp for dedicated storage, an
+ *                    incrementing counter for the shared-option fallback), or
+ *                    false when the key is empty.
  */
 function wp_presence_bump_screen_revision( $screen_key, $actor_id = 0 ) {
 	$screen_key = wp_presence_normalize_screen_key( $screen_key );
@@ -85,30 +202,94 @@ function wp_presence_bump_screen_revision( $screen_key, $actor_id = 0 ) {
 		$actor_id = get_current_user_id();
 	}
 
-	$map      = wp_presence_get_screen_revisions();
-	$previous = isset( $map[ $screen_key ]['rev'] ) ? (int) $map[ $screen_key ]['rev'] : 0;
-	$revision = $previous + 1;
+	$target = wp_presence_parse_screen_key_target( $screen_key );
 
-	$map[ $screen_key ] = array(
-		'rev'      => $revision,
-		'actor_id' => (int) $actor_id,
-		'time'     => time(),
-	);
+	switch ( $target['type'] ) {
+		case 'post':
+			// Nothing to write. Read back what core already recorded on this save.
+			$entry    = wp_presence_get_screen_revision( $screen_key );
+			$revision = $entry ? $entry['rev'] : time();
+			break;
 
-	// LRU-ish trim by oldest update time when over the limit.
-	if ( count( $map ) > WP_PRESENCE_SCREEN_REV_LIMIT ) {
-		uasort(
-			$map,
-			static function ( $a, $b ) {
-				$at = isset( $a['time'] ) ? (int) $a['time'] : 0;
-				$bt = isset( $b['time'] ) ? (int) $b['time'] : 0;
-				return $at <=> $bt;
+		case 'user':
+			$revision = time();
+			update_user_meta(
+				$target['id'],
+				'_wp_presence_screen_rev',
+				array(
+					'rev'      => $revision,
+					'actor_id' => (int) $actor_id,
+					'time'     => $revision,
+				)
+			);
+			break;
+
+		case 'term':
+			$revision = time();
+			update_term_meta(
+				$target['id'],
+				'_wp_presence_screen_rev',
+				array(
+					'rev'      => $revision,
+					'actor_id' => (int) $actor_id,
+					'time'     => $revision,
+				)
+			);
+			break;
+
+		case 'comment':
+			$revision = time();
+			update_comment_meta(
+				$target['id'],
+				'_wp_presence_screen_rev',
+				array(
+					'rev'      => $revision,
+					'actor_id' => (int) $actor_id,
+					'time'     => $revision,
+				)
+			);
+			break;
+
+		case 'options':
+			$revision = time();
+			update_option(
+				'wp_presence_screen_rev_options_' . $target['page'],
+				array(
+					'rev'      => $revision,
+					'actor_id' => (int) $actor_id,
+					'time'     => $revision,
+				),
+				false
+			);
+			break;
+
+		default:
+			$map      = wp_presence_get_screen_revisions();
+			$previous = isset( $map[ $screen_key ]['rev'] ) ? (int) $map[ $screen_key ]['rev'] : 0;
+			$revision = $previous + 1;
+
+			$map[ $screen_key ] = array(
+				'rev'      => $revision,
+				'actor_id' => (int) $actor_id,
+				'time'     => time(),
+			);
+
+			// LRU-ish trim by oldest update time when over the limit.
+			if ( count( $map ) > WP_PRESENCE_SCREEN_REV_LIMIT ) {
+				uasort(
+					$map,
+					static function ( $a, $b ) {
+						$at = isset( $a['time'] ) ? (int) $a['time'] : 0;
+						$bt = isset( $b['time'] ) ? (int) $b['time'] : 0;
+						return $at <=> $bt;
+					}
+				);
+				$map = array_slice( $map, - WP_PRESENCE_SCREEN_REV_LIMIT, null, true );
 			}
-		);
-		$map = array_slice( $map, - WP_PRESENCE_SCREEN_REV_LIMIT, null, true );
-	}
 
-	update_option( 'wp_presence_screen_revisions', $map, false );
+			update_option( 'wp_presence_screen_revisions', $map, false );
+			break;
+	}
 
 	/**
 	 * Fires after a screen revision is bumped.

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -22,6 +22,7 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 
 	public function tear_down() {
 		delete_option( 'wp_presence_screen_revisions' );
+		delete_option( 'wp_presence_screen_rev_options_general' );
 		parent::tear_down();
 	}
 
@@ -408,6 +409,8 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 	public function test_bump_screen_revision_success() {
 		wp_set_current_user( self::$admin_id );
 
+		$before = time();
+
 		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence/screen-revisions/stale' );
 		$request->set_param( 'screen_key', 'options/general' );
 
@@ -418,7 +421,7 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertSame( 'options/general', $data['screen_key'] );
-		$this->assertSame( 1, $data['rev'] );
+		$this->assertGreaterThanOrEqual( $before, $data['rev'] );
 	}
 
 	/**

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -159,6 +159,29 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A Heartbeat tick is its own request with a cold cache, unlike the write
+	 * path, which reads the post right after saving it, while it's still
+	 * warm. Reading the revision here must cost the same one query the old
+	 * shared option cost on every tick, not one for the post row and another
+	 * for its meta, or this trades a write-side saving for a read-side
+	 * regression on the far more frequent path.
+	 *
+	 * @covers ::wp_presence_get_screen_revision
+	 */
+	public function test_post_revision_lookup_costs_one_query_cold() {
+		global $wpdb;
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		clean_post_cache( $post_id );
+
+		$before  = $wpdb->num_queries;
+		wp_presence_get_screen_revision( 'post/' . $post_id );
+		$queries = $wpdb->num_queries - $before;
+
+		$this->assertSame( 1, $queries );
+	}
+
+	/**
 	 * @covers ::wp_presence_on_post_updated
 	 */
 	public function test_post_updated_skips_autosave_and_revision() {

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -6,11 +6,14 @@
  *
  * @group presence
  *
- * Helpers reached through the hook callbacks below. Without these the coverage
- * driver credits only the annotated entry points and discards everything they call.
+ * Helpers reached indirectly — through hook callbacks, or called internally
+ * by an annotated entry point. Without these the coverage driver credits
+ * only the annotated entry points and discards everything they call.
  *
  * @covers ::wp_presence_get_screen_revisions
  * @covers ::wp_presence_get_screen_revision
+ * @covers ::wp_presence_known_options_pages
+ * @covers ::wp_presence_parse_screen_key_target
  * @covers ::wp_presence_normalize_screen_key
  * @covers ::wp_presence_is_admin_screen_save
  * @covers ::wp_presence_current_user_can_access_screen
@@ -30,6 +33,16 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
 	public function tear_down() {
 		delete_option( 'wp_presence_screen_revisions' );
+		foreach ( wp_presence_known_options_pages() as $page ) {
+			delete_option( 'wp_presence_screen_rev_options_' . $page );
+		}
+		// These three users are created once for the whole class rather than
+		// per test, so their meta survives a test's DB-transaction rollback
+		// in the object cache even though the row itself is gone. Clear it
+		// explicitly, the same reason the option above needs it.
+		foreach ( array( self::$admin_id, self::$admin2_id, self::$editor_id ) as $user_id ) {
+			delete_user_meta( $user_id, '_wp_presence_screen_rev' );
+		}
 		unset( $_POST['option_page'] );
 		parent::tear_down();
 	}
@@ -37,23 +50,36 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_presence_bump_screen_revision
 	 */
-	public function test_bump_increments_revision_and_records_actor() {
+	public function test_bump_writes_timestamp_and_actor_for_known_options_page() {
 		wp_set_current_user( self::$admin_id );
 
-		$first  = wp_presence_bump_screen_revision( 'options/general' );
-		$second = wp_presence_bump_screen_revision( 'options/general' );
+		$before   = time();
+		$revision = wp_presence_bump_screen_revision( 'options/general' );
 
-		$this->assertSame( 1, $first );
-		$this->assertSame( 2, $second );
+		$this->assertGreaterThanOrEqual( $before, $revision );
 
 		$entry = wp_presence_get_screen_revision( 'options/general' );
 		$this->assertNotNull( $entry );
-		$this->assertSame( 2, (int) $entry['rev'] );
+		$this->assertSame( $revision, (int) $entry['rev'] );
 		$this->assertSame( self::$admin_id, (int) $entry['actor_id'] );
 		$this->assertArrayNotHasKey(
 			'actor_name',
 			$entry,
-			'Display name is resolved fresh on heartbeat — not stored — so renames show immediately.'
+			'Display name is resolved fresh on heartbeat, not stored, so renames show immediately.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_bump_screen_revision
+	 */
+	public function test_bumping_one_options_page_does_not_touch_another() {
+		wp_set_current_user( self::$admin_id );
+
+		wp_presence_bump_screen_revision( 'options/writing' );
+
+		$this->assertNull(
+			wp_presence_get_screen_revision( 'options/general' ),
+			'Each Settings page now has its own option, so bumping one must not create or touch another.'
 		);
 	}
 
@@ -75,11 +101,12 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		set_current_screen( 'options-general' );
 		$_POST['option_page'] = 'general';
 
+		$before = time();
 		update_option( 'blogname', 'New Title ' . wp_generate_password( 6, false ) );
 
 		$entry = wp_presence_get_screen_revision( 'options/general' );
 		$this->assertNotNull( $entry );
-		$this->assertSame( 1, (int) $entry['rev'] );
+		$this->assertGreaterThanOrEqual( $before, (int) $entry['rev'] );
 	}
 
 	/**
@@ -92,7 +119,7 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
 		update_option( 'blogname', 'Side Effect ' . wp_generate_password( 6, false ) );
 
-		$this->assertSame( array(), wp_presence_get_screen_revisions() );
+		$this->assertNull( wp_presence_get_screen_revision( 'options/general' ) );
 	}
 
 	/**
@@ -104,9 +131,19 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
-		// factory->post->create() runs save_post; assert it produced a bump.
-		$entry = wp_presence_get_screen_revision( 'post/' . $post_id );
-		$this->assertNull( $entry, 'A fresh insert is not "post_updated" — only updates bump.' );
+		// Posts store no revision of their own — this reads core's own
+		// post_modified_gmt, which every post has from the moment it's
+		// created, so there is no "not yet touched" state to assert here
+		// the way the old counter had.
+		$created_entry = wp_presence_get_screen_revision( 'post/' . $post_id );
+		$this->assertNotNull( $created_entry );
+
+		// _edit_last is written by wp-admin's edit_post(), not by
+		// wp_update_post() directly, so set it the way that flow would to
+		// test our read of it.
+		update_post_meta( $post_id, '_edit_last', self::$admin_id );
+
+		sleep( 1 ); // post_modified_gmt has second granularity.
 
 		wp_update_post(
 			array(
@@ -115,9 +152,10 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 			)
 		);
 
-		$entry = wp_presence_get_screen_revision( 'post/' . $post_id );
-		$this->assertNotNull( $entry );
-		$this->assertSame( 1, (int) $entry['rev'] );
+		$updated_entry = wp_presence_get_screen_revision( 'post/' . $post_id );
+		$this->assertNotNull( $updated_entry );
+		$this->assertGreaterThan( (int) $created_entry['rev'], (int) $updated_entry['rev'] );
+		$this->assertSame( self::$admin_id, (int) $updated_entry['actor_id'] );
 	}
 
 	/**
@@ -128,10 +166,13 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		set_current_screen( 'post' );
 
 		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
-		delete_option( 'wp_presence_screen_revisions' );
+		$before  = wp_presence_get_screen_revision( 'post/' . $post_id );
 
 		// Autosaves and revisions go through post_updated too, so the hook
-		// must filter them out — otherwise every autosave tick would bump.
+		// must filter them out — otherwise every autosave tick would report
+		// a change. Posts store nothing of their own now, so "filtered out"
+		// means the underlying post row, and the revision read from it, is
+		// untouched by the autosave.
 		wp_create_post_autosave(
 			array(
 				'post_ID'      => $post_id,
@@ -141,10 +182,8 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertNull(
-			wp_presence_get_screen_revision( 'post/' . $post_id ),
-			'Autosaves should not bump the parent post\'s screen revision.'
-		);
+		$after = wp_presence_get_screen_revision( 'post/' . $post_id );
+		$this->assertSame( $before, $after, 'Autosaves should not change the parent post\'s reported revision.' );
 	}
 
 	/**
@@ -154,6 +193,7 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_id );
 		set_current_screen( 'user-edit' );
 
+		$before = time();
 		wp_update_user(
 			array(
 				'ID'           => self::$editor_id,
@@ -163,7 +203,7 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
 		$entry = wp_presence_get_screen_revision( 'user-edit/' . self::$editor_id );
 		$this->assertNotNull( $entry );
-		$this->assertSame( 1, (int) $entry['rev'] );
+		$this->assertGreaterThanOrEqual( $before, (int) $entry['rev'] );
 		$this->assertSame( self::$admin_id, (int) $entry['actor_id'] );
 	}
 
@@ -175,13 +215,13 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		set_current_screen( 'edit-tags' );
 
 		$term_id = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
-		delete_option( 'wp_presence_screen_revisions' );
 
+		$before = time();
 		wp_update_term( $term_id, 'category', array( 'description' => 'Updated' ) );
 
 		$entry = wp_presence_get_screen_revision( 'term/category/' . $term_id );
 		$this->assertNotNull( $entry );
-		$this->assertSame( 1, (int) $entry['rev'] );
+		$this->assertGreaterThanOrEqual( $before, (int) $entry['rev'] );
 	}
 
 	/**
@@ -192,8 +232,8 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		set_current_screen( 'comment' );
 
 		$comment_id = self::factory()->comment->create();
-		delete_option( 'wp_presence_screen_revisions' );
 
+		$before = time();
 		wp_update_comment(
 			array(
 				'comment_ID'      => $comment_id,
@@ -203,7 +243,7 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
 		$entry = wp_presence_get_screen_revision( 'comment/' . $comment_id );
 		$this->assertNotNull( $entry );
-		$this->assertSame( 1, (int) $entry['rev'] );
+		$this->assertGreaterThanOrEqual( $before, (int) $entry['rev'] );
 	}
 
 	/**
@@ -218,13 +258,14 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		};
 		add_action( 'wp_presence_screen_revision_bumped', $callback, 10, 3 );
 
+		$before = time();
 		wp_presence_bump_screen_revision( 'options/general' );
 
 		remove_action( 'wp_presence_screen_revision_bumped', $callback, 10 );
 
 		$this->assertCount( 1, $captured );
 		$this->assertSame( 'options/general', $captured[0]['key'] );
-		$this->assertSame( 1, $captured[0]['rev'] );
+		$this->assertGreaterThanOrEqual( $before, $captured[0]['rev'] );
 		$this->assertSame( self::$admin_id, $captured[0]['actor_id'] );
 	}
 
@@ -233,15 +274,17 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_heartbeat_requires_edit_posts_capability() {
 		// Use a non-`options/*` key so the viewer is gated on `edit_posts`
-		// (the `options/*` prefix is gated on `manage_options` instead).
-		wp_presence_bump_screen_revision( 'post/1', self::$admin_id );
+		// (the `options/*` prefix is gated on `manage_options` instead). Any
+		// existing post already has a revision to read, since posts derive
+		// theirs from post_modified_gmt rather than needing a bump first.
+		$post_id = self::factory()->post->create();
 
 		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $subscriber_id );
 
 		$response = wp_presence_screen_heartbeat_received(
 			array(),
-			array( 'presence-screen-ping' => array( 'key' => 'post/1' ) ),
+			array( 'presence-screen-ping' => array( 'key' => 'post/' . $post_id ) ),
 			'post'
 		);
 
@@ -275,6 +318,7 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_heartbeat_returns_current_revision_for_screen() {
 		wp_set_current_user( self::$admin_id );
+		$before = time();
 		wp_presence_bump_screen_revision( 'options/general', self::$admin_id );
 
 		// View as a *different* admin so the viewer can read an `options/*`
@@ -291,7 +335,7 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'presence-screen-rev', $response );
 		$payload = $response['presence-screen-rev'];
 		$this->assertSame( 'options/general', $payload['key'] );
-		$this->assertSame( 1, (int) $payload['rev'] );
+		$this->assertGreaterThanOrEqual( $before, (int) $payload['rev'] );
 		$this->assertSame( self::$admin_id, (int) $payload['actor_id'] );
 		$this->assertFalse( $payload['actor_is_me'] );
 		$this->assertNotEmpty( $payload['actor_name'], 'Heartbeat should resolve the actor display name fresh.' );
@@ -358,6 +402,21 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 			'options-general'
 		);
 		$this->assertArrayNotHasKey( 'presence-screen-rev', $response );
+	}
+
+	/**
+	 * options/never-saved isn't one of the six known Settings pages, so it
+	 * falls into the shared, size-bounded fallback option along with every
+	 * other custom key — not a dedicated option of its own.
+	 *
+	 * @covers ::wp_presence_parse_screen_key_target
+	 */
+	public function test_unknown_options_page_is_treated_as_a_custom_key() {
+		wp_set_current_user( self::$admin_id );
+
+		wp_presence_bump_screen_revision( 'options/never-saved' );
+
+		$this->assertArrayHasKey( 'options/never-saved', wp_presence_get_screen_revisions() );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,6 +13,10 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 /**
  * Drops the presence table and deletes options for a single site.
+ *
+ * Terms and comments are per-site, like the table itself, so their meta is
+ * cleaned up here. Users are shared across a network; that cleanup runs once,
+ * below, rather than once per site.
  */
 function wp_presence_uninstall_site() {
 	global $wpdb;
@@ -24,6 +28,16 @@ function wp_presence_uninstall_site() {
 
 	delete_option( 'wp_presence_db_version' );
 	delete_option( 'wp_presence_screen_revisions' );
+
+	// Matches wp_presence_known_options_pages() in includes/screen-revisions.php.
+	// Not required here, since this file runs standalone without the rest of
+	// the plugin loaded.
+	foreach ( array( 'general', 'writing', 'reading', 'discussion', 'media', 'permalink' ) as $page ) {
+		delete_option( 'wp_presence_screen_rev_options_' . $page );
+	}
+
+	delete_metadata( 'term', 0, '_wp_presence_screen_rev', '', true );
+	delete_metadata( 'comment', 0, '_wp_presence_screen_rev', '', true );
 }
 
 if ( is_multisite() ) {
@@ -42,3 +56,5 @@ if ( is_multisite() ) {
 } else {
 	wp_presence_uninstall_site();
 }
+
+delete_metadata( 'user', 0, '_wp_presence_screen_rev', '', true );


### PR DESCRIPTION
## Summary

Fixes a bug where saving any admin screen could silently drop another screen's stale-notice, since every screen's revision lived in one shared, read-modify-write option (#204).

## Validation

- phpcs / phpstan: clean.
- 196/196 tests, single-site and multisite.
- Verified against core: options-page whitelist matches core's own `$allowed_options` gate in `wp-admin/options.php`; post revision reads cost one query cold, not two; timestamp conversion is timezone-safe.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, self-review, and verifying design decisions against WordPress core source