### PR TITLE
perf: back off heartbeat polling interval for idle rooms

### DIFF
--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -9,9 +9,41 @@
 	const editorPostId = parseInt(config.editorPostId, 10) || 0;
 	const restUrl = config.restUrl || '';
 	const nonce = config.nonce || '';
+	const idleTicks = parseInt(config.idleTicks, 10) || 0;
+	const idleInterval = parseInt(config.idleInterval, 10) || 0;
+	const ttl = parseInt(config.ttl, 10) || 60;
+	const backoffEnabled = idleTicks > 0 && idleInterval > 0;
 
 	// Guards against duplicate leave() invocations.
 	let hasLeft = false;
+
+	let unchangedTicks = 0;
+	let lastOnlineHash = '';
+	let normalInterval = null;
+
+	// Reads the interval lazily (not at page load) so it reflects whatever
+	// another script, e.g. post.js's lock-refresh interval, already set.
+	function widenInterval() {
+		if (normalInterval !== null) {
+			return;
+		}
+		const current = wp.heartbeat.interval();
+		// Clamp under the TTL, or an idle-but-open tab would drop out of its own room between ticks.
+		const target = Math.min(idleInterval, ttl - 15);
+		if (target <= current) {
+			return;
+		}
+		normalInterval = current;
+		wp.heartbeat.interval(target);
+	}
+
+	function resetBackoff() {
+		unchangedTicks = 0;
+		if (normalInterval !== null) {
+			wp.heartbeat.interval(normalInterval);
+			normalInterval = null;
+		}
+	}
 
 	// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
 	$(function () {
@@ -43,6 +75,34 @@
 
 			hasLeft = false;
 		});
+
+		if (backoffEnabled) {
+			// Reuses the Who's Online widget's hash exchange on every screen,
+			// not just the Dashboard, to learn whether the room changed.
+			$(document).on('heartbeat-send', function (event, data) {
+				if (lastOnlineHash) {
+					data['presence-online-hash'] = lastOnlineHash;
+				}
+			});
+
+			$(document).on('heartbeat-tick', function (event, data) {
+				if (data['presence-online-unchanged']) {
+					unchangedTicks++;
+					if (unchangedTicks >= idleTicks) {
+						widenInterval();
+					}
+					return;
+				}
+				if (data['presence-online-hash']) {
+					lastOnlineHash = data['presence-online-hash'];
+				}
+				if (data['presence-online']) {
+					resetBackoff();
+				}
+			});
+
+			document.addEventListener('keydown', resetBackoff);
+		}
 	});
 
 	function leave() {
@@ -95,6 +155,7 @@
 	// does not sit out the next heartbeat interval.
 	document.addEventListener('visibilitychange', function () {
 		if (document.visibilityState === 'visible') {
+			resetBackoff();
 			tickNow();
 		}
 	});

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -13,6 +13,7 @@
 	const idleInterval = parseInt(config.idleInterval, 10) || 0;
 	const ttl = parseInt(config.ttl, 10) || 60;
 	const backoffEnabled = idleTicks > 0 && idleInterval > 0;
+	const TTL_SAFETY_MARGIN = 15;
 
 	// Guards against duplicate leave() invocations.
 	let hasLeft = false;
@@ -28,8 +29,8 @@
 			return;
 		}
 		const current = wp.heartbeat.interval();
