### PR TITLE
chore: drop the YouTube demo link, lead with Playground instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ WordPress has no way to know who is logged in, what screen they are on, or which
 
 > "This idea of presence I think is really cool and seeing where people are... you log into your WordPress, I see oh Matias is moderating some comments, Lynn is on the dashboard maybe reading some news... that idea of like you log in and you can kind of see the neighborhood of like who else is also there." — [Matt Mullenweg, WordPress 7.0 planning session](https://youtu.be/F-xMPY9WqG4?si=YK0rIUM2nuYy7x45&t=2435)
 
-[![Watch the demo on YouTube](https://img.youtube.com/vi/Xa5WkZdjBD4/maxresdefault.jpg)](https://youtu.be/Xa5WkZdjBD4)
-
-▶ [Watch the demo on YouTube](https://youtu.be/Xa5WkZdjBD4) (no audio)
-
 ## Try it
 
 [![Open in WordPress Playground](https://img.shields.io/badge/Open%20in-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Presence API
 
 [![CI](https://github.com/WordPress/presence-api/actions/workflows/ci.yml/badge.svg)](https://github.com/WordPress/presence-api/actions/workflows/ci.yml)
+[![Open in WordPress Playground](https://img.shields.io/badge/Open%20in-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json)
 
 > **Status:** Experimental feature plugin
 
@@ -12,11 +13,7 @@ WordPress has no way to know who is logged in, what screen they are on, or which
 
 > "This idea of presence I think is really cool and seeing where people are... you log into your WordPress, I see oh Matias is moderating some comments, Lynn is on the dashboard maybe reading some news... that idea of like you log in and you can kind of see the neighborhood of like who else is also there." — [Matt Mullenweg, WordPress 7.0 planning session](https://youtu.be/F-xMPY9WqG4?si=YK0rIUM2nuYy7x45&t=2435)
 
-## Try it
-
-[![Open in WordPress Playground](https://img.shields.io/badge/Open%20in-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json)
-
-Or run locally:
+## Run locally
 
 ```bash
 npm install

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,8 @@ Presence API gives WordPress a system-wide awareness layer. It tracks which user
 
 Data flows through the Heartbeat API and is stored in a dedicated `wp_presence` table with a 60-second TTL. No writes to `wp_postmeta` means no post-cache invalidation on every heartbeat.
 
+[Test in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json) without installing anything.
+
 = Features =
 
 * Who's Online dashboard widget with idle detection
@@ -24,12 +26,6 @@ Data flows through the Heartbeat API and is stored in a dedicated `wp_presence` 
 * Admin bar indicator showing other users on the same page
 * Editors column in the post list
 * Online filter in the Users list
-
-= Try it =
-
-[Test in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json) without installing anything.
-
-[Watch the demo on YouTube](https://youtu.be/Xa5WkZdjBD4)
 
 = For Developers =
 


### PR DESCRIPTION
The Playground badge already lets people try it live instead of just watching it, so it's now the top call-to-action instead of a video link buried below the fold.