### PR TITLE
perf: skip Who's Online payload when room state is unchanged

### DIFF
--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -733,7 +733,58 @@ JS,
 		}
 
 		$entries = wp_get_presence( wp_presence_admin_room() );
-		$online  = array();
+		$hash    = self::hash_online_state( $entries );
+
+		$client_hash = isset( $data['presence-online-hash'] ) ? sanitize_text_field( $data['presence-online-hash'] ) : '';
+
+		if ( $client_hash && $client_hash === $hash ) {
+			$response['presence-online-unchanged'] = true;
+
+			return $response;
+		}
+
+		$response['presence-online']      = self::build_online_entries( $entries );
+		$response['presence-online-hash'] = $hash;
+
+		return $response;
+	}
+
+	/**
+	 * Hashes the meaningful state of a room's presence entries.
+	 *
+	 * Excludes date_gmt, which every tick rewrites for the pinging user and so
+	 * would flip the hash on every tick.
+	 *
+	 * @param array $entries Presence entry objects from wp_get_presence().
+	 * @return string The state hash.
+	 */
+	private static function hash_online_state( $entries ) {
+		$state = array();
+
+		foreach ( $entries as $entry ) {
+			$state[] = array(
+				(int) $entry->user_id,
+				isset( $entry->data['screen'] ) ? $entry->data['screen'] : '',
+				isset( $entry->data['post_status'] ) ? $entry->data['post_status'] : '',
+				isset( $entry->data['title'] ) ? $entry->data['title'] : '',
+				isset( $entry->data['post_id'] ) ? (int) $entry->data['post_id'] : 0,
+			);
+		}
+
+		// wp_get_presence() orders by date_gmt, which reshuffles as clients ping.
+		sort( $state );
+
+		return md5( (string) wp_json_encode( $state ) );
+	}
+
+	/**
+	 * Builds the structured presence payload for a room's entries.
+	 *
+	 * @param array $entries Presence entry objects from wp_get_presence().
+	 * @return array Presence data for client consumption.
+	 */
+	private static function build_online_entries( $entries ) {
+		$online = array();
 
 		cache_users( wp_list_pluck( $entries, 'user_id' ) );
 
@@ -763,8 +814,6 @@ JS,
 			);
 		}
 
