### PR TITLE
perf: coalesce presence polling across tabs of the same user

### DIFF
--- a/assets/js/active-posts.js
+++ b/assets/js/active-posts.js
@@ -16,32 +16,7 @@
 	// Sitewide data, no per-tab context — the dedupe key is fixed.
 	var pingContextKey = 'wp-presence-active-posts-ping';
 
-	var hasLocks = typeof navigator !== 'undefined' &&
-		navigator.locks &&
-		typeof navigator.locks.request === 'function';
-
-	// No Locks API: ping independently, same as before.
-	var isPingLeader = ! hasLocks;
-
-	var pingChannel = typeof BroadcastChannel === 'function'
-		? new BroadcastChannel( pingContextKey )
-		: null;
-
-	if ( pingChannel ) {
-		pingChannel.addEventListener( 'message', function ( event ) {
-			$( document ).trigger( 'heartbeat-tick', [ event.data ] );
-		} );
-	}
-
-	if ( hasLocks ) {
-		// All tabs queue on this lock; the winner leads until its tab closes.
-		navigator.locks
-			.request( pingContextKey, function () {
-				isPingLeader = true;
-				return new Promise( function () {} );
-			} )
-			.catch( function () {} );
-	}
+	var tabCoordinator = window.wpPresenceCreateTabCoordinator( pingContextKey, [ 'presence-active-posts' ] );
 
 	function esc(str) {
 		var el = document.createElement('span');
@@ -50,20 +25,11 @@
 	}
 
 	$(document).on('heartbeat-send', function(event, data) {
-		if ( ! isPingLeader ) {
+		if ( ! tabCoordinator.isLeader() ) {
 			return;
 		}
 		data['presence-active-posts-ping'] = true;
 	});
-
-	if ( pingChannel ) {
-		$( document ).on( 'heartbeat-tick', function ( event, data ) {
-			if ( ! isPingLeader || ! data || ! data[ 'presence-active-posts' ] ) {
-				return;
-			}
-			pingChannel.postMessage( { 'presence-active-posts': data[ 'presence-active-posts' ] } );
-		} );
-	}
 
 	var lastSignature = '';
 

--- a/assets/js/active-posts.js
+++ b/assets/js/active-posts.js
@@ -1,0 +1,154 @@
+/**
+ * Active Posts dashboard widget client.
+ *
+ * @package Presence_API
+ */
+
+( function ( $ ) {
+	'use strict';
+
+	if ( typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined' ) {
+		return;
+	}
+
+	var i18n = window.wpPresenceActivePosts || {};
+
+	// Sitewide data, no per-tab context — the dedupe key is fixed.
+	var pingContextKey = 'wp-presence-active-posts-ping';
+
+	var hasLocks = typeof navigator !== 'undefined' &&
+		navigator.locks &&
+		typeof navigator.locks.request === 'function';
+
+	// No Locks API: ping independently, same as before.
+	var isPingLeader = ! hasLocks;
+
+	var pingChannel = typeof BroadcastChannel === 'function'
+		? new BroadcastChannel( pingContextKey )
+		: null;
+
+	if ( pingChannel ) {
+		pingChannel.addEventListener( 'message', function ( event ) {
+			$( document ).trigger( 'heartbeat-tick', [ event.data ] );
+		} );
+	}
+
+	if ( hasLocks ) {
+		// All tabs queue on this lock; the winner leads until its tab closes.
+		navigator.locks
+			.request( pingContextKey, function () {
+				isPingLeader = true;
+				return new Promise( function () {} );
+			} )
+			.catch( function () {} );
+	}
+
+	function esc(str) {
+		var el = document.createElement('span');
+		el.textContent = str;
+		return el.innerHTML;
+	}
+
+	$(document).on('heartbeat-send', function(event, data) {
+		if ( ! isPingLeader ) {
+			return;
+		}
+		data['presence-active-posts-ping'] = true;
+	});
+
+	if ( pingChannel ) {
+		$( document ).on( 'heartbeat-tick', function ( event, data ) {
+			if ( ! isPingLeader || ! data || ! data[ 'presence-active-posts' ] ) {
+				return;
+			}
+			pingChannel.postMessage( { 'presence-active-posts': data[ 'presence-active-posts' ] } );
+		} );
+	}
+
+	var lastSignature = '';
+
+	function captureFocus(container) {
+		var active = document.activeElement;
+		if (!active || !$.contains(container[0], active)) {
+			return null;
+		}
+		var item = $(active).closest('[data-post-id]');
+		return { postId: item.length ? item.data('post-id') : null };
+	}
+
+	function restoreFocus(container, info) {
+		if (!info) {
+			return;
+		}
+		var target = null;
+		if (info.postId !== null && info.postId !== undefined) {
+			target = container.find('[data-post-id="' + info.postId + '"] a').first();
+		}
+		if (target && target.length) {
+			target.trigger('focus');
+		} else {
+			container.trigger('focus');
+		}
+	}
+
+	function buildFullPostsHtml(posts) {
+		var html = '<ul class="presence-active-posts-list" aria-label="' + esc(i18n.postsBeingEdited) + '">';
+		posts.forEach(function(post) {
+			var anyActive = post.editors.some(function(e) { return e.status === 'active'; });
+			var statusLabel = anyActive ? '' : i18n.statusIdle;
+			html += '<li class="presence-active-post-item" data-post-id="' + post.post_id + '">';
+			html += '<span class="presence-editor-stack">';
+			var stackMax = Math.min(post.editors.length, 4);
+			post.editors.slice(0, stackMax).forEach(function(editor, idx) {
+				if (editor.avatar_url) {
+					html += '<img src="' + esc(editor.avatar_url) + '" width="24" height="24" style="z-index:' + (stackMax - idx) + '" alt="' + esc(editor.display_name) + '" />';
+				}
+			});
+			html += '</span>';
+			html += '<div class="presence-active-post-info">';
+			if (post.editors.length === 1) {
+				html += '<div><span class="presence-editor-count">' + esc(post.editors[0].display_name) + '</span></div>';
+			} else {
+				html += '<div><span class="presence-editor-count">' + esc(i18n.editorCount.replace('%d', post.editors.length)) + '</span></div>';
+			}
+			html += '<div><span class="presence-post-title"><a href="' + esc(post.edit_url) + '">' + esc(post.post_title) + '</a></span></div>';
+			html += '</div>';
+			html += '<span class="presence-status-text">' + esc(statusLabel) + '</span>';
+			html += '</li>';
+		});
+		html += '</ul>';
+		return html;
+	}
+
+	$(document).on('heartbeat-tick', function(event, data) {
+		if (!data['presence-active-posts']) {
+			return;
+		}
+
+		var container = $('#presence-active-posts-list');
+		if (!container.length) {
+			return;
+		}
+
+		var posts = data['presence-active-posts'];
+		if (!posts.length) {
+			if (lastSignature !== '') {
+				var clearFocus = captureFocus(container);
+				container.html('<p>' + esc(i18n.noPostsEdited) + '</p>');
+				restoreFocus(container, clearFocus);
+				lastSignature = '';
+			}
+			return;
+		}
+
+		var sig = posts.map(function(p) {
+			return p.post_id + ':' + p.editors.map(function(e) { return e.user_id + '/' + e.status; }).join('+');
+		}).join(',');
+		if (sig !== lastSignature) {
+			var focusInfo = captureFocus(container);
+			container.html(buildFullPostsHtml(posts));
+			restoreFocus(container, focusInfo);
+			lastSignature = sig;
+		}
+	});
+})(jQuery);

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -22,17 +22,6 @@
 		frontPostId: (frontContext && frontContext.post_id) || 0,
 	});
 
