### PR TITLE
perf: cap heartbeat payload to visible rows only

### DIFF
--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -763,9 +763,10 @@ JS,
 			return $response;
 		}
 
-		$visible_count = self::VISIBLE_ROWS + 2;
+		// Cap to visible rows plus overflow threshold (expandable list max).
+		$cap = self::VISIBLE_ROWS + self::get_overflow_threshold();
 		$response['presence-online']       = self::build_online_entries(
-			array_slice( $entries, 0, $visible_count )
+			array_slice( $entries, 0, $cap )
 		);
 		$response['presence-online-total'] = count( $entries );
 		$response['presence-online-hash']  = $hash;

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -764,7 +764,7 @@ JS,
 		}
 
 		// Cap to visible rows plus overflow threshold (expandable list max).
-		$cap = self::VISIBLE_ROWS + self::get_overflow_threshold();
+		$cap                               = self::VISIBLE_ROWS + self::get_overflow_threshold();
 		$response['presence-online']       = self::build_online_entries(
 			array_slice( $entries, 0, $cap )
 		);

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -763,8 +763,12 @@ JS,
 			return $response;
 		}
 
-		$response['presence-online']      = self::build_online_entries( $entries );
-		$response['presence-online-hash'] = $hash;
+		$visible_count = self::VISIBLE_ROWS + 2;
+		$response['presence-online']       = self::build_online_entries(
+			array_slice( $entries, 0, $visible_count )
+		);
+		$response['presence-online-total'] = count( $entries );
+		$response['presence-online-hash']  = $hash;
 
 		return $response;
 	}

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -240,15 +240,15 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	}
 
 	/**
-	 * Heartbeat payload is capped to visible rows plus a small buffer.
+	 * Heartbeat payload is capped to visible rows plus overflow threshold.
 	 *
 	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
 	 */
-	public function test_heartbeat_payload_is_capped_to_visible_rows() {
+	public function test_heartbeat_payload_is_capped_to_expandable_list_max() {
 		wp_set_current_user( self::$editor_id );
 
-		// Create more users than VISIBLE_ROWS + 2 (3 + 2 = 5).
-		for ( $i = 0; $i < 10; $i++ ) {
+		// Create more users than VISIBLE_ROWS + OVERFLOW_THRESHOLD (3 + 20 = 23).
+		for ( $i = 0; $i < 30; $i++ ) {
 			$this->add_user_to_room( 'dashboard', 0 );
 		}
 
@@ -257,11 +257,11 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 		$this->assertArrayHasKey( 'presence-online', $response );
 		$this->assertArrayHasKey( 'presence-online-total', $response );
 
-		// Should only send VISIBLE_ROWS + 2 entries.
-		$this->assertCount( 5, $response['presence-online'] );
+		// Should only send VISIBLE_ROWS + OVERFLOW_THRESHOLD entries.
+		$this->assertCount( 23, $response['presence-online'] );
 
 		// Total should reflect all users.
-		$this->assertSame( 11, $response['presence-online-total'] );
+		$this->assertSame( 31, $response['presence-online-total'] );
 	}
 
 	/**

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -240,6 +240,31 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * Heartbeat payload is capped to visible rows plus a small buffer.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_heartbeat_payload_is_capped_to_visible_rows() {
+		wp_set_current_user( self::$editor_id );
+
+		// Create more users than VISIBLE_ROWS + 2 (3 + 2 = 5).
+		for ( $i = 0; $i < 10; $i++ ) {
+			$this->add_user_to_room( 'dashboard', 0 );
+		}
+
+		$response = $this->tick();
+
+		$this->assertArrayHasKey( 'presence-online', $response );
+		$this->assertArrayHasKey( 'presence-online-total', $response );
+
+		// Should only send VISIBLE_ROWS + 2 entries.
+		$this->assertCount( 5, $response['presence-online'] );
+
+		// Total should reflect all users.
+		$this->assertSame( 11, $response['presence-online-total'] );
+	}
+
+	/**
 	 * @covers WP_Presence_Widget_Whos_Online::render
 	 * @covers WP_Presence_Widget_Whos_Online::render_user_row
 	 */


### PR DESCRIPTION
Fixes #291

Sending all entries when the widget only displays 3 rows wastes bandwidth. From #132 benchmarks, at 1000 concurrent users this was 4 MB/sec egress for presence alone.

Now caps to VISIBLE_ROWS + OVERFLOW_THRESHOLD (3 + 20 = 23 entries) before sending, since that's the maximum the widget can render in expandable list mode. Adds `presence-online-total` for accurate overflow display.

At 1000 users, this reduces the payload from 240 KB to ~5.5 KB per tick.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.5
Used for: Assisting with implementation

</details>