-		$response['presence-online'] = $online;
-
-		return $response;
+		return $online;
 	}
 }

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -336,6 +336,7 @@ class WP_Presence_Widget_Whos_Online {
 	var isExpanded = false;
 	var lastSignature = '';
 	var lastEntries = [];
+	var lastHash = '';
 
 	function captureFocus(container) {
 		var active = document.activeElement;
@@ -443,11 +444,30 @@ class WP_Presence_Widget_Whos_Online {
 		return html;
 	}
 
+	$(document).on('heartbeat-send', function(event, data) {
+		if (lastHash) {
+			data['presence-online-hash'] = lastHash;
+		}
+	});
+
 	// Update the widget when heartbeat response comes back.
 	$(document).on('heartbeat-tick', function(event, data) {
+		if (data['presence-online-unchanged']) {
+			// An unchanged room means every cached entry is still ticking, so
+			// advance the timestamps the idle sweep reads or it greys out users
+			// who are still here.
+			var nowGmt = new Date().toISOString().slice(0, 19).replace('T', ' ');
+			for (var i = 0; i < lastEntries.length; i++) {
+				lastEntries[i].date_gmt = nowGmt;
+			}
+			return;
+		}
+
 		if (!data['presence-online']) {
 			return;
 		}
+
+		lastHash = data['presence-online-hash'] || '';
 
 		var container = $('#presence-whos-online-list');
 		if (!container.length) {

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -453,8 +453,8 @@ class WP_Presence_Widget_Whos_Online {
 	// Update the widget when heartbeat response comes back.
 	$(document).on('heartbeat-tick', function(event, data) {
 		if (data['presence-online-unchanged']) {
-			// Same users on the same screens, so only freshness can have moved.
-			// Feed it to the idle sweep and leave the DOM alone.
+			// Only freshness can have moved, so feed the idle sweep and leave
+			// the DOM alone.
 			var seen = data['presence-online-unchanged'];
 			for (var i = 0; i < lastEntries.length; i++) {
 				if (seen[lastEntries[i].user_id]) {
@@ -729,9 +729,8 @@ JS,
 	/**
 	 * Handles the heartbeat received event for presence updates.
 	 *
-	 * Returns structured presence data for every user in the room. Returns
-	 * avatar URLs and timestamps rather than pre-rendered HTML, allowing
-	 * clients to render as needed.
+	 * Returns avatar URLs and timestamps rather than pre-rendered HTML, or only
+	 * last-seen times when the client's hash still matches the room.
 	 *
 	 * The current user's own entry is written by
 	 * wp_presence_admin_heartbeat_received(), which runs at an earlier
@@ -801,10 +800,8 @@ JS,
 	/**
 	 * Maps each present user to the time they were last seen.
 	 *
-	 * Sent instead of the full payload when the room is unchanged. Without it
-	 * the client has no way to tell a user who is still ticking from one whose
-	 * tab went hidden, and would keep showing the latter as active until their
-	 * entry expires.
+	 * Replaces the full payload when the room is unchanged, so the client can
+	 * still tell a user who is ticking from one whose tab went hidden.
 	 *
 	 * @param array $entries Presence entry objects from wp_get_presence().
 	 * @return object User ID to last-seen GMT datetime.

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -453,12 +453,13 @@ class WP_Presence_Widget_Whos_Online {
 	// Update the widget when heartbeat response comes back.
 	$(document).on('heartbeat-tick', function(event, data) {
 		if (data['presence-online-unchanged']) {
-			// An unchanged room means every cached entry is still ticking, so
-			// advance the timestamps the idle sweep reads or it greys out users
-			// who are still here.
-			var nowGmt = new Date().toISOString().slice(0, 19).replace('T', ' ');
+			// Same users on the same screens, so only freshness can have moved.
+			// Feed it to the idle sweep and leave the DOM alone.
+			var seen = data['presence-online-unchanged'];
 			for (var i = 0; i < lastEntries.length; i++) {
-				lastEntries[i].date_gmt = nowGmt;
+				if (seen[lastEntries[i].user_id]) {
+					lastEntries[i].date_gmt = seen[lastEntries[i].user_id];
+				}
 			}
 			return;
 		}
@@ -758,7 +759,7 @@ JS,
 		$client_hash = isset( $data['presence-online-hash'] ) ? sanitize_text_field( $data['presence-online-hash'] ) : '';
 
 		if ( $client_hash && $client_hash === $hash ) {
-			$response['presence-online-unchanged'] = true;
+			$response['presence-online-unchanged'] = self::build_seen_timestamps( $entries );
 
 			return $response;
 		}
@@ -795,6 +796,28 @@ JS,
 		sort( $state );
 
 		return md5( (string) wp_json_encode( $state ) );
+	}
+
+	/**
+	 * Maps each present user to the time they were last seen.
+	 *
+	 * Sent instead of the full payload when the room is unchanged. Without it
+	 * the client has no way to tell a user who is still ticking from one whose
+	 * tab went hidden, and would keep showing the latter as active until their
+	 * entry expires.
+	 *
+	 * @param array $entries Presence entry objects from wp_get_presence().
+	 * @return object User ID to last-seen GMT datetime.
+	 */
+	private static function build_seen_timestamps( $entries ) {
+		$seen = array();
+
+		foreach ( $entries as $entry ) {
+			$seen[ (int) $entry->user_id ] = $entry->date_gmt;
+		}
+
+		// Cast so an empty room encodes as {} rather than [].
+		return (object) $seen;
 	}
 
 	/**

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -141,8 +141,8 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	}
 
 	/**
-	 * The unchanged reply is the only thing keeping the idle dots honest, so it
-	 * has to carry each user's real last-seen time rather than a bare flag.
+	 * The unchanged reply is all that keeps the idle dots honest, so it has to
+	 * carry real last-seen times rather than a bare flag.
 	 *
 	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
 	 */

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -20,15 +20,51 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	 * Sends a ping through the write handler, then the widget's read handler,
 	 * mirroring the priority order they are registered at on heartbeat_received.
 	 *
-	 * @param array $ping The presence-ping payload.
+	 * @param array $ping  The presence-ping payload.
+	 * @param array $extra Additional top-level Heartbeat data keys.
 	 * @return array The Heartbeat response.
 	 */
-	private function tick( $ping = array( 'screen' => 'dashboard' ) ) {
-		$data = array( 'presence-ping' => $ping );
+	private function tick( $ping = array( 'screen' => 'dashboard' ), $extra = array() ) {
+		$data = array_merge( array( 'presence-ping' => $ping ), $extra );
 
 		wp_presence_admin_heartbeat_received( array(), $data, 'dashboard' );
 
 		return WP_Presence_Widget_Whos_Online::heartbeat_received( array(), $data, 'dashboard' );
+	}
+
+	/**
+	 * Adds another user to the admin room with an explicit age.
+	 *
+	 * @param string $screen      The screen slug to record.
+	 * @param int    $seconds_ago How far in the past to date the entry.
+	 * @return int The new user's ID.
+	 */
+	private function add_user_to_room( $screen, $seconds_ago ) {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( wp_presence_admin_room(), 'user-' . $user_id, array( 'screen' => $screen ), $user_id );
+
+		$this->age_entry( $user_id, $seconds_ago );
+
+		return $user_id;
+	}
+
+	/**
+	 * Backdates a user's entry, which is what wp_get_presence() orders by.
+	 *
+	 * @param int $user_id     The user whose entry to backdate.
+	 * @param int $seconds_ago How far in the past to date the entry.
+	 */
+	private function age_entry( $user_id, $seconds_ago ) {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - $seconds_ago ) ),
+			array( 'client_id' => 'user-' . $user_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
 	}
 
 	/**
@@ -76,6 +112,102 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 		// date_gmt should be a datetime string, not pre-formatted.
 		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $entry['date_gmt'] );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_heartbeat_returns_state_hash_alongside_payload() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->tick();
+
+		$this->assertArrayHasKey( 'presence-online-hash', $response );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $response['presence-online-hash'] );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_heartbeat_skips_payload_when_hash_matches() {
+		wp_set_current_user( self::$editor_id );
+
+		$hash = $this->tick()['presence-online-hash'];
+
+		$response = $this->tick( array( 'screen' => 'dashboard' ), array( 'presence-online-hash' => $hash ) );
+
+		$this->assertTrue( $response['presence-online-unchanged'] );
+		$this->assertArrayNotHasKey( 'presence-online', $response );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_heartbeat_returns_payload_when_hash_is_stale() {
+		wp_set_current_user( self::$editor_id );
+
+		$this->tick();
+
+		$response = $this->tick( array( 'screen' => 'dashboard' ), array( 'presence-online-hash' => 'stale' ) );
+
+		$this->assertArrayHasKey( 'presence-online', $response );
+		$this->assertArrayNotHasKey( 'presence-online-unchanged', $response );
+	}
+
+	/**
+	 * The optimization is worthless if the hash moves on its own: every tick
+	 * rewrites the pinging user's timestamp, and wp_get_presence() orders by it.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_hash_is_stable_when_only_timestamps_change() {
+		$older = $this->add_user_to_room( 'edit', 20 );
+		$this->add_user_to_room( 'upload', 10 );
+
+		wp_set_current_user( self::$editor_id );
+
+		$first = $this->tick()['presence-online-hash'];
+
+		// Overtake the other entry, flipping the order the rows come back in.
+		$this->age_entry( $older, 5 );
+
+		$second = $this->tick()['presence-online-hash'];
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_hash_changes_when_a_users_screen_changes() {
+		$other_id = $this->add_user_to_room( 'edit', 10 );
+
+		wp_set_current_user( self::$editor_id );
+
+		$first = $this->tick()['presence-online-hash'];
+
+		wp_set_presence( wp_presence_admin_room(), 'user-' . $other_id, array( 'screen' => 'upload' ), $other_id );
+
+		$second = $this->tick()['presence-online-hash'];
+
+		$this->assertNotSame( $first, $second );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_hash_changes_when_a_user_leaves() {
+		$other_id = $this->add_user_to_room( 'edit', 10 );
+
+		wp_set_current_user( self::$editor_id );
+
+		$first = $this->tick()['presence-online-hash'];
+
+		wp_remove_presence( wp_presence_admin_room(), 'user-' . $other_id );
+
+		$second = $this->tick()['presence-online-hash'];
+
+		$this->assertNotSame( $first, $second );
 	}
 
 	/**

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -136,8 +136,35 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 		$response = $this->tick( array( 'screen' => 'dashboard' ), array( 'presence-online-hash' => $hash ) );
 
-		$this->assertTrue( $response['presence-online-unchanged'] );
+		$this->assertArrayHasKey( 'presence-online-unchanged', $response );
 		$this->assertArrayNotHasKey( 'presence-online', $response );
+	}
+
+	/**
+	 * The unchanged reply is the only thing keeping the idle dots honest, so it
+	 * has to carry each user's real last-seen time rather than a bare flag.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_unchanged_response_carries_last_seen_timestamps() {
+		$idle_id = $this->add_user_to_room( 'dashboard', 40 );
+
+		wp_set_current_user( self::$editor_id );
+
+		$hash = $this->tick()['presence-online-hash'];
+
+		$seen = $this->tick( array( 'screen' => 'dashboard' ), array( 'presence-online-hash' => $hash ) )['presence-online-unchanged'];
+
+		$this->assertSame(
+			gmdate( 'Y-m-d H:i:s', time() - 40 ),
+			$seen->{$idle_id},
+			'A user who stopped pinging must keep their stale timestamp.'
+		);
+		$this->assertSame(
+			gmdate( 'Y-m-d H:i:s' ),
+			$seen->{self::$editor_id},
+			'The pinging user must be reported as current.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description

Closes #268.

Server hashes the room's meaningful state; the client echoes its last hash. On a match the response carries last-seen timestamps instead of the payload, skipping `cache_users()`, per-user `get_userdata()` / `get_avatar_url()`, label building, and most of the JSON.

### Review notes

- The unchanged reply carries a `user_id → last-seen` map, not a bare flag: the hash excludes `date_gmt` (it would flip every tick), so a flag alone breaks the idle dot for backgrounded tabs. Verified the dot still greys at 30s and clears at 60s, matching `main`.
- Display names and avatars aren't on the presence row, so profile changes won't reach other widgets until room state changes for another reason.

### Testing

1. Log in as two users - admin in a normal window, an editor in an incognito window - both on the Dashboard. Position the windows side by side so neither covers the other; a fully covered window reports itself hidden and stops pinging, which invalidates the test.
2. Confirm the editor appears in the admin's Who's Online widget with a solid green dot.
3. In the admin window, open DevTools → Network and filter `admin-ajax` (presence rides WordPress's Heartbeat; it has no endpoint of its own). After the first tick, responses should carry `presence-online-unchanged` with a `user_id → last-seen` map instead of the full `presence-online` array, and drop noticeably in size.
4. In the editor window, switch to a second tab so the Dashboard is backgrounded. Leave it open - closing it deletes the presence entry and tests nothing.
5. Watch the editor's row in the admin window. The dot should turn grey at ~30s and the row should clear at ~60s - identical to `main` - while the admin's responses keep coming back as `presence-online-unchanged`.

### Out of scope

`heartbeat_received()` runs on every admin screen but only the Dashboard consumes the data - off-Dashboard ticks still build an unread payload and can't be hash-suppressed. Will be raising a issue for this.

### Measurement

To follow

### Screenshots

<img width="1512" height="734" alt="image" src="https://github.com/user-attachments/assets/9cc0cb69-cd4f-4dd9-8faa-795864261113" />

<img width="1512" height="810" alt="image" src="https://github.com/user-attachments/assets/05096042-746f-429b-ab80-914ed921ceb7" />

<img width="1512" height="775" alt="image" src="https://github.com/user-attachments/assets/c0b126e8-c060-428a-a0e9-ef0e9137faae" />

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation and tests