-	const hasLocks = typeof navigator !== 'undefined' &&
-		navigator.locks &&
-		typeof navigator.locks.request === 'function';
-
-	// No Locks API: ping independently, same as before.
-	let isPingLeader = !hasLocks;
-
-	const pingChannel = typeof BroadcastChannel === 'function'
-		? new BroadcastChannel(pingContextKey)
-		: null;
-
 	// Response keys other presence-api features read off heartbeat-tick.
 	// Followers relay these from the leader instead of going stale.
 	const RELAYED_TICK_KEYS = [
@@ -47,22 +36,7 @@
 		'presence-heartbeat-room-list',
 	];
 
-	if (pingChannel) {
-		pingChannel.addEventListener('message', function (event) {
-			$(document).trigger('heartbeat-tick', [event.data]);
-		});
-	}
-
-	if (hasLocks) {
-		// All tabs queue on this lock; whichever gets it becomes leader.
-		// Closing or crashing the leader's tab releases it automatically.
-		navigator.locks
-			.request(pingContextKey, function () {
-				isPingLeader = true;
-				return new Promise(function () {});
-			})
-			.catch(function () {});
-	}
+	const tabCoordinator = window.wpPresenceCreateTabCoordinator(pingContextKey, RELAYED_TICK_KEYS);
 
 	// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
 	$(function () {
@@ -79,7 +53,7 @@
 
 			hasLeft = false;
 
-			if (!isPingLeader) {
+			if (!tabCoordinator.isLeader()) {
 				return;
 			}
 
@@ -98,28 +72,6 @@
 				data['presence-editor-ping'] = { post_id: editorPostId };
 			}
 		});
-
-		if (pingChannel) {
-			$(document).on('heartbeat-tick', function (event, data) {
-				if (!isPingLeader || !data) {
-					return;
-				}
-
-				const relayed = {};
-				let hasRelayedData = false;
-
-				RELAYED_TICK_KEYS.forEach(function (key) {
-					if (Object.prototype.hasOwnProperty.call(data, key)) {
-						relayed[key] = data[key];
-						hasRelayedData = true;
-					}
-				});
-
-				if (hasRelayedData) {
-					pingChannel.postMessage(relayed);
-				}
-			});
-		}
 	});
 
 	function leave() {

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -13,6 +13,57 @@
 	// Guards against duplicate leave() invocations.
 	let hasLeft = false;
 
+	// Tabs on the same screen and post send an identical ping. Key by both
+	// so a different post or screen never gets coalesced with this one.
+	const pingContextKey = 'wp-presence-ping:' + JSON.stringify({
+		screen: window.pagenow || 'front',
+		editorPostId: editorPostId,
+		frontTitle: (frontContext && frontContext.title) || '',
+		frontPostId: (frontContext && frontContext.post_id) || 0,
+	});
+
+	const hasLocks = typeof navigator !== 'undefined' &&
+		navigator.locks &&
+		typeof navigator.locks.request === 'function';
+
+	// No Locks API: ping independently, same as before.
+	let isPingLeader = !hasLocks;
+
+	const pingChannel = typeof BroadcastChannel === 'function'
+		? new BroadcastChannel(pingContextKey)
+		: null;
+
+	// Response keys other presence-api features read off heartbeat-tick.
+	// Followers relay these from the leader instead of going stale.
+	const RELAYED_TICK_KEYS = [
+		'presence-online',
+		'presence-online-total',
+		'presence-online-hash',
+		'presence-online-unchanged',
+		'presence-heartbeat-users',
+		'presence-heartbeat-entries',
+		'presence-heartbeat-query-ms',
+		'presence-heartbeat-ttl',
+		'presence-heartbeat-room-list',
+	];
+
+	if (pingChannel) {
+		pingChannel.addEventListener('message', function (event) {
+			$(document).trigger('heartbeat-tick', [event.data]);
+		});
+	}
+
+	if (hasLocks) {
+		// All tabs queue on this lock; whichever gets it becomes leader.
+		// Closing or crashing the leader's tab releases it automatically.
+		navigator.locks
+			.request(pingContextKey, function () {
+				isPingLeader = true;
+				return new Promise(function () {});
+			})
+			.catch(function () {});
+	}
+
 	// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
 	$(function () {
 		$(document).on('heartbeat-send', function (event, data) {
@@ -23,6 +74,12 @@
 			// both.
 			if (document.visibilityState === 'hidden') {
 				delete data['wp-refresh-post-lock'];
+				return;
+			}
+
+			hasLeft = false;
+
+			if (!isPingLeader) {
 				return;
 			}
 
@@ -40,9 +97,29 @@
 			if (editorPostId) {
 				data['presence-editor-ping'] = { post_id: editorPostId };
 			}
-
-			hasLeft = false;
 		});
+
+		if (pingChannel) {
+			$(document).on('heartbeat-tick', function (event, data) {
+				if (!isPingLeader || !data) {
+					return;
+				}
+
+				const relayed = {};
+				let hasRelayedData = false;
+
+				RELAYED_TICK_KEYS.forEach(function (key) {
+					if (Object.prototype.hasOwnProperty.call(data, key)) {
+						relayed[key] = data[key];
+						hasRelayedData = true;
+					}
+				});
+
+				if (hasRelayedData) {
+					pingChannel.postMessage(relayed);
+				}
+			});
+		}
 	});
 
 	function leave() {

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -27,6 +27,36 @@
 		return;
 	}
 
+	// Tabs on the same screen send an identical ping — key by screenKey.
+	const pingContextKey = 'wp-presence-screen-ping:' + screenKey;
+
+	const hasLocks = typeof navigator !== 'undefined' &&
+		navigator.locks &&
+		typeof navigator.locks.request === 'function';
+
+	// No Locks API: ping independently, same as before.
+	let isPingLeader = ! hasLocks;
+
+	const pingChannel = typeof BroadcastChannel === 'function'
+		? new BroadcastChannel( pingContextKey )
+		: null;
+
+	if ( pingChannel ) {
+		pingChannel.addEventListener( 'message', function ( event ) {
+			$( document ).trigger( 'heartbeat-tick', [ event.data ] );
+		} );
+	}
+
+	if ( hasLocks ) {
+		// All tabs queue on this lock; the winner leads until its tab closes.
+		navigator.locks
+			.request( pingContextKey, function () {
+				isPingLeader = true;
+				return new Promise( function () {} );
+			} )
+			.catch( function () {} );
+	}
+
 	window.wp = window.wp || {};
 	window.wp.presence = window.wp.presence || {};
 
@@ -60,8 +90,20 @@
 		if ( document.visibilityState === 'hidden' ) {
 			return;
 		}
+		if ( ! isPingLeader ) {
+			return;
+		}
 		data[ 'presence-screen-ping' ] = { key: screenKey };
 	} );