-		// Clamp under the TTL, or an idle-but-open tab would drop out of its own room between ticks.
-		const target = Math.min(idleInterval, ttl - 15);
+		// Stay under the TTL, or an idle-but-open tab would drop out of its own room between ticks.
+		const target = Math.min(idleInterval, ttl - TTL_SAFETY_MARGIN);
 		if (target <= current) {
 			return;
 		}

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -29,6 +29,46 @@ function wp_presence_editor_state( $screen_id, $locked ) {
 }
 
 /**
+ * Returns how many consecutive unchanged ticks trigger the idle Heartbeat backoff.
+ *
+ * @since 0.1.24
+ *
+ * @return int Tick count. Default 5. 0 disables the backoff.
+ */
+function wp_presence_get_heartbeat_idle_ticks() {
+	/**
+	 * Filters the tick count.
+	 *
+	 * @since 0.1.24
+	 *
+	 * @param int $ticks Tick count. Default 5.
+	 */
+	return (int) apply_filters( 'wp_presence_heartbeat_idle_ticks', 5 );
+}
+
+/**
+ * Returns the desired widened Heartbeat interval, in seconds, for idle rooms.
+ *
+ * The client clamps this below the presence TTL, so it backs off by less
+ * than this (or not at all) on a screen whose normal interval is already
+ * near that ceiling.
+ *
+ * @since 0.1.24
+ *
+ * @return int Interval in seconds. Default 45.
+ */
+function wp_presence_get_heartbeat_idle_interval() {
+	/**
+	 * Filters the interval.
+	 *
+	 * @since 0.1.24
+	 *
+	 * @param int $interval Interval in seconds. Default 45.
+	 */
+	return (int) apply_filters( 'wp_presence_heartbeat_idle_interval', 45 );
+}
+
+/**
  * Enqueues heartbeat and the presence ping script on all admin pages.
  */
 function wp_presence_enqueue_heartbeat_ping() {
@@ -136,6 +176,9 @@ function wp_presence_enqueue_heartbeat_ping() {
 		'editorPostId' => $editor_post_id,
 		'restUrl'      => esc_url_raw( rest_url( 'wp-presence/v1/presence' ) ),
 		'nonce'        => wp_create_nonce( 'wp_rest' ),
+		'idleTicks'    => wp_presence_get_heartbeat_idle_ticks(),
+		'idleInterval' => wp_presence_get_heartbeat_idle_interval(),
+		'ttl'          => wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ),
 	);
 
 	wp_enqueue_script(

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -31,6 +31,8 @@ function wp_presence_editor_state( $screen_id, $locked ) {
 /**
  * Returns how many consecutive unchanged ticks trigger the idle Heartbeat backoff.
  *
+ * @access private
+ *
  * @since 0.1.24
  *
  * @return int Tick count. Default 5. 0 disables the backoff.
@@ -52,6 +54,8 @@ function wp_presence_get_heartbeat_idle_ticks() {
  * The client clamps this below the presence TTL, so it backs off by less
  * than this (or not at all) on a screen whose normal interval is already
  * near that ceiling.
+ *
+ * @access private
  *
  * @since 0.1.24
  *

--- a/tests/e2e/presence-heartbeat-backoff.test.js
+++ b/tests/e2e/presence-heartbeat-backoff.test.js
@@ -1,0 +1,116 @@
+/**
+ * Presence API — Heartbeat Idle Backoff E2E Tests
+ *
+ * Asserts that presence-ping.js widens the Heartbeat interval after enough
+ * consecutive unchanged ticks, and snaps it back on local activity.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js tests/e2e/presence-heartbeat-backoff.test.js
+ *
+ * @package WordPress
+ * @since 7.1.0
+ */
+import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
+
+const TEST_USERS = [
+	{
+		username: 'presence_test_backoff',
+		email: 'presence_test_backoff@example.com',
+		firstName: 'User',
+		lastName: 'B',
+		password: 'password',
+		roles: [ 'editor' ],
+	},
+];
+
+const test = base.extend( {
+	// A second user is required for the post-lock dialog (and its 10-second
+	// Heartbeat interval) to render on the edit screen at all.
+	testUsers: [
+		async ( { requestUtils }, use ) => {
+			for ( const user of TEST_USERS ) {
+				await requestUtils.createUser( user ).catch( ( error ) => {
+					if ( error?.code !== 'existing_user_login' ) {
+						throw error;
+					}
+				} );
+			}
+			await use( TEST_USERS );
+			await requestUtils.deleteAllUsers();
+		},
+		{ scope: 'test' },
+	],
+} );
+
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+/**
+ * Forces a heartbeat tick and resolves with the data object the tick carried.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<object>}
+ */
+function captureHeartbeatTick( page ) {
+	return page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				jQuery( document ).one( 'heartbeat-tick', ( event, data ) => {
+					resolve( data );
+				} );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+test.describe( 'Presence Heartbeat Idle Backoff', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'widens the interval after consecutive unchanged ticks, then snaps back on keydown', async ( {
+		admin,
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'E2E Heartbeat Backoff Test',
+			status: 'publish',
+		} );
+
+		await admin.visitAdminPage( 'post.php', `post=${ post.id }&action=edit` );
+		await waitForHeartbeat( page );
+
+		// The post-lock dialog is present (2+ users exist), so post.js has
+		// already set the interval to 10 seconds by the time heartbeat is ready.
+		const normalInterval = await page.evaluate( () => wp.heartbeat.interval() );
+		expect( normalInterval ).toBe( 10 );
+
+		// One tick establishes the room's hash; repeat until the client sees
+		// enough consecutive unchanged ticks to back off.
+		let widened = false;
+		for ( let i = 0; i < 10 && ! widened; i++ ) {
+			await captureHeartbeatTick( page );
+			const current = await page.evaluate( () => wp.heartbeat.interval() );
+			if ( current > normalInterval ) {
+				widened = true;
+			}
+		}
+
+		expect( widened ).toBe( true );
+		const widenedInterval = await page.evaluate( () => wp.heartbeat.interval() );
+		expect( widenedInterval ).toBeGreaterThan( normalInterval );
+		expect( widenedInterval ).toBeLessThan( 60 ); // Stays under the presence TTL.
+
+		await page.evaluate( () => {
+			document.dispatchEvent( new KeyboardEvent( 'keydown', { bubbles: true } ) );
+		} );
+
+		const afterKeydown = await page.evaluate( () => wp.heartbeat.interval() );
+		expect( afterKeydown ).toBe( normalInterval );
+	} );
+} );

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -170,6 +170,56 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_presence_enqueue_heartbeat_ping
+	 * @covers ::wp_presence_get_heartbeat_idle_ticks
+	 * @covers ::wp_presence_get_heartbeat_idle_interval
+	 */
+	public function test_ping_config_carries_idle_backoff_settings() {
+		wp_set_current_user( self::$editor_id );
+
+		$wp_scripts        = wp_scripts();
+		$wp_scripts->queue = array();
+		$wp_scripts->done  = array();
+		wp_deregister_script( 'wp-presence-ping' );
+
+		wp_presence_enqueue_heartbeat_ping();
+
+		$config = $this->get_ping_config();
+
+		$this->assertSame( 5, $config['idleTicks'] );
+		$this->assertSame( 45, $config['idleInterval'] );
+		$this->assertSame( WP_PRESENCE_DEFAULT_TTL, $config['ttl'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_get_heartbeat_idle_ticks
+	 */
+	public function test_idle_ticks_filter_overrides_default() {
+		add_filter(
+			'wp_presence_heartbeat_idle_ticks',
+			function () {
+				return 3;
+			}
+		);
+
+		$this->assertSame( 3, wp_presence_get_heartbeat_idle_ticks() );
+	}
+
+	/**
+	 * @covers ::wp_presence_get_heartbeat_idle_interval
+	 */
+	public function test_idle_interval_filter_overrides_default() {
+		add_filter(
+			'wp_presence_heartbeat_idle_interval',
+			function () {
+				return 90;
+			}
+		);
+
+		$this->assertSame( 90, wp_presence_get_heartbeat_idle_interval() );
+	}
+
+	/**
 	 * @covers ::wp_presence_editor_heartbeat_received
 	 */
 	public function test_editor_heartbeat_writes_presence() {


### PR DESCRIPTION
### Description

Closes #270.

The client counts consecutive Heartbeat ticks where nothing changed, then widens `wp.heartbeat.interval()` to poll less often. It snaps back to normal on a keystroke or when the tab becomes visible again.

### Review notes

- The wider interval never exceeds the 60-second presence TTL. On screens that already poll at 60s (dashboard, list tables), there's no room to widen further, so those screens are unaffected. Screens with a faster interval (like the 10s post-edit screen) get real savings, widening up to 45s.
- The hash check used to detect "nothing changed" now runs on every screen, not just the Dashboard. This also means non-Dashboard screens skip the full payload once state settles.
- Two new filters: `wp_presence_heartbeat_idle_ticks` (default 5) and `wp_presence_heartbeat_idle_interval` (default 45).

### Testing

1. Create a second user so the post-lock dialog (and its 10s interval) shows up, then edit an existing post as admin alone.
2. Watch Network → `admin-ajax`. After the first tick, responses should say `presence-online-unchanged`.
3. After 5 unchanged ticks in a row, check `wp.heartbeat.interval()` in the console — it should be 45.
4. Press a key on the page, or switch tabs away and back — the interval drops back to 10 right away.
5. Verified this manually end to end. Automated version: `tests/e2e/presence-heartbeat-backoff.test.js`.

### Screenshots

<img width="466" height="554" alt="Screenshot 2026-08-19 at 11 33 18 PM" src="https://github.com/user-attachments/assets/fad39a03-1de6-46fc-887e-6b27ea2c203c" />

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation and tests