+
+	if ( pingChannel ) {
+		$( document ).on( 'heartbeat-tick', function ( event, data ) {
+			if ( ! isPingLeader || ! data || ! data[ 'presence-screen-rev' ] ) {
+				return;
+			}
+			pingChannel.postMessage( { 'presence-screen-rev': data[ 'presence-screen-rev' ] } );
+		} );
+	}
 
 	$( document ).on( 'heartbeat-tick', function ( event, data ) {
 		const info = data && data[ 'presence-screen-rev' ];

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -30,32 +30,7 @@
 	// Tabs on the same screen send an identical ping — key by screenKey.
 	const pingContextKey = 'wp-presence-screen-ping:' + screenKey;
 
-	const hasLocks = typeof navigator !== 'undefined' &&
-		navigator.locks &&
-		typeof navigator.locks.request === 'function';
-
-	// No Locks API: ping independently, same as before.
-	let isPingLeader = ! hasLocks;
-
-	const pingChannel = typeof BroadcastChannel === 'function'
-		? new BroadcastChannel( pingContextKey )
-		: null;
-
-	if ( pingChannel ) {
-		pingChannel.addEventListener( 'message', function ( event ) {
-			$( document ).trigger( 'heartbeat-tick', [ event.data ] );
-		} );
-	}
-
-	if ( hasLocks ) {
-		// All tabs queue on this lock; the winner leads until its tab closes.
-		navigator.locks
-			.request( pingContextKey, function () {
-				isPingLeader = true;
-				return new Promise( function () {} );
-			} )
-			.catch( function () {} );
-	}
+	const tabCoordinator = window.wpPresenceCreateTabCoordinator( pingContextKey, [ 'presence-screen-rev' ] );
 
 	window.wp = window.wp || {};
 	window.wp.presence = window.wp.presence || {};
@@ -90,20 +65,11 @@
 		if ( document.visibilityState === 'hidden' ) {
 			return;
 		}
-		if ( ! isPingLeader ) {
+		if ( ! tabCoordinator.isLeader() ) {
 			return;
 		}
 		data[ 'presence-screen-ping' ] = { key: screenKey };
 	} );
-
-	if ( pingChannel ) {
-		$( document ).on( 'heartbeat-tick', function ( event, data ) {
-			if ( ! isPingLeader || ! data || ! data[ 'presence-screen-rev' ] ) {
-				return;
-			}
-			pingChannel.postMessage( { 'presence-screen-rev': data[ 'presence-screen-rev' ] } );
-		} );
-	}
 
 	$( document ).on( 'heartbeat-tick', function ( event, data ) {
 		const info = data && data[ 'presence-screen-rev' ];

--- a/assets/js/tab-coordinator.js
+++ b/assets/js/tab-coordinator.js
@@ -1,0 +1,77 @@
+/**
+ * Cross-tab Heartbeat ping coordinator.
+ *
+ * Elects one tab per key to actually send Heartbeat's ping payload; other
+ * tabs relay the elected tab's response over BroadcastChannel instead of
+ * pinging independently. Falls back to independent pinging when Web Locks
+ * or BroadcastChannel aren't available.
+ *
+ * @package Presence_API
+ */
+( function ( $ ) {
+	'use strict';
+
+	/**
+	 * @param {string}   key         Unique lock/channel name for this ping type.
+	 * @param {string[]} relayedKeys heartbeat-tick response keys to relay from the leader to followers.
+	 * @return {{isLeader: function(): boolean}} Coordinator handle.
+	 */
+	window.wpPresenceCreateTabCoordinator = function ( key, relayedKeys ) {
+		var hasLocks = typeof navigator !== 'undefined' &&
+			navigator.locks &&
+			typeof navigator.locks.request === 'function';
+
+		// No Locks API: ping independently, same as before.
+		var isPingLeader = ! hasLocks;
+
+		var channel = typeof BroadcastChannel === 'function'
+			? new BroadcastChannel( key )
+			: null;
+
+		if ( channel ) {
+			channel.addEventListener( 'message', function ( event ) {
+				$( document ).trigger( 'heartbeat-tick', [ event.data ] );
+			} );
+		}
+
+		if ( hasLocks ) {
+			// All tabs queue on this lock; the winner leads until its tab
+			// closes. Closing or crashing the leader's tab releases the
+			// lock automatically, promoting the next queued tab.
+			navigator.locks
+				.request( key, function () {
+					isPingLeader = true;
+					return new Promise( function () {} );
+				} )
+				.catch( function () {} );
+		}
+
+		if ( channel ) {
+			$( document ).on( 'heartbeat-tick', function ( event, data ) {
+				if ( ! isPingLeader || ! data ) {
+					return;
+				}
+
+				var relayed = {};
+				var hasRelayedData = false;
+
+				relayedKeys.forEach( function ( relayedKey ) {
+					if ( Object.prototype.hasOwnProperty.call( data, relayedKey ) ) {
+						relayed[ relayedKey ] = data[ relayedKey ];
+						hasRelayedData = true;
+					}
+				} );
+
+				if ( hasRelayedData ) {
+					channel.postMessage( relayed );
+				}
+			} );
+		}
+
+		return {
+			isLeader: function () {
+				return isPingLeader;
+			},
+		};
+	};
+} )( jQuery );

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -139,9 +139,17 @@ function wp_presence_enqueue_heartbeat_ping() {
 	);
 
 	wp_enqueue_script(
+		'wp-presence-tab-coordinator',
+		WP_PRESENCE_PLUGIN_URL . 'assets/js/tab-coordinator.js',
+		array( 'jquery' ),
+		WP_PRESENCE_VERSION,
+		true
+	);
+
+	wp_enqueue_script(
 		'wp-presence-ping',
 		WP_PRESENCE_PLUGIN_URL . 'assets/js/presence-ping.js',
-		array( 'jquery', 'heartbeat' ),
+		array( 'jquery', 'heartbeat', 'wp-presence-tab-coordinator' ),
 		WP_PRESENCE_VERSION,
 		true
 	);

--- a/includes/screen-revisions.php
+++ b/includes/screen-revisions.php
@@ -630,9 +630,17 @@ function wp_presence_enqueue_stale_screen_banner() {
 	);
 
 	wp_enqueue_script(
+		'wp-presence-tab-coordinator',
+		WP_PRESENCE_PLUGIN_URL . 'assets/js/tab-coordinator.js',
+		array( 'jquery' ),
+		WP_PRESENCE_VERSION,
+		true
+	);
+
+	wp_enqueue_script(
 		'wp-presence-stale-screen',
 		WP_PRESENCE_PLUGIN_URL . 'assets/js/stale-screen.js',
-		array( 'jquery', 'heartbeat' ),
+		array( 'jquery', 'heartbeat', 'wp-presence-tab-coordinator' ),
 		WP_PRESENCE_VERSION,
 		true
 	);

--- a/includes/widgets/class-wp-presence-widget-active-posts.php
+++ b/includes/widgets/class-wp-presence-widget-active-posts.php
@@ -57,9 +57,18 @@ class WP_Presence_Widget_Active_Posts {
 
 		wp_enqueue_script( 'heartbeat' );
 
+		wp_enqueue_script(
+			'wp-presence-active-posts',
+			WP_PRESENCE_PLUGIN_URL . 'assets/js/active-posts.js',
+			array( 'jquery', 'heartbeat' ),
+			WP_PRESENCE_VERSION,
+			true
+		);
+
 		wp_add_inline_script(
-			'heartbeat',
-			self::get_inline_script()
+			'wp-presence-active-posts',
+			sprintf( 'window.wpPresenceActivePosts = %s;', wp_json_encode( self::get_i18n_strings() ) ),
+			'before'
 		);
 
 		wp_register_style( 'presence-active-posts-widget', false, array(), WP_PRESENCE_VERSION );
@@ -88,130 +97,18 @@ class WP_Presence_Widget_Active_Posts {
 	}
 
 	/**
-	 * Returns the inline JavaScript for Heartbeat integration.
+	 * Returns the translated strings active-posts.js reads off window.wpPresenceActivePosts.
 	 *
-	 * @return string JavaScript code.
+	 * @return array Translated strings.
 	 */
-	private static function get_inline_script() {
-		$i18n_json = wp_json_encode(
-			array(
-				'noPostsEdited'    => __( 'All quiet.', 'presence-api' ),
-				'postsBeingEdited' => __( 'Posts currently being edited', 'presence-api' ),
-				'statusEditing'    => __( 'Editing', 'presence-api' ),
-				'statusIdle'       => __( 'Idle', 'presence-api' ),
-				/* translators: %d: Number of editors. */
-				'editorCount'      => __( '%d editors', 'presence-api' ),
-			)
-		);
-
-		return sprintf(
-			<<<'JS'
-(function($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
-		return;
-	}
-
-	var i18n = %s;
-
-	function esc(str) {
-		var el = document.createElement('span');
-		el.textContent = str;
-		return el.innerHTML;
-	}
-
-	$(document).on('heartbeat-send', function(event, data) {
-		data['presence-active-posts-ping'] = true;
-	});
-
-	var lastSignature = '';
-
-	function captureFocus(container) {
-		var active = document.activeElement;
-		if (!active || !$.contains(container[0], active)) {
-			return null;
-		}
-		var item = $(active).closest('[data-post-id]');
-		return { postId: item.length ? item.data('post-id') : null };
-	}
-
-	function restoreFocus(container, info) {
-		if (!info) {
-			return;
-		}
-		var target = null;
-		if (info.postId !== null && info.postId !== undefined) {
-			target = container.find('[data-post-id="' + info.postId + '"] a').first();
-		}
-		if (target && target.length) {
-			target.trigger('focus');
-		} else {
-			container.trigger('focus');
-		}
-	}
-
-	function buildFullPostsHtml(posts) {
-		var html = '<ul class="presence-active-posts-list" aria-label="' + esc(i18n.postsBeingEdited) + '">';
-		posts.forEach(function(post) {
-			var anyActive = post.editors.some(function(e) { return e.status === 'active'; });
-			var statusLabel = anyActive ? '' : i18n.statusIdle;
-			html += '<li class="presence-active-post-item" data-post-id="' + post.post_id + '">';
-			html += '<span class="presence-editor-stack">';
-			var stackMax = Math.min(post.editors.length, 4);
-			post.editors.slice(0, stackMax).forEach(function(editor, idx) {
-				if (editor.avatar_url) {
-					html += '<img src="' + esc(editor.avatar_url) + '" width="24" height="24" style="z-index:' + (stackMax - idx) + '" alt="' + esc(editor.display_name) + '" />';
-				}
-			});
-			html += '</span>';
-			html += '<div class="presence-active-post-info">';
-			if (post.editors.length === 1) {
-				html += '<div><span class="presence-editor-count">' + esc(post.editors[0].display_name) + '</span></div>';
-			} else {
-				html += '<div><span class="presence-editor-count">' + esc(i18n.editorCount.replace('%%d', post.editors.length)) + '</span></div>';
-			}
-			html += '<div><span class="presence-post-title"><a href="' + esc(post.edit_url) + '">' + esc(post.post_title) + '</a></span></div>';
-			html += '</div>';
-			html += '<span class="presence-status-text">' + esc(statusLabel) + '</span>';
-			html += '</li>';
-		});
-		html += '</ul>';
-		return html;
-	}
-
-	$(document).on('heartbeat-tick', function(event, data) {
-		if (!data['presence-active-posts']) {
-			return;
-		}
-
-		var container = $('#presence-active-posts-list');
-		if (!container.length) {
-			return;
-		}
-
-		var posts = data['presence-active-posts'];
-		if (!posts.length) {
-			if (lastSignature !== '') {
-				var clearFocus = captureFocus(container);
-				container.html('<p>' + esc(i18n.noPostsEdited) + '</p>');
-				restoreFocus(container, clearFocus);
-				lastSignature = '';
-			}
-			return;
-		}
-
-		var sig = posts.map(function(p) {
-			return p.post_id + ':' + p.editors.map(function(e) { return e.user_id + '/' + e.status; }).join('+');
-		}).join(',');
-		if (sig !== lastSignature) {
-			var focusInfo = captureFocus(container);
-			container.html(buildFullPostsHtml(posts));
-			restoreFocus(container, focusInfo);
-			lastSignature = sig;
-		}
-	});
-})(jQuery);
-JS,
-			$i18n_json
+	private static function get_i18n_strings() {
+		return array(
+			'noPostsEdited'    => __( 'All quiet.', 'presence-api' ),
+			'postsBeingEdited' => __( 'Posts currently being edited', 'presence-api' ),
+			'statusEditing'    => __( 'Editing', 'presence-api' ),
+			'statusIdle'       => __( 'Idle', 'presence-api' ),
+			/* translators: %d: Number of editors. */
+			'editorCount'      => __( '%d editors', 'presence-api' ),
 		);
 	}
 

--- a/includes/widgets/class-wp-presence-widget-active-posts.php
+++ b/includes/widgets/class-wp-presence-widget-active-posts.php
@@ -58,9 +58,17 @@ class WP_Presence_Widget_Active_Posts {
 		wp_enqueue_script( 'heartbeat' );
 
 		wp_enqueue_script(
+			'wp-presence-tab-coordinator',
+			WP_PRESENCE_PLUGIN_URL . 'assets/js/tab-coordinator.js',
+			array( 'jquery' ),
+			WP_PRESENCE_VERSION,
+			true
+		);
+
+		wp_enqueue_script(
 			'wp-presence-active-posts',
 			WP_PRESENCE_PLUGIN_URL . 'assets/js/active-posts.js',
-			array( 'jquery', 'heartbeat' ),
+			array( 'jquery', 'heartbeat', 'wp-presence-tab-coordinator' ),
 			WP_PRESENCE_VERSION,
 			true
 		);

--- a/src/README.md
+++ b/src/README.md
@@ -117,4 +117,5 @@ Example live region pattern:
 - Requires `wp.heartbeat` to be available in the global scope.
 - Deduplicates users by ID.
 - Prevents race conditions: if a heartbeat tick fires while a fetch is in progress, the second request is skipped.
+- Coalesces polling across tabs and instances sharing a room and `fields`: one tab polls (via Web Locks, where available) and shares results with the rest over `BroadcastChannel`.
 - In development mode, logs warnings and errors to the console for debugging.

--- a/src/hooks/use-presence-users.js
+++ b/src/hooks/use-presence-users.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { onHeartbeatTick, isHeartbeatAvailable } from '../utils/heartbeat-events';
+import { isHeartbeatAvailable } from '../utils/heartbeat-events';
+import { subscribeToPresencePolling } from '../utils/presence-poll-coordinator';
 
 /**
  * Subscribes to WordPress Heartbeat to poll for presence room occupants.
@@ -40,8 +40,6 @@ export default function usePresenceUsers( room, options = {} ) {
 	const [ users, setUsers ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
-	const abortControllerRef = useRef();
-	const fetchInProgressRef = useRef( false );
 
 	const currentUserId = useSelect(
 		( select ) => select( 'core' ).getCurrentUser()?.id,
@@ -63,32 +61,17 @@ export default function usePresenceUsers( room, options = {} ) {
 
 		let isInitialFetch = true;
 
-		const fetchPresence = async () => {
-			if ( fetchInProgressRef.current ) {
-				return;
-			}
-
-			fetchInProgressRef.current = true;
-
-			if ( abortControllerRef.current ) {
-				abortControllerRef.current.abort();
-			}
-
-			abortControllerRef.current = new AbortController();
-			const { signal } = abortControllerRef.current;
-
-			try {
-				const params = new URLSearchParams( {
-					room,
-					_fields: fields,
-				} );
-
-				const entries = await apiFetch( {
-					path: `/wp-presence/v1/presence?${ params }`,
-					signal,
-				} );
-
-				if ( signal.aborted ) {
+		const unsubscribe = subscribeToPresencePolling(
+			room,
+			fields,
+			( { entries, error: fetchError } ) => {
+				if ( fetchError ) {
+					setUsers( [] );
+					setError( fetchError );
+					if ( isInitialFetch ) {
+						setIsLoading( false );
+						isInitialFetch = false;
+					}
 					return;
 				}
 
@@ -130,34 +113,10 @@ export default function usePresenceUsers( room, options = {} ) {
 					setIsLoading( false );
 					isInitialFetch = false;
 				}
-			} catch ( err ) {
-				if ( signal.aborted || err.name === 'AbortError' ) {
-					return;
-				}
-
-				setUsers( [] );
-				setError( err );
-				if ( isInitialFetch ) {
-					setIsLoading( false );
-					isInitialFetch = false;
-				}
-			} finally {
-				fetchInProgressRef.current = false;
 			}
-		};
+		);
 
-		fetchPresence();
-
-		const cleanup = onHeartbeatTick( () => {
-			fetchPresence();
-		} );
-
-		return () => {
-			cleanup();
-			if ( abortControllerRef.current ) {
-				abortControllerRef.current.abort();
-			}
-		};
+		return unsubscribe;
 	}, [ room, currentUserId, includeSelf, fields ] );
 
 	return {

--- a/src/utils/presence-poll-coordinator.js
+++ b/src/utils/presence-poll-coordinator.js
@@ -1,0 +1,201 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { onHeartbeatTick } from './heartbeat-events';
+
+/**
+ * Coalesces presence polling for a given room + fields pair.
+ *
+ * All subscribers for the same room and `_fields` share one coordinator.
+ * Web Locks elects one tab as the poller; BroadcastChannel relays its
+ * results to the rest. Falls back to independent per-tab polling if either
+ * API is unavailable.
+ *
+ * Keyed room -> fields -> coordinator, so the two can't collide as a string.
+ */
+const coordinators = new Map();
+
+/**
+ * Subscribes to presence data for a room, sharing the poll with every other
+ * subscriber asking for the same room and fields.
+ *
+ * @param {string}   room     Presence room id.
+ * @param {string}   fields   `_fields` parameter for the REST request.
+ * @param {Function} callback Called with `{ entries, error }` whenever new data arrives.
+ * @return {Function} Unsubscribe function.
+ */
+export function subscribeToPresencePolling( room, fields, callback ) {
+	let byFields = coordinators.get( room );
+	if ( ! byFields ) {
+		byFields = new Map();
+		coordinators.set( room, byFields );
+	}
+
+	let coordinator = byFields.get( fields );
+	if ( ! coordinator ) {
+		coordinator = createCoordinator( room, fields );
+		byFields.set( fields, coordinator );
+	}
+
+	coordinator.subscribers.add( callback );
+
+	if ( coordinator.lastResult ) {
+		callback( coordinator.lastResult );
+	}
+
+	coordinator.start();
+
+	return () => {
+		coordinator.subscribers.delete( callback );
+
+		if ( coordinator.subscribers.size === 0 ) {
+			coordinator.teardown();
+			byFields.delete( fields );
+			if ( byFields.size === 0 ) {
+				coordinators.delete( room );
+			}
+		}
+	};
+}
+
+function createCoordinator( room, fields ) {
+	const lockName = `wp-presence-poll:${ room }:${ fields }`;
+
+	const coordinator = {
+		subscribers: new Set(),
+		lastResult: null,
+		started: false,
+		fetchInProgress: false,
+		abortController: null,
+		heartbeatCleanup: null,
+		releaseLock: null,
+		lockAbortController:
+			typeof AbortController === 'function' ? new AbortController() : null,
+		channel:
+			typeof BroadcastChannel === 'function'
+				? new BroadcastChannel( lockName )
+				: null,
+	};
+
+	function notify( result ) {
+		coordinator.lastResult = result;
+		coordinator.subscribers.forEach( ( callback ) => callback( result ) );
+	}
+
+	if ( coordinator.channel ) {
+		coordinator.channel.addEventListener( 'message', ( event ) => {
+			notify( event.data );
+		} );
+	}
+
+	function deliver( result ) {
+		notify( result );
+		if ( coordinator.channel ) {
+			coordinator.channel.postMessage( result );
+		}
+	}
+
+	async function fetchAndBroadcast() {
+		if ( coordinator.fetchInProgress ) {
+			return;
+		}
+		coordinator.fetchInProgress = true;
+
+		if ( coordinator.abortController ) {
+			coordinator.abortController.abort();
+		}
+		coordinator.abortController = new AbortController();
+		const { signal } = coordinator.abortController;
+
+		try {
+			const params = new URLSearchParams( { room, _fields: fields } );
+			const entries = await apiFetch( {
+				path: `/wp-presence/v1/presence?${ params }`,
+				signal,
+			} );
+
+			if ( signal.aborted ) {
+				return;
+			}
+
+			deliver( { entries, error: null } );
+		} catch ( err ) {
+			if ( signal.aborted || err.name === 'AbortError' ) {
+				return;
+			}
+
+			deliver( { entries: null, error: err } );
+		} finally {
+			coordinator.fetchInProgress = false;
+		}
+	}
+
+	function becomeLeader() {
+		fetchAndBroadcast();
+		coordinator.heartbeatCleanup = onHeartbeatTick( () => fetchAndBroadcast() );
+	}
+
+	coordinator.start = function () {
+		if ( coordinator.started ) {
+			return;
+		}
+		coordinator.started = true;
+
+		const hasLocks =
+			typeof navigator !== 'undefined' &&
+			navigator.locks &&
+			typeof navigator.locks.request === 'function';
+
+		if ( ! hasLocks ) {
+			becomeLeader();
+			return;
+		}
+
+		const options = coordinator.lockAbortController
+			? { signal: coordinator.lockAbortController.signal }
+			: {};
+
+		// All tabs queue on this lock; whichever gets it becomes leader.
+		// The rest wait and listen on BroadcastChannel instead. Closing or
+		// crashing the leader's tab releases the lock automatically.
+		navigator.locks
+			.request( lockName, options, () => new Promise( ( resolve ) => {
+				coordinator.releaseLock = resolve;
+				becomeLeader();
+			} ) )
+			.catch( () => {} );
+	};
+
+	coordinator.teardown = function () {
+		coordinator.started = false;
+
+		if ( coordinator.heartbeatCleanup ) {
+			coordinator.heartbeatCleanup();
+			coordinator.heartbeatCleanup = null;
+		}
+
+		if ( coordinator.abortController ) {
+			coordinator.abortController.abort();
+		}
+
+		if ( coordinator.lockAbortController ) {
+			coordinator.lockAbortController.abort();
+		}
+
+		if ( coordinator.releaseLock ) {
+			coordinator.releaseLock();
+			coordinator.releaseLock = null;
+		}
+
+		if ( coordinator.channel ) {
+			coordinator.channel.close();
+		}
+	};
+
+	return coordinator;
+}

--- a/src/utils/test/presence-poll-coordinator.test.js
+++ b/src/utils/test/presence-poll-coordinator.test.js
@@ -1,0 +1,202 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { subscribeToPresencePolling } from '../presence-poll-coordinator';
+
+jest.mock( '@wordpress/api-fetch' );
+
+let mockHeartbeatTickCallbacks = [];
+
+jest.mock( '../heartbeat-events', () => ( {
+	onHeartbeatTick: jest.fn( ( callback ) => {
+		mockHeartbeatTickCallbacks.push( callback );
+		return () => {
+			mockHeartbeatTickCallbacks = mockHeartbeatTickCallbacks.filter(
+				( cb ) => cb !== callback
+			);
+		};
+	} ),
+} ) );
+
+const flush = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+describe( 'subscribeToPresencePolling', () => {
+	beforeEach( () => {
+		apiFetch.mockClear();
+		mockHeartbeatTickCallbacks = [];
+	} );
+
+	afterEach( () => {
+		delete global.navigator.locks;
+		delete global.BroadcastChannel;
+		jest.clearAllMocks();
+	} );
+
+	it( 'shares a single request across multiple subscribers for the same room and fields', async () => {
+		apiFetch.mockResolvedValue( [ { user_id: 2 } ] );
+
+		const callbackA = jest.fn();
+		const callbackB = jest.fn();
+
+		const unsubscribeA = subscribeToPresencePolling(
+			'room-shared',
+			'user_id',
+			callbackA
+		);
+		const unsubscribeB = subscribeToPresencePolling(
+			'room-shared',
+			'user_id',
+			callbackB
+		);
+
+		await flush();
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( callbackA ).toHaveBeenCalledWith( {
+			entries: [ { user_id: 2 } ],
+			error: null,
+		} );
+		expect( callbackB ).toHaveBeenCalledWith( {
+			entries: [ { user_id: 2 } ],
+			error: null,
+		} );
+
+		unsubscribeA();
+		unsubscribeB();
+	} );
+
+	it( 'polls independently for different fields on the same room', async () => {
+		apiFetch.mockResolvedValue( [] );
+
+		const unsubscribeA = subscribeToPresencePolling(
+			'room-fields',
+			'user_id',
+			jest.fn()
+		);
+		const unsubscribeB = subscribeToPresencePolling(
+			'room-fields',
+			'user_id,display_name',
+			jest.fn()
+		);
+
+		await flush();
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+
+		unsubscribeA();
+		unsubscribeB();
+	} );
+
+	it( 'stops polling on heartbeat tick once every subscriber has left', async () => {
+		apiFetch.mockResolvedValue( [] );
+
+		const unsubscribe = subscribeToPresencePolling(
+			'room-teardown',
+			'user_id',
+			jest.fn()
+		);
+		await flush();
+		expect( mockHeartbeatTickCallbacks ).toHaveLength( 1 );
+
+		unsubscribe();
+		expect( mockHeartbeatTickCallbacks ).toHaveLength( 0 );
+
+		mockHeartbeatTickCallbacks.forEach( ( cb ) => cb() );
+		await flush();
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not call apiFetch until this tab wins the Web Lock', async () => {
+		let grantLock;
+		global.navigator.locks = {
+			request: jest.fn( ( name, options, callback ) => {
+				return new Promise( ( resolve ) => {
+					grantLock = () => callback().then( resolve );
+				} );
+			} ),
+		};
+		apiFetch.mockResolvedValue( [] );
+
+		const unsubscribe = subscribeToPresencePolling(
+			'room-lock',
+			'user_id',
+			jest.fn()
+		);
+
+		await flush();
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( global.navigator.locks.request ).toHaveBeenCalledWith(
+			'wp-presence-poll:room-lock:user_id',
+			expect.any( Object ),
+			expect.any( Function )
+		);
+
+		grantLock();
+		await flush();
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		unsubscribe();
+	} );
+
+	it( 'delivers results received over BroadcastChannel without fetching itself', () => {
+		let messageHandler;
+		global.BroadcastChannel = function () {
+			return {
+				addEventListener: ( type, handler ) => {
+					messageHandler = handler;
+				},
+				postMessage: jest.fn(),
+				close: jest.fn(),
+			};
+		};
+		// Another tab holds the lock, so this request never resolves.
+		global.navigator.locks = {
+			request: jest.fn( () => new Promise( () => {} ) ),
+		};
+
+		const callback = jest.fn();
+		const unsubscribe = subscribeToPresencePolling(
+			'room-follower',
+			'user_id',
+			callback
+		);
+
+		messageHandler( {
+			data: { entries: [ { user_id: 9 } ], error: null },
+		} );
+
+		expect( callback ).toHaveBeenCalledWith( {
+			entries: [ { user_id: 9 } ],
+			error: null,
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+
+		unsubscribe();
+	} );
+
+	it( 'delivers a fetch error to subscribers', async () => {
+		const mockError = new Error( 'Network error' );
+		apiFetch.mockRejectedValue( mockError );
+
+		const callback = jest.fn();
+		const unsubscribe = subscribeToPresencePolling(
+			'room-error',
+			'user_id',
+			callback
+		);
+
+		await flush();
+
+		expect( callback ).toHaveBeenCalledWith( {
+			entries: null,
+			error: mockError,
+		} );
+
+		unsubscribe();
+	} );
+} );

--- a/tests/e2e/presence-active-posts-coalescing.test.js
+++ b/tests/e2e/presence-active-posts-coalescing.test.js
@@ -1,0 +1,154 @@
+/**
+ * Presence API — Active Posts Cross-Tab Coalescing E2E Tests
+ *
+ * Asserts active-posts.js elects one tab to send
+ * presence-active-posts-ping, siblings stay silent, closing the leader
+ * promotes a sibling, and the leader's presence-active-posts relays to
+ * siblings over BroadcastChannel. Unlike presence-ping and
+ * presence-screen-ping, this ping has no per-page context, so any two
+ * Dashboard tabs are duplicates and the dedupe key is fixed.
+ *
+ * Uses two pages in one browser context, not two Playwright contexts —
+ * Web Locks and BroadcastChannel are scoped per storage partition.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js tests/e2e/presence-active-posts-coalescing.test.js
+ *
+ * @package WordPress
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+function captureHeartbeatSend( page ) {
+	return page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				jQuery( document ).one( 'heartbeat-send', ( event, data ) => {
+					resolve( data );
+				} );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+async function waitForLeaderPing( page, maxAttempts = 20 ) {
+	for ( let attempt = 0; attempt < maxAttempts; attempt++ ) {
+		const data = await captureHeartbeatSend( page );
+		if ( data[ 'presence-active-posts-ping' ] ) {
+			return data;
+		}
+		await page.waitForTimeout( 100 );
+	}
+	throw new Error( 'Tab never won presence-active-posts-ping leadership.' );
+}
+
+function waitForActivePostsTick( page, timeoutMs = 8000 ) {
+	return page.evaluate( ( timeout ) => {
+		return new Promise( ( resolve, reject ) => {
+			const timer = setTimeout( () => {
+				jQuery( document ).off( 'heartbeat-tick', handler );
+				reject( new Error( 'Timed out waiting for a relayed tick.' ) );
+			}, timeout );
+
+			function handler( event, data ) {
+				if ( data && data[ 'presence-active-posts' ] ) {
+					clearTimeout( timer );
+					jQuery( document ).off( 'heartbeat-tick', handler );
+					resolve( data );
+				}
+			}
+
+			jQuery( document ).on( 'heartbeat-tick', handler );
+		} );
+	}, timeoutMs );
+}
+
+test.describe( 'Presence Active Posts Tab Coalescing', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'elects one tab to send presence-active-posts-ping; a sibling tab stays silent', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/' );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto( '/wp-admin/' );
+		await waitForHeartbeat( sibling );
+
+		const siblingData = await captureHeartbeatSend( sibling );
+		expect( siblingData[ 'presence-active-posts-ping' ] ).toBeUndefined();
+
+		await sibling.close();
+	} );
+
+	test( 'promotes the sibling tab once the leader tab closes', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/' );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto( '/wp-admin/' );
+		await waitForHeartbeat( sibling );
+
+		const beforeClose = await captureHeartbeatSend( sibling );
+		expect( beforeClose[ 'presence-active-posts-ping' ] ).toBeUndefined();
+
+		await page.close();
+
+		const promoted = await waitForLeaderPing( sibling );
+		expect( promoted[ 'presence-active-posts-ping' ] ).toBe( true );
+
+		await sibling.close();
+	} );
+
+	test( "relays the leader's active-posts data to a sibling tab", async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Active Posts Coalescing Post',
+			status: 'draft',
+		} );
+
+		// Dedicated tab: navigating `page` away would trigger presence-ping's
+		// pagehide handler, deleting the very entry we're trying to occupy.
+		const editorTab = await page.context().newPage();
+		await editorTab.goto(
+			`/wp-admin/post.php?post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( editorTab );
+		await editorTab.evaluate( () => wp.heartbeat.connectNow() );
+
+		await page.goto( '/wp-admin/' );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto( '/wp-admin/' );
+		await waitForHeartbeat( sibling );
+
+		const [ relayed ] = await Promise.all( [
+			waitForActivePostsTick( sibling ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+
+		expect( relayed[ 'presence-active-posts' ].length ).toBeGreaterThan( 0 );
+		expect( relayed[ 'presence-active-posts' ][ 0 ].post_id ).toBe(
+			post.id
+		);
+
+		await sibling.close();
+		await editorTab.close();
+	} );
+} );

--- a/tests/e2e/presence-stale-screen-coalescing.test.js
+++ b/tests/e2e/presence-stale-screen-coalescing.test.js
@@ -1,0 +1,195 @@
+/**
+ * Presence API — Stale-Screen Cross-Tab Coalescing E2E Tests
+ *
+ * Asserts stale-screen.js elects one tab per screen to send
+ * presence-screen-ping, siblings stay silent, closing the leader promotes a
+ * sibling, and the leader's presence-screen-rev relays to siblings over
+ * BroadcastChannel.
+ *
+ * Uses two pages in one browser context, not two Playwright contexts —
+ * Web Locks and BroadcastChannel are scoped per storage partition.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js tests/e2e/presence-stale-screen-coalescing.test.js
+ *
+ * @package WordPress
+ */
+import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
+import { execSync } from 'node:child_process';
+
+const TEST_USERS = [
+	{
+		username: 'presence_test_stale_b',
+		email: 'presence_test_stale_b@example.com',
+		firstName: 'Stale',
+		lastName: 'B',
+		password: 'password',
+		roles: [ 'editor' ],
+	},
+];
+
+const test = base.extend( {
+	testUsers: [
+		async ( { requestUtils }, use ) => {
+			for ( const user of TEST_USERS ) {
+				await requestUtils.createUser( user ).catch( ( error ) => {
+					if ( error?.code !== 'existing_user_login' ) {
+						throw error;
+					}
+				} );
+			}
+			await use( TEST_USERS );
+			await requestUtils.deleteAllUsers();
+		},
+		{ scope: 'test' },
+	],
+} );
+
+function execOutput( command ) {
+	return execSync( command, { encoding: 'utf8', timeout: 30_000 } )
+		.trim()
+		.split( '\n' )
+		.pop()
+		.trim();
+}
+
+function wpEval( phpExpression ) {
+	execSync(
+		`npx wp-env run cli wp eval ${ JSON.stringify( phpExpression ) }`,
+		{ stdio: 'pipe', timeout: 30_000 }
+	);
+}
+
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+function captureHeartbeatSend( page ) {
+	return page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				jQuery( document ).one( 'heartbeat-send', ( event, data ) => {
+					resolve( data );
+				} );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+async function waitForLeaderPing( page, maxAttempts = 20 ) {
+	for ( let attempt = 0; attempt < maxAttempts; attempt++ ) {
+		const data = await captureHeartbeatSend( page );
+		if ( data[ 'presence-screen-ping' ] ) {
+			return data;
+		}
+		await page.waitForTimeout( 100 );
+	}
+	throw new Error( 'Tab never won presence-screen-ping leadership.' );
+}
+
+test.describe( 'Presence Stale-Screen Tab Coalescing', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'elects one tab to send presence-screen-ping; a sibling tab on the same post stays silent', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Stale Screen Coalescing Post',
+			status: 'draft',
+		} );
+
+		await page.goto( `/wp-admin/post.php?post=${ post.id }&action=edit` );
+		await waitForHeartbeat( page );
+		const leaderData = await waitForLeaderPing( page );
+		expect( leaderData[ 'presence-screen-ping' ].key ).toBe(
+			`post/${ post.id }`
+		);
+
+		const sibling = await page.context().newPage();
+		await sibling.goto(
+			`/wp-admin/post.php?post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( sibling );
+
+		const siblingData = await captureHeartbeatSend( sibling );
+		expect( siblingData[ 'presence-screen-ping' ] ).toBeUndefined();
+
+		await sibling.close();
+	} );
+
+	test( 'promotes the sibling tab once the leader tab closes', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Stale Screen Promotion Post',
+			status: 'draft',
+		} );
+
+		await page.goto( `/wp-admin/post.php?post=${ post.id }&action=edit` );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto(
+			`/wp-admin/post.php?post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( sibling );
+
+		const beforeClose = await captureHeartbeatSend( sibling );
+		expect( beforeClose[ 'presence-screen-ping' ] ).toBeUndefined();
+
+		await page.close();
+
+		const promoted = await waitForLeaderPing( sibling );
+		expect( promoted[ 'presence-screen-ping' ].key ).toBe(
+			`post/${ post.id }`
+		);
+
+		await sibling.close();
+	} );
+
+	test( "relays the leader's stale-screen banner to a sibling tab", async ( {
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Stale Screen Relay Post',
+			status: 'draft',
+		} );
+
+		await page.goto( `/wp-admin/post.php?post=${ post.id }&action=edit` );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto(
+			`/wp-admin/post.php?post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( sibling );
+
+		// bump_screen_revision() no-ops for post keys — save the post instead.
+		const otherUserId = execOutput(
+			`npx wp-env run cli wp user get ${ testUsers[ 0 ].username } --field=ID`
+		);
+		// Each `wp eval` call is its own process — no need to restore the user.
+		wpEval(
+			`wp_set_current_user( ${ otherUserId } ); wp_update_post( array( 'ID' => ${ post.id }, 'post_content' => get_post_field( 'post_content', ${ post.id } ) ) );`
+		);
+
+		await Promise.all( [
+			sibling.waitForSelector( '.wp-presence-stale-notice', {
+				timeout: 8000,
+			} ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+
+		await sibling.close();
+	} );
+} );

--- a/tests/e2e/presence-tab-coalescing.test.js
+++ b/tests/e2e/presence-tab-coalescing.test.js
@@ -1,0 +1,204 @@
+/**
+ * Presence API — Cross-Tab Polling Coalescing E2E Tests
+ *
+ * Asserts presence-ping.js elects one tab per screen/post context to send
+ * presence-ping, siblings stay silent, closing the leader promotes a
+ * sibling, and the leader's Who's Online response relays over
+ * BroadcastChannel.
+ *
+ * Uses two pages in one browser context, not two Playwright contexts —
+ * Web Locks and BroadcastChannel are scoped per storage partition, so
+ * separate contexts would never see each other.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js tests/e2e/presence-tab-coalescing.test.js
+ *
+ * @package WordPress
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Waits until the WordPress heartbeat library is ready on the page.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+/**
+ * Forces a heartbeat tick and resolves with the data object that
+ * `heartbeat-send` listeners saw.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @return {Promise<object>}
+ */
+function captureHeartbeatSend( page ) {
+	return page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				jQuery( document ).one( 'heartbeat-send', ( event, data ) => {
+					resolve( data );
+				} );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+/**
+ * Retries a forced heartbeat tick until this tab wins Web Locks leadership
+ * and sends presence-ping, or gives up.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number}                          maxAttempts
+ * @return {Promise<object>} The `heartbeat-send` data from the winning attempt.
+ */
+async function waitForLeaderPing( page, maxAttempts = 20 ) {
+	for ( let attempt = 0; attempt < maxAttempts; attempt++ ) {
+		const data = await captureHeartbeatSend( page );
+		if ( data[ 'presence-ping' ] ) {
+			return data;
+		}
+		await page.waitForTimeout( 100 );
+	}
+	throw new Error( 'Tab never won presence-ping leadership.' );
+}
+
+/**
+ * Waits for a heartbeat-tick carrying Who's Online data, ignoring any
+ * unrelated ticks that arrive first (e.g. this tab's own post-lock tick).
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number}                          timeoutMs
+ * @return {Promise<object>}
+ */
+function waitForOnlineDataTick( page, timeoutMs = 8000 ) {
+	return page.evaluate( ( timeout ) => {
+		return new Promise( ( resolve, reject ) => {
+			const timer = setTimeout( () => {
+				jQuery( document ).off( 'heartbeat-tick', handler );
+				reject( new Error( 'Timed out waiting for a relayed tick.' ) );
+			}, timeout );
+
+			function handler( event, data ) {
+				if (
+					data &&
+					( data[ 'presence-online' ] ||
+						data[ 'presence-online-unchanged' ] )
+				) {
+					clearTimeout( timer );
+					jQuery( document ).off( 'heartbeat-tick', handler );
+					resolve( data );
+				}
+			}
+
+			jQuery( document ).on( 'heartbeat-tick', handler );
+		} );
+	}, timeoutMs );
+}
+
+test.describe( 'Presence Tab Coalescing', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'elects one tab to send presence-ping; a sibling tab on the same screen stays silent', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/' );
+		await waitForHeartbeat( page );
+
+		// Let this tab win leadership before the sibling opens, so the
+		// outcome is deterministic instead of racing two tabs.
+		const leaderData = await waitForLeaderPing( page );
+		expect( leaderData[ 'presence-ping' ].screen ).toBeTruthy();
+
+		const sibling = await page.context().newPage();
+		await sibling.goto( '/wp-admin/' );
+		await waitForHeartbeat( sibling );
+
+		const siblingData = await captureHeartbeatSend( sibling );
+		expect( siblingData[ 'presence-ping' ] ).toBeUndefined();
+
+		await sibling.close();
+	} );
+
+	test( 'promotes the sibling tab once the leader tab closes', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/' );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto( '/wp-admin/' );
+		await waitForHeartbeat( sibling );
+
+		const beforeClose = await captureHeartbeatSend( sibling );
+		expect( beforeClose[ 'presence-ping' ] ).toBeUndefined();
+
+		await page.close();
+
+		const promoted = await waitForLeaderPing( sibling );
+		expect( promoted[ 'presence-ping' ].screen ).toBeTruthy();
+
+		await sibling.close();
+	} );
+
+	test( "relays the leader's Who's Online data to a sibling tab", async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-admin/' );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+
+		const sibling = await page.context().newPage();
+		await sibling.goto( '/wp-admin/' );
+		await waitForHeartbeat( sibling );
+
+		const [ relayed ] = await Promise.all( [
+			waitForOnlineDataTick( sibling ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+
+		expect(
+			relayed[ 'presence-online' ] || relayed[ 'presence-online-unchanged' ]
+		).toBeTruthy();
+
+		await sibling.close();
+	} );
+
+	test( 'tabs editing different posts are never coalesced with each other', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const postA = await requestUtils.createPost( {
+			title: 'Tab Coalescing Post A',
+			status: 'draft',
+		} );
+		const postB = await requestUtils.createPost( {
+			title: 'Tab Coalescing Post B',
+			status: 'draft',
+		} );
+
+		await page.goto( `/wp-admin/post.php?post=${ postA.id }&action=edit` );
+		await waitForHeartbeat( page );
+		const dataA = await waitForLeaderPing( page );
+		expect( dataA[ 'presence-editor-ping' ].post_id ).toBe( postA.id );
+
+		const pageB = await page.context().newPage();
+		await pageB.goto(
+			`/wp-admin/post.php?post=${ postB.id }&action=edit`
+		);
+		await waitForHeartbeat( pageB );
+
+		// A different post is a different context, so this tab must win
+		// its own leadership rather than being silenced as a false sibling.
+		const dataB = await waitForLeaderPing( pageB );
+		expect( dataB[ 'presence-editor-ping' ].post_id ).toBe( postB.id );
+
+		await pageB.close();
+	} );
+} );

--- a/tests/widgets/test-widget-active-posts.php
+++ b/tests/widgets/test-widget-active-posts.php
@@ -315,4 +315,50 @@ class WP_Test_Presence_Widget_Active_Posts extends WP_Presence_UnitTestCase {
 
 		$this->assertStringStartsWith( '[', $encoded );
 	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::enqueue_scripts
+	 * @covers WP_Presence_Widget_Active_Posts::get_i18n_strings
+	 */
+	public function test_enqueue_scripts_registers_script_with_i18n_config() {
+		wp_deregister_script( 'wp-presence-active-posts' );
+
+		$wp_scripts        = wp_scripts();
+		$wp_scripts->queue = array();
+		$wp_scripts->done  = array();
+
+		WP_Presence_Widget_Active_Posts::enqueue_scripts( 'index.php' );
+
+		$this->assertTrue( wp_script_is( 'wp-presence-active-posts', 'enqueued' ) );
+
+		$wp_scripts = wp_scripts();
+		$this->assertArrayHasKey( 'wp-presence-active-posts', $wp_scripts->registered );
+		$extra = $wp_scripts->registered['wp-presence-active-posts']->extra;
+		$this->assertArrayHasKey( 'before', $extra );
+
+		$found_config = false;
+		foreach ( $extra['before'] as $script ) {
+			if ( $script && strpos( $script, 'window.wpPresenceActivePosts =' ) !== false ) {
+				$found_config = true;
+				$this->assertStringContainsString( 'Posts currently being edited', $script );
+				break;
+			}
+		}
+		$this->assertTrue( $found_config );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::enqueue_scripts
+	 */
+	public function test_enqueue_scripts_skips_other_admin_pages() {
+		wp_deregister_script( 'wp-presence-active-posts' );
+
+		$wp_scripts        = wp_scripts();
+		$wp_scripts->queue = array();
+		$wp_scripts->done  = array();
+
+		WP_Presence_Widget_Active_Posts::enqueue_scripts( 'edit.php' );
+
+		$this->assertFalse( wp_script_is( 'wp-presence-active-posts', 'enqueued' ) );
+	}
 }


### PR DESCRIPTION
Fixes #269

## Summary

When the same user has an admin screen open in multiple tabs, each tab independently pings Heartbeat, triggering its own `wp_set_presence()` write and Who's Online/Active Posts/stale-screen lookup - redundant work that scales with tab count, not with actual viewers.

Elects one tab per context (Web Locks) to send the ping; sibling tabs skip their own ping and instead receive the elected tab's response over `BroadcastChannel`, so their widgets/banners stay live. Closing the elected tab promotes a sibling automatically. Tabs on a different post or screen are never coalesced with each other.

Covers all three tab-scoped ping mechanisms in the plugin:

- `presence-ping` / `presence-editor-ping` (admin + editor rooms, Who's Online) - dedupe key is screen + post + front-page context
- `presence-screen-ping` (stale-screen banner) - dedupe key is `screenKey`
- `presence-active-posts-ping` (Active Posts widget) - fixed dedupe key, since this ping carries no per-page context (sitewide data). Required first extracting its script from inline PHP into an external file (`assets/js/active-posts.js`) so it could be enqueued and coalesced like the other two.

Also ships `usePresenceUsers`, a React hook + coordinator for third-party consumers of the public presence REST endpoint - a related but separate improvement, unaffected by the wp-admin fix above since nothing in this plugin's own UI uses that hook yet.

## Test plan

- [x] New unit tests for the coordinator (`presence-poll-coordinator.test.js`)
- [x] New e2e tests per mechanism: election, promotion on leader-tab close, response relay, different-post/screen isolation
- [x] `npm run test` - no regressions
- [x] `npm run test:e2e` - no regressions
- [x] Manual multi-tab testing across all three mechanisms

<details>
<summary>Screenshots</summary>

<img width="3432" height="957" alt="image" src="https://github.com/user-attachments/assets/6782e509-c8c2-4679-aa43-250c88e147c7" />

<img width="3432" height="955" alt="image" src="https://github.com/user-attachments/assets/48e2a068-b72e-4dc0-af4d-a857823fe8e0" />

<img width="3432" height="1001" alt="image" src="https://github.com/user-attachments/assets/e1549ab0-c89f-4272-862b-11e143168236" />

<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/8b473701-b617-4108-8b7b-3bca5ea9fc60" />

<img width="972" height="602" alt="image" src="https://github.com/user-attachments/assets/f170dd7e-4aac-4e9b-9c57-b14e1af59f79" />

</details>


<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with implementation

</details>