### PR TITLE
feat: network presence UI for the Sites list, Users list, and network dashboard

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -822,3 +822,29 @@ function wp_presence_hydrate_room_users( $rooms, $timeout = WP_PRESENCE_DEFAULT_
 
 	return $rooms;
 }
+/**
+ * Renders a small avatar stack for a list of users.
+ *
+ * Shared across every surface that shows an overlapping avatar stack (the
+ * dashboard widget's overflow indicator, the network Sites list column, the
+ * network dashboard widget) so they all render the stack identically.
+ *
+ * @access private
+ * @param array $users Users, each with 'avatar_url' and 'display_name'.
+ * @param int   $max   Optional. Maximum avatars to show. Default 4.
+ * @param int   $size  Optional. Avatar width and height in pixels. Default 20.
+ * @return string HTML markup.
+ */
+function wp_presence_render_avatar_stack( $users, $max = 4, $size = 20 ) {
+	$stack_max = min( count( $users ), $max );
+	$html      = '<span class="presence-avatar-stack">';
+
+	foreach ( array_slice( $users, 0, $stack_max ) as $index => $user ) {
+		$z     = $stack_max - $index;
+		$html .= '<img src="' . esc_url( $user['avatar_url'] ) . '" width="' . (int) $size . '" height="' . (int) $size . '" style="z-index:' . (int) $z . '" alt="' . esc_attr( $user['display_name'] ) . '" />';
+	}
+
+	$html .= '</span>';
+
+	return $html;
+}

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -16,6 +16,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// How many people a network surface draws per site. Every one of them costs a
+// user load and an avatar URL, so this is also what the read path is asked to
+// resolve; the headcount beside the stack is the site's real total.
+if ( ! defined( 'WP_PRESENCE_NETWORK_AVATARS' ) ) {
+	define( 'WP_PRESENCE_NETWORK_AVATARS', 4 );
+}
+
 /**
  * Checks whether the network-wide presence summary table exists.
  *
@@ -332,20 +339,69 @@ function wp_presence_network_capability() {
 /**
  * Returns the distinct user IDs online anywhere on the network.
  *
+ * Reads the snapshot rather than the summary: the Users list column asks only
+ * whether a given row's user is in this set, so resolving a display name and
+ * an avatar URL for everyone online to answer that would be the whole cost of
+ * the read for none of its output.
+ *
  * @access private
  * @return int[] User IDs.
  */
 function wp_presence_get_network_online_user_ids() {
-	$summary  = wp_presence_get_network_summary();
 	$user_ids = array();
 
-	foreach ( $summary['sites'] as $site ) {
-		foreach ( $site['users'] as $user ) {
-			$user_ids[ $user['user_id'] ] = true;
+	foreach ( wp_presence_get_network_snapshot()['sites'] as $site_user_ids ) {
+		foreach ( $site_user_ids as $user_id ) {
+			$user_ids[ $user_id ] = true;
 		}
 	}
 
 	return array_keys( $user_ids );
+}
+
+/**
+ * Returns the sites a given user is currently online on.
+ *
+ * The summary is keyed by site, and the Network Users list needs it keyed by
+ * user, so the inversion is built once for the request and shared by every row
+ * rather than rescanning the network per row.
+ *
+ * @access private
+ * @param int $user_id The user to look up.
+ * @return WP_Site[] Sites the user is online on, busiest site first.
+ */
+function wp_presence_get_network_sites_for_user( $user_id ) {
+	$by_user = wp_presence_network_cached(
+		'sites-by-user',
+		static function () {
+			$by_user = array();
+
+			foreach ( wp_presence_get_network_snapshot()['sites'] as $blog_id => $site_user_ids ) {
+				foreach ( $site_user_ids as $site_user_id ) {
+					$by_user[ $site_user_id ][] = $blog_id;
+				}
+			}
+
+			return $by_user;
+		}
+	);
+
+	$blog_ids = $by_user[ (int) $user_id ] ?? array();
+
+	if ( ! $blog_ids ) {
+		return array();
+	}
+
+	// Resolved here rather than in the index above, so a network where nobody
+	// is looked up pays for no sites at all. get_sites() primes the site cache,
+	// so rows sharing a site resolve it once.
+	return get_sites(
+		array(
+			'site__in' => $blog_ids,
+			'number'   => 0,
+			'orderby'  => 'site__in',
+		)
+	);
 }
 
 /**

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -304,6 +304,25 @@ function wp_presence_network_capability() {
 }
 
 /**
+ * Returns the distinct user IDs online anywhere on the network.
+ *
+ * @access private
+ * @return int[] User IDs.
+ */
+function wp_presence_get_network_online_user_ids() {
+	$summary  = wp_presence_get_network_summary();
+	$user_ids = array();
+
+	foreach ( $summary['sites'] as $site ) {
+		foreach ( $site['users'] as $user ) {
+			$user_ids[ $user['user_id'] ] = true;
+		}
+	}
+
+	return array_keys( $user_ids );
+}
+
+/**
  * Returns the network-wide presence summary.
  *
  * Reads the shared wp_presence_network_summary table -- one row per site,

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Network Sites list: "Online" column.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds an "Online" column to the Network Admin Sites list table.
+ *
+ * @param array $columns Existing column headers.
+ * @return array Column headers with "Online" added.
+ */
+function wp_presence_register_network_sites_column( $columns ) {
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return $columns;
+	}
+
+	$columns['presence_online'] = __( 'Online', 'presence-api' );
+
+	return $columns;
+}
+
+/**
+ * Renders the "Online" column for a single row of the Sites list table.
+ *
+ * Rendered once per page load, the same as every other column on this table
+ * (e.g. "Last Updated"), rather than kept live via Heartbeat: the table isn't
+ * ours to own the markup or lifecycle of, and a snapshot as of page load
+ * matches how the rest of the table already behaves. Called once per row, but
+ * wp_presence_get_network_summary() is one query against the shared network
+ * summary table, not one query per site, so this costs one query per page
+ * load rather than one per row.
+ *
+ * @param string $column_name Column being rendered.
+ * @param int    $blog_id     The site ID for the current row.
+ */
+function wp_presence_render_network_sites_column( $column_name, $blog_id ) {
+	if ( 'presence_online' !== $column_name ) {
+		return;
+	}
+
+	$summary = wp_presence_get_network_summary();
+
+	foreach ( $summary['sites'] as $site ) {
+		if ( (int) $site['blog_id'] === (int) $blog_id ) {
+			echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'] ) );
+			echo ' ' . (int) $site['user_count'];
+			return;
+		}
+	}
+
+	echo '&#8212;';
+}

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -32,9 +32,8 @@ function wp_presence_register_network_sites_column( $columns ) {
  * (e.g. "Last Updated"), rather than kept live via Heartbeat: the table isn't
  * ours to own the markup or lifecycle of, and a snapshot as of page load
  * matches how the rest of the table already behaves. Called once per row, but
- * wp_presence_get_network_summary() is one query against the shared network
- * summary table, not one query per site, so this costs one query per page
- * load rather than one per row.
+ * wp_presence_get_network_summary() holds its build for the request, so the
+ * summary is read and hydrated once per page load rather than once per row.
  *
  * @param string $column_name Column being rendered.
  * @param int    $blog_id     The site ID for the current row.

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -31,9 +31,11 @@ function wp_presence_register_network_sites_column( $columns ) {
  * Rendered once per page load, the same as every other column on this table
  * (e.g. "Last Updated"), rather than kept live via Heartbeat: the table isn't
  * ours to own the markup or lifecycle of, and a snapshot as of page load
- * matches how the rest of the table already behaves. Called once per row, but
- * wp_presence_get_network_summary() holds its build for the request, so the
- * summary is read and hydrated once per page load rather than once per row.
+ * matches how the rest of the table already behaves.
+ *
+ * Called once per row, and asks for that row's site only. The underlying
+ * snapshot is read once for the request; what each row adds is resolving the
+ * handful of people whose avatars it is about to draw.
  *
  * @param string $column_name Column being rendered.
  * @param int    $blog_id     The site ID for the current row.
@@ -43,15 +45,20 @@ function wp_presence_render_network_sites_column( $column_name, $blog_id ) {
 		return;
 	}
 
-	$summary = wp_presence_get_network_summary();
+	$summary = wp_presence_get_network_summary(
+		array(
+			'blog_id'        => (int) $blog_id,
+			'users_per_site' => WP_PRESENCE_NETWORK_AVATARS,
+		)
+	);
 
-	foreach ( $summary['sites'] as $site ) {
-		if ( (int) $site['blog_id'] === (int) $blog_id ) {
-			echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'] ) );
-			echo ' ' . (int) $site['user_count'];
-			return;
-		}
+	if ( ! $summary['sites'] ) {
+		echo '&#8212;';
+		return;
 	}
 
-	echo '&#8212;';
+	$site = $summary['sites'][0];
+
+	echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'], WP_PRESENCE_NETWORK_AVATARS ) );
+	echo ' ' . (int) $site['user_count'];
 }

--- a/includes/network-user-list.php
+++ b/includes/network-user-list.php
@@ -95,9 +95,10 @@ function wp_presence_register_network_users_column( $columns ) {
 /**
  * Renders the "Online" column for a single row of the Network Users list table.
  *
- * Called once per row, but wp_presence_get_network_summary() holds its build
- * for the request, so the summary is read and hydrated once per page load
- * rather than once per row.
+ * Called once per row. The column names sites, not people, so it reads the
+ * user-to-site index rather than the summary: resolving a display name and an
+ * avatar URL for everyone online would be the whole cost of the read for
+ * output this column never uses.
  *
  * @param string $output      Existing column output.
  * @param string $column_name Column being rendered.
@@ -109,20 +110,17 @@ function wp_presence_render_network_users_column( $output, $column_name, $user_i
 		return $output;
 	}
 
-	$summary = wp_presence_get_network_summary();
-	$sites   = array();
-
-	foreach ( $summary['sites'] as $site ) {
-		foreach ( $site['users'] as $user ) {
-			if ( (int) $user['user_id'] === (int) $user_id ) {
-				$sites[] = $site['domain'] . $site['path'];
-			}
-		}
-	}
+	$sites = wp_presence_get_network_sites_for_user( $user_id );
 
 	if ( ! $sites ) {
 		return '&#8212;';
 	}
 
-	return esc_html( implode( ', ', $sites ) );
+	$names = array();
+
+	foreach ( $sites as $site ) {
+		$names[] = $site->domain . $site->path;
+	}
+
+	return esc_html( implode( ', ', $names ) );
 }

--- a/includes/network-user-list.php
+++ b/includes/network-user-list.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Network Users list: "Online" view, filter, and column.
+ *
+ * Mirrors the single-site Users list "Online" view in includes/user-list.php,
+ * scoped to users online anywhere on the network rather than the current site.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds an "Online" view to the Network Users list table.
+ *
+ * @param array $views Existing views.
+ * @return array Modified views.
+ */
+function wp_presence_network_users_views( $views ) {
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return $views;
+	}
+
+	$online_count = count( wp_presence_get_network_online_user_ids() );
+	$is_current   = isset( $_GET['presence_status'] ) && 'online' === $_GET['presence_status']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+	$class = $is_current ? 'current' : '';
+	$url   = wp_nonce_url( network_admin_url( 'users.php?presence_status=online' ), 'presence_online_filter' );
+
+	$views['presence_online'] = sprintf(
+		'<a href="%s" class="%s">%s <span class="count">(%d)</span></a>',
+		esc_url( $url ),
+		$class,
+		esc_html__( 'Online', 'presence-api' ),
+		$online_count
+	);
+
+	if ( $is_current && isset( $views['all'] ) ) {
+		$views['all'] = str_replace( 'class="current"', '', $views['all'] );
+	}
+
+	return $views;
+}
+
+/**
+ * Restricts the Network Users list query to users online anywhere on the
+ * network, when the "Online" view is active.
+ *
+ * @param array $args Query args passed to WP_User_Query.
+ * @return array Modified query args.
+ */
+function wp_presence_filter_network_online_users( $args ) {
+	if ( ! is_network_admin() || ! current_user_can( wp_presence_network_capability() ) ) {
+		return $args;
+	}
+
+	if ( empty( $_GET['presence_status'] ) || 'online' !== $_GET['presence_status'] ) {
+		return $args;
+	}
+
+	if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'presence_online_filter' ) ) {
+		return $args;
+	}
+
+	$args['include'] = wp_presence_get_network_online_user_ids();
+
+	if ( ! $args['include'] ) {
+		// WP_User_Query treats an empty include as "no restriction", not "match
+		// nothing," so force a result set of zero rather than falling through
+		// to every network user.
+		$args['include'] = array( 0 );
+	}
+
+	return $args;
+}
+
+/**
+ * Adds an "Online" column to the Network Users list table.
+ *
+ * @param array $columns Existing column headers.
+ * @return array Column headers with "Online" added.
+ */
+function wp_presence_register_network_users_column( $columns ) {
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return $columns;
+	}
+
+	$columns['presence_online'] = __( 'Online', 'presence-api' );
+
+	return $columns;
+}
+
+/**
+ * Renders the "Online" column for a single row of the Network Users list table.
+ *
+ * Called once per row, but wp_presence_get_network_summary() is one query
+ * against the shared network summary table, not one query per site, so this
+ * costs one query per page load rather than one per row.
+ *
+ * @param string $output      Existing column output.
+ * @param string $column_name Column being rendered.
+ * @param int    $user_id     The user ID for the current row.
+ * @return string Column output.
+ */
+function wp_presence_render_network_users_column( $output, $column_name, $user_id ) {
+	if ( 'presence_online' !== $column_name ) {
+		return $output;
+	}
+
+	$summary = wp_presence_get_network_summary();
+	$sites   = array();
+
+	foreach ( $summary['sites'] as $site ) {
+		foreach ( $site['users'] as $user ) {
+			if ( (int) $user['user_id'] === (int) $user_id ) {
+				$sites[] = $site['domain'] . $site['path'];
+			}
+		}
+	}
+
+	if ( ! $sites ) {
+		return '&#8212;';
+	}
+
+	return esc_html( implode( ', ', $sites ) );
+}

--- a/includes/network-user-list.php
+++ b/includes/network-user-list.php
@@ -95,9 +95,9 @@ function wp_presence_register_network_users_column( $columns ) {
 /**
  * Renders the "Online" column for a single row of the Network Users list table.
  *
- * Called once per row, but wp_presence_get_network_summary() is one query
- * against the shared network summary table, not one query per site, so this
- * costs one query per page load rather than one per row.
+ * Called once per row, but wp_presence_get_network_summary() holds its build
+ * for the request, so the summary is read and hydrated once per page load
+ * rather than once per row.
  *
  * @param string $output      Existing column output.
  * @param string $column_name Column being rendered.

--- a/includes/user-list.php
+++ b/includes/user-list.php
@@ -56,10 +56,15 @@ function wp_presence_users_views( $views ) {
 /**
  * Filters the users query to only include online users when presence_status=online.
  *
+ * Stands down in Network Admin. is_admin() is true there too, and the Network
+ * Users list runs its own WP_User_Query, so without this the network "Online"
+ * view would have its network-wide set of IDs replaced with the ones online on
+ * whichever site the request resolved to.
+ *
  * @param WP_User_Query $query The user query.
  */
 function wp_presence_filter_online_users( $query ) {
-	if ( ! is_admin() || ! current_user_can( 'edit_posts' ) ) {
+	if ( ! is_admin() || is_network_admin() || ! current_user_can( 'edit_posts' ) ) {
 		return;
 	}
 

--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -85,14 +85,42 @@ class WP_Presence_Network_Widget_Whos_Online {
 	 */
 	public static function render() {
 		echo '<div id="presence-network-widget-list" aria-live="polite" tabindex="-1">';
-		self::render_summary( wp_presence_get_network_summary() );
+		self::render_summary( self::get_summary() );
 		echo '</div>';
+	}
+
+	/**
+	 * Reads the slice of the network this widget draws.
+	 *
+	 * Five sites with four avatars each, asked for as five sites with four
+	 * avatars each. The widget is on the network dashboard, so on a large
+	 * network this read is the one that has to stay cheap.
+	 *
+	 * @return array See wp_presence_get_network_summary().
+	 */
+	private static function get_summary() {
+		return wp_presence_get_network_summary(
+			array(
+				'sites'          => self::VISIBLE_SITES,
+				'users_per_site' => WP_PRESENCE_NETWORK_AVATARS,
+			)
+		);
+	}
+
+	/**
+	 * Returns how many sites are online beyond the ones being shown.
+	 *
+	 * @param array $summary Return value of self::get_summary().
+	 * @return int Site count, zero if the whole network fits.
+	 */
+	private static function overflow_count( $summary ) {
+		return max( 0, (int) $summary['total_sites_online'] - count( $summary['sites'] ) );
 	}
 
 	/**
 	 * Renders the compact site list for a network summary.
 	 *
-	 * @param array $summary Return value of wp_presence_get_network_summary().
+	 * @param array $summary Return value of self::get_summary().
 	 */
 	private static function render_summary( $summary ) {
 		if ( empty( $summary['sites'] ) ) {
@@ -100,14 +128,11 @@ class WP_Presence_Network_Widget_Whos_Online {
 			return;
 		}
 
-		$visible  = array_slice( $summary['sites'], 0, self::VISIBLE_SITES );
-		$overflow = array_slice( $summary['sites'], self::VISIBLE_SITES );
-
 		echo '<ul class="presence-user-list" aria-label="' . esc_attr__( 'Sites with online users', 'presence-api' ) . '">';
 
-		foreach ( $visible as $site ) {
+		foreach ( $summary['sites'] as $site ) {
 			echo '<li class="presence-site-item">';
-			echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'] ) );
+			echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'], WP_PRESENCE_NETWORK_AVATARS ) );
 			echo '<span class="presence-site-info"><a href="' . esc_url( $site['url'] ) . '">' . esc_html( $site['domain'] . $site['path'] ) . '</a></span>';
 			echo '<span class="presence-site-count">' . (int) $site['user_count'] . '</span>';
 			echo '</li>';
@@ -115,15 +140,17 @@ class WP_Presence_Network_Widget_Whos_Online {
 
 		echo '</ul>';
 
-		if ( ! empty( $overflow ) ) {
+		$overflow = self::overflow_count( $summary );
+
+		if ( $overflow ) {
 			printf(
 				'<a href="%1$s" class="presence-more-link">%2$s</a>',
 				esc_url( network_admin_url( 'sites.php' ) ),
 				esc_html(
 					sprintf(
 						/* translators: %d: Number of additional sites with online users. */
-						_n( '+%d more site — view all', '+%d more sites — view all', count( $overflow ), 'presence-api' ),
-						count( $overflow )
+						_n( '+%d more site — view all', '+%d more sites — view all', $overflow, 'presence-api' ),
+						$overflow
 					)
 				)
 			);
@@ -153,8 +180,9 @@ class WP_Presence_Network_Widget_Whos_Online {
 			return $response;
 		}
 
-		$summary     = wp_presence_get_network_summary();
-		$hash        = self::hash_summary( $summary );
+		$summary     = self::get_summary();
+		$overflow    = self::overflow_count( $summary );
+		$hash        = self::hash_summary( $summary, $overflow );
 		$client_hash = isset( $data['presence-network-widget-hash'] ) ? sanitize_text_field( $data['presence-network-widget-hash'] ) : '';
 
 		if ( $client_hash && $client_hash === $hash ) {
@@ -163,30 +191,31 @@ class WP_Presence_Network_Widget_Whos_Online {
 			return $response;
 		}
 
-		$response['presence-network-widget']      = $summary['sites'];
-		$response['presence-network-widget-hash'] = $hash;
+		$response['presence-network-widget']          = $summary['sites'];
+		$response['presence-network-widget-overflow'] = $overflow;
+		$response['presence-network-widget-hash']     = $hash;
 
 		return $response;
 	}
 
 	/**
-	 * Hashes the meaningful state of a network summary.
+	 * Hashes the state this widget draws.
 	 *
-	 * @param array $summary Return value of wp_presence_get_network_summary().
+	 * The payload itself, rather than a picked-out subset of it. A hash over
+	 * blog IDs and user IDs alone held a stale rename or a changed avatar on
+	 * screen for as long as the same people stayed online, and a hash over the
+	 * whole network never matched twice on a network large enough for the sixth
+	 * site to keep changing out of sight.
+	 *
+	 * The read path already returns sites busiest-first and users by name, so
+	 * there is nothing left to normalize here.
+	 *
+	 * @param array $summary  Return value of self::get_summary().
+	 * @param int   $overflow Sites online beyond the ones being sent.
 	 * @return string The state hash.
 	 */
-	private static function hash_summary( $summary ) {
-		$state = array();
-
-		foreach ( $summary['sites'] as $site ) {
-			$user_ids = wp_list_pluck( $site['users'], 'user_id' );
-			sort( $user_ids );
-			$state[] = array( $site['blog_id'], $user_ids );
-		}
-
-		sort( $state );
-
-		return md5( (string) wp_json_encode( $state ) );
+	private static function hash_summary( $summary, $overflow ) {
+		return md5( (string) wp_json_encode( array( $summary['sites'], $overflow ) ) );
 	}
 
 	/**
@@ -211,7 +240,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 
 	var i18n = %s;
 	var viewAllUrl = %s;
-	var visibleMax = %d;
+	var avatarMax = %d;
 	var lastHash = '';
 	var lastSignature = '';
 
@@ -222,7 +251,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 	}
 
 	function buildAvatarStack(users) {
-		var stackMax = Math.min(users.length, 4);
+		var stackMax = Math.min(users.length, avatarMax);
 		var html = '<span class="presence-avatar-stack">';
 		users.slice(0, stackMax).forEach(function(user, idx) {
 			if (user.avatar_url) {
@@ -233,24 +262,23 @@ class WP_Presence_Network_Widget_Whos_Online {
 		return html;
 	}
 
-	function buildListHtml(sites) {
+	// Already cut to the sites and avatars this widget shows, so nothing is
+	// sliced here; overflow is a count the server sends, not what is left over.
+	function buildListHtml(sites, overflow) {
 		if (!sites.length) {
 			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
 		}
 
-		var visible = sites.slice(0, visibleMax);
-		var overflow = sites.slice(visibleMax);
-
 		var html = '<ul class="presence-user-list">';
-		visible.forEach(function(site) {
+		sites.forEach(function(site) {
 			html += '<li class="presence-site-item">' + buildAvatarStack(site.users);
 			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
 			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
 		});
 		html += '</ul>';
 
-		if (overflow.length) {
-			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">+' + overflow.length + ' — ' + esc(i18n.viewAll) + '</a>';
+		if (overflow > 0) {
+			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">+' + overflow + ' — ' + esc(i18n.viewAll) + '</a>';
 		}
 
 		return html;
@@ -279,12 +307,16 @@ class WP_Presence_Network_Widget_Whos_Online {
 			return;
 		}
 
-		var sig = data['presence-network-widget'].map(function(s) {
-			return s.blog_id + ':' + s.users.map(function(u) { return u.user_id; }).sort().join(',');
-		}).sort().join('|');
+		var sites = data['presence-network-widget'];
+		var overflow = data['presence-network-widget-overflow'] || 0;
+
+		// Signature over what gets drawn, matching the server-side hash: a
+		// rename or a new avatar has to repaint, and the order is already the
+		// order it renders in.
+		var sig = JSON.stringify([sites, overflow]);
 
 		if (sig !== lastSignature) {
-			container.html(buildListHtml(data['presence-network-widget']));
+			container.html(buildListHtml(sites, overflow));
 			lastSignature = sig;
 		}
 	});
@@ -292,7 +324,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 JS,
 			$i18n_json,
 			wp_json_encode( esc_url_raw( network_admin_url( 'sites.php' ) ) ),
-			self::VISIBLE_SITES
+			WP_PRESENCE_NETWORK_AVATARS
 		);
 	}
 }

--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Network Dashboard Widget: Who's Online
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the network dashboard's "Who's Online" widget with Heartbeat integration.
+ *
+ * The one new surface this plugin adds for multisite: everything else folds
+ * into existing Network Admin screens (Sites and Users list columns), but a
+ * dashboard widget mirrors the single-site "at a glance" pattern and has no
+ * existing native screen to fold into.
+ */
+class WP_Presence_Network_Widget_Whos_Online {
+
+	/**
+	 * Maximum number of sites shown before linking out to the Sites list.
+	 *
+	 * @var int
+	 */
+	const VISIBLE_SITES = 5;
+
+	/**
+	 * Registers the network dashboard widget.
+	 */
+	public static function register() {
+		if ( ! current_user_can( wp_presence_network_capability() ) ) {
+			return;
+		}
+
+		wp_add_dashboard_widget(
+			'presence_network_whos_online',
+			__( "Who's Online", 'presence-api' ),
+			array( __CLASS__, 'render' )
+		);
+
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueues the widget's JavaScript and CSS.
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public static function enqueue_scripts( $hook_suffix ) {
+		if ( 'index.php' !== $hook_suffix ) {
+			return;
+		}
+
+		wp_enqueue_script( 'heartbeat' );
+		wp_add_inline_script( 'heartbeat', self::get_inline_script() );
+
+		wp_register_style( 'presence-network-widget', false, array(), WP_PRESENCE_VERSION );
+		wp_enqueue_style( 'presence-network-widget' );
+		wp_add_inline_style( 'presence-network-widget', self::get_inline_css() );
+	}
+
+	/**
+	 * Returns the inline CSS for the widget.
+	 *
+	 * @return string CSS code.
+	 */
+	private static function get_inline_css() {
+		return '#presence-network-widget-list p { margin: 0; padding: 6px 12px; color: #646970; }
+			#presence-network-widget-list .presence-user-list { margin: 0; }
+			#presence-network-widget-list .presence-site-item { display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-bottom: 1px solid #f0f0f1; }
+			#presence-network-widget-list .presence-site-item:last-child { border-bottom: none; }
+			#presence-network-widget-list .presence-site-info { flex: 1; min-width: 0; }
+			#presence-network-widget-list .presence-site-count { color: #646970; font-size: 12px; }
+			#presence-network-widget-list .presence-more-link { display: block; padding: 6px 12px; color: var(--wp-admin-theme-color, #2271b1); font-size: 13px; text-decoration: none; }
+			#presence-network-widget-list .presence-more-link:hover { text-decoration: underline; }
+			#presence-network-widget-list .presence-avatar-stack { display: inline-flex; align-items: center; }
+			#presence-network-widget-list .presence-avatar-stack img { border-radius: 50%; width: 20px; height: 20px; margin-inline-start: -6px; box-shadow: 0 0 0 2px #fff; position: relative; }
+			#presence-network-widget-list .presence-avatar-stack img:first-child { margin-inline-start: 0; }';
+	}
+
+	/**
+	 * Renders the widget.
+	 */
+	public static function render() {
+		echo '<div id="presence-network-widget-list" aria-live="polite" tabindex="-1">';
+		self::render_summary( wp_presence_get_network_summary() );
+		echo '</div>';
+	}
+
+	/**
+	 * Renders the compact site list for a network summary.
+	 *
+	 * @param array $summary Return value of wp_presence_get_network_summary().
+	 */
+	private static function render_summary( $summary ) {
+		if ( empty( $summary['sites'] ) ) {
+			echo '<p>' . esc_html__( 'No users are currently online anywhere on the network.', 'presence-api' ) . '</p>';
+			return;
+		}
+
+		$visible  = array_slice( $summary['sites'], 0, self::VISIBLE_SITES );
+		$overflow = array_slice( $summary['sites'], self::VISIBLE_SITES );
+
+		echo '<ul class="presence-user-list" aria-label="' . esc_attr__( 'Sites with online users', 'presence-api' ) . '">';
+
+		foreach ( $visible as $site ) {
+			echo '<li class="presence-site-item">';
+			echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'] ) );
+			echo '<span class="presence-site-info"><a href="' . esc_url( $site['url'] ) . '">' . esc_html( $site['domain'] . $site['path'] ) . '</a></span>';
+			echo '<span class="presence-site-count">' . (int) $site['user_count'] . '</span>';
+			echo '</li>';
+		}
+
+		echo '</ul>';
+
+		if ( ! empty( $overflow ) ) {
+			printf(
+				'<a href="%1$s" class="presence-more-link">%2$s</a>',
+				esc_url( network_admin_url( 'sites.php' ) ),
+				esc_html(
+					sprintf(
+						/* translators: %d: Number of additional sites with online users. */
+						_n( '+%d more site — view all', '+%d more sites — view all', count( $overflow ), 'presence-api' ),
+						count( $overflow )
+					)
+				)
+			);
+		}
+	}
+
+	/**
+	 * Handles the heartbeat received event for the network dashboard widget.
+	 *
+	 * Self-gates on a widget-specific ping key so every other admin screen's
+	 * tick costs one empty() check here, never the capability check or the
+	 * summary query.
+	 *
+	 * @param array  $response  The Heartbeat response.
+	 * @param array  $data      The $_POST data sent.
+	 * @param string $screen_id The screen ID.
+	 * Nonce verification is handled by WordPress in wp_ajax_heartbeat().
+	 *
+	 * @return array The Heartbeat response.
+	 */
+	public static function heartbeat_received( $response, $data, $screen_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by filter signature.
+		if ( empty( $data['presence-network-widget-ping'] ) ) {
+			return $response;
+		}
+
+		if ( ! current_user_can( wp_presence_network_capability() ) ) {
+			return $response;
+		}
+
+		$summary     = wp_presence_get_network_summary();
+		$hash        = self::hash_summary( $summary );
+		$client_hash = isset( $data['presence-network-widget-hash'] ) ? sanitize_text_field( $data['presence-network-widget-hash'] ) : '';
+
+		if ( $client_hash && $client_hash === $hash ) {
+			$response['presence-network-widget-unchanged'] = true;
+
+			return $response;
+		}
+
+		$response['presence-network-widget']      = $summary['sites'];
+		$response['presence-network-widget-hash'] = $hash;
+
+		return $response;
+	}
+
+	/**
+	 * Hashes the meaningful state of a network summary.
+	 *
+	 * @param array $summary Return value of wp_presence_get_network_summary().
+	 * @return string The state hash.
+	 */
+	private static function hash_summary( $summary ) {
+		$state = array();
+
+		foreach ( $summary['sites'] as $site ) {
+			$user_ids = wp_list_pluck( $site['users'], 'user_id' );
+			sort( $user_ids );
+			$state[] = array( $site['blog_id'], $user_ids );
+		}
+
+		sort( $state );
+
+		return md5( (string) wp_json_encode( $state ) );
+	}
+
+	/**
+	 * Returns the inline JavaScript for Heartbeat integration.
+	 *
+	 * @return string JavaScript code.
+	 */
+	private static function get_inline_script() {
+		$i18n_json = wp_json_encode(
+			array(
+				'noUsersOnline' => __( 'No users are currently online anywhere on the network.', 'presence-api' ),
+				'viewAll'       => __( 'view all', 'presence-api' ),
+			)
+		);
+
+		return sprintf(
+			<<<'JS'
+(function($) {
+	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+		return;
+	}
+
+	var i18n = %s;
+	var viewAllUrl = %s;
+	var visibleMax = %d;
+	var lastHash = '';
+	var lastSignature = '';
+
+	function esc(str) {
+		var el = document.createElement('span');
+		el.textContent = str;
+		return el.innerHTML;
+	}
+
+	function buildAvatarStack(users) {
+		var stackMax = Math.min(users.length, 4);
+		var html = '<span class="presence-avatar-stack">';
+		users.slice(0, stackMax).forEach(function(user, idx) {
+			if (user.avatar_url) {
+				html += '<img src="' + esc(user.avatar_url) + '" width="20" height="20" style="z-index:' + (stackMax - idx) + '" alt="' + esc(user.display_name) + '" />';
+			}
+		});
+		html += '</span>';
+		return html;
+	}
+
+	function buildListHtml(sites) {
+		if (!sites.length) {
+			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
+		}
+
+		var visible = sites.slice(0, visibleMax);
+		var overflow = sites.slice(visibleMax);
+
+		var html = '<ul class="presence-user-list">';
+		visible.forEach(function(site) {
+			html += '<li class="presence-site-item">' + buildAvatarStack(site.users);
+			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
+			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
+		});
+		html += '</ul>';
+
+		if (overflow.length) {
+			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">+' + overflow.length + ' — ' + esc(i18n.viewAll) + '</a>';
+		}
+
+		return html;
+	}
+
+	$(document).on('heartbeat-send', function(event, data) {
+		data['presence-network-widget-ping'] = true;
+		if (lastHash) {
+			data['presence-network-widget-hash'] = lastHash;
+		}
+	});
+
+	$(document).on('heartbeat-tick', function(event, data) {
+		if (data['presence-network-widget-unchanged']) {
+			return;
+		}
+
+		if (!data['presence-network-widget']) {
+			return;
+		}
+
+		lastHash = data['presence-network-widget-hash'] || '';
+
+		var container = $('#presence-network-widget-list');
+		if (!container.length) {
+			return;
+		}
+
+		var sig = data['presence-network-widget'].map(function(s) {
+			return s.blog_id + ':' + s.users.map(function(u) { return u.user_id; }).sort().join(',');
+		}).sort().join('|');
+
+		if (sig !== lastSignature) {
+			container.html(buildListHtml(data['presence-network-widget']));
+			lastSignature = sig;
+		}
+	});
+})(jQuery);
+JS,
+			$i18n_json,
+			wp_json_encode( esc_url_raw( network_admin_url( 'sites.php' ) ) ),
+			self::VISIBLE_SITES
+		);
+	}
+}

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -660,45 +660,35 @@ JS,
 			echo '</ul>';
 
 			if ( ! empty( $overflow ) ) {
-				$stack_max = min( count( $overflow ), 4 );
+				$stack_max   = min( count( $overflow ), 4 );
+				$stack_users = array();
+
+				foreach ( array_slice( $overflow, 0, $stack_max ) as $oentry ) {
+					$ouser = get_userdata( $oentry->user_id );
+
+					if ( ! $ouser ) {
+						continue;
+					}
+
+					$stack_users[] = array(
+						'display_name' => $ouser->display_name,
+						'avatar_url'   => get_avatar_url( $ouser->ID, array( 'size' => 24 ) ),
+					);
+				}
 
 				if ( count( $overflow ) > self::get_overflow_threshold() ) {
 					// Summary mode: avatar stack + count linking to Users page.
 					echo '<a href="' . esc_url( admin_url( 'users.php?presence_status=online' ) ) . '" class="presence-overflow-toggle">';
-					echo '<span class="presence-avatar-stack">';
-
-					foreach ( array_slice( $overflow, 0, $stack_max ) as $index => $oentry ) {
-						$ouser = get_userdata( $oentry->user_id );
-
-						if ( ! $ouser ) {
-							continue;
-						}
-
-						$z = $stack_max - $index;
-						echo '<img src="' . esc_url( get_avatar_url( $ouser->ID, array( 'size' => 24 ) ) ) . '" width="24" height="24" style="z-index:' . (int) $z . '" alt="' . esc_attr( $ouser->display_name ) . '" />';
-					}
-
-					echo '</span><span class="presence-overflow-text">';
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4, 24 ) );
+					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more — view all users', 'presence-api' ), count( $overflow ) ) );
 					echo '</span></a>';
 				} else {
 					// Expandable list mode.
 					echo '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="false" aria-controls="presence-overflow-list">';
-					echo '<span class="presence-avatar-stack">';
-
-					foreach ( array_slice( $overflow, 0, $stack_max ) as $index => $oentry ) {
-						$ouser = get_userdata( $oentry->user_id );
-
-						if ( ! $ouser ) {
-							continue;
-						}
-
-						$z = $stack_max - $index;
-						echo '<img src="' . esc_url( get_avatar_url( $ouser->ID, array( 'size' => 24 ) ) ) . '" width="24" height="24" style="z-index:' . (int) $z . '" alt="' . esc_attr( $ouser->display_name ) . '" />';
-					}
-
-					echo '</span><span class="presence-overflow-text">';
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4, 24 ) );
+					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more', 'presence-api' ), count( $overflow ) ) );
 					echo '</span></button>';

--- a/presence-api.php
+++ b/presence-api.php
@@ -102,6 +102,9 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget
 
 if ( is_multisite() ) {
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-functions.php';
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-sites-list.php';
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-user-list.php';
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-network-widget-whos-online.php';
 }
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -334,6 +337,19 @@ add_action( 'wp_dashboard_setup', array( 'WP_Presence_Widget_Whos_Online', 'regi
 add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Whos_Online', 'heartbeat_received' ), 10, 3 );
 add_action( 'wp_dashboard_setup', array( 'WP_Presence_Widget_Active_Posts', 'register' ) );
 add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Active_Posts', 'heartbeat_received' ), 10, 3 );
+
+if ( is_multisite() ) {
+	add_filter( 'wpmu_blogs_columns', 'wp_presence_register_network_sites_column' );
+	add_action( 'manage_sites_custom_column', 'wp_presence_render_network_sites_column', 10, 2 );
+
+	add_filter( 'views_users-network', 'wp_presence_network_users_views' );
+	add_filter( 'users_list_table_query_args', 'wp_presence_filter_network_online_users' );
+	add_filter( 'wpmu_users_columns', 'wp_presence_register_network_users_column' );
+	add_filter( 'manage_users-network_custom_column', 'wp_presence_render_network_users_column', 10, 3 );
+
+	add_action( 'wp_network_dashboard_setup', array( 'WP_Presence_Network_Widget_Whos_Online', 'register' ) );
+	add_filter( 'heartbeat_received', array( 'WP_Presence_Network_Widget_Whos_Online', 'heartbeat_received' ), 10, 3 );
+}
 
 if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG )
 	&& function_exists( 'wp_presence_heartbeat_widget_register' )

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -707,4 +707,58 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		wp_remove_presence( wp_presence_admin_room(), 'client-1' );
 		$this->assertSame( 1, $fired );
 	}
+	/**
+	 * The avatars overlap, so the first user has to paint on top of the ones
+	 * after them rather than under.
+	 *
+	 * @covers ::wp_presence_render_avatar_stack
+	 */
+	public function test_avatar_stack_paints_the_first_user_on_top() {
+		$html = wp_presence_render_avatar_stack(
+			array(
+				array(
+					'avatar_url'   => 'https://example.com/ana.png',
+					'display_name' => 'Ana & Co',
+				),
+				array(
+					'avatar_url'   => 'https://example.com/bo.png',
+					'display_name' => 'Bo',
+				),
+			)
+		);
+
+		$this->assertSame( 2, substr_count( $html, '<img ' ) );
+		$this->assertLessThan(
+			strpos( $html, 'z-index:1' ),
+			strpos( $html, 'z-index:2' ),
+			'The first avatar in the list needs the highest z-index.'
+		);
+		$this->assertStringContainsString( 'alt="Ana &amp; Co"', $html );
+		$this->assertStringContainsString( 'width="20" height="20"', $html );
+	}
+
+	/**
+	 * The stack stands in for a crowd rather than showing all of it, so a busy
+	 * room renders the same handful of avatars as a quiet one.
+	 *
+	 * @covers ::wp_presence_render_avatar_stack
+	 */
+	public function test_avatar_stack_stops_at_the_maximum() {
+		$users = array_fill(
+			0,
+			10,
+			array(
+				'avatar_url'   => 'https://example.com/ana.png',
+				'display_name' => 'Ana',
+			)
+		);
+
+		$this->assertSame( 4, substr_count( wp_presence_render_avatar_stack( $users ), '<img ' ) );
+
+		$sized = wp_presence_render_avatar_stack( $users, 2, 24 );
+
+		$this->assertSame( 2, substr_count( $sized, '<img ' ) );
+		$this->assertStringContainsString( 'width="24" height="24"', $sized );
+	}
+
 }

--- a/tests/test-network-presence-ui.php
+++ b/tests/test-network-presence-ui.php
@@ -272,6 +272,44 @@ class WP_Test_Network_Presence_UI extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * The single-site filter runs on this screen too, since is_admin() is true
+	 * in Network Admin, and the list table's own WP_User_Query fires
+	 * pre_get_users after users_list_table_query_args has already set the
+	 * network-wide IDs. Asserted through a real query rather than the filter's
+	 * return value, because the collision only shows up downstream of it.
+	 *
+	 * @covers ::wp_presence_filter_network_online_users
+	 * @covers ::wp_presence_filter_online_users
+	 */
+	public function test_the_network_online_view_is_not_narrowed_to_the_current_site() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		// Online on another site, and deliberately not on the one this request
+		// resolved to.
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$_GET['presence_status'] = 'online';
+		$_GET['_wpnonce']        = wp_create_nonce( 'presence_online_filter' );
+
+		$args = wp_presence_filter_network_online_users(
+			array(
+				'number' => 10,
+				'fields' => 'ID',
+			)
+		);
+
+		$query = new WP_User_Query( $args );
+
+		$this->assertSame(
+			array( self::$editor_id ),
+			array_map( 'intval', $query->get_results() ),
+			'pre_get_users narrowed the network view to the current site.'
+		);
+	}
+
+	/**
 	 * @covers ::wp_presence_render_network_users_column
 	 */
 	public function test_users_column_lists_the_sites_a_user_is_online_on() {

--- a/tests/test-network-presence-ui.php
+++ b/tests/test-network-presence-ui.php
@@ -1,7 +1,9 @@
 <?php
 /**
- * Tests for the network-wide presence UI: the Sites list column, the Users
- * list view/filter/column, and the network dashboard widget.
+ * Tests for the network-wide presence UI: the Sites list column and the
+ * Users list view, filter, and column.
+ *
+ * The network dashboard widget has its own file alongside the other widgets.
  *
  * @package Presence_API
  *
@@ -310,107 +312,5 @@ class WP_Test_Network_Presence_UI extends WP_Presence_UnitTestCase {
 		$columns = wp_presence_register_network_users_column( array( 'username' => 'Username' ) );
 
 		$this->assertArrayHasKey( 'presence_online', $columns );
-	}
-
-	// -----------------------------------------------------------------
-	// Network dashboard widget
-	// -----------------------------------------------------------------
-
-	/**
-	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
-	 */
-	public function test_widget_heartbeat_ignores_without_ping() {
-		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received( array( 'existing' => true ), array(), 'dashboard-network' );
-
-		$this->assertSame( array( 'existing' => true ), $response, 'A tick with no ping key should be left untouched.' );
-	}
-
-	/**
-	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
-	 */
-	public function test_widget_heartbeat_requires_capability() {
-		wp_set_current_user( self::$editor_id );
-
-		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
-			array(),
-			array( 'presence-network-widget-ping' => true ),
-			'dashboard-network'
-		);
-
-		$this->assertArrayNotHasKey( 'presence-network-widget', $response );
-	}
-
-	/**
-	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
-	 */
-	public function test_widget_heartbeat_returns_a_hash_on_first_ping() {
-		$this->become_network_admin();
-
-		$blog_id = $this->create_blog();
-		$this->set_presence_on_site( $blog_id, self::$editor_id );
-
-		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
-			array(),
-			array( 'presence-network-widget-ping' => true ),
-			'dashboard-network'
-		);
-
-		$this->assertArrayHasKey( 'presence-network-widget', $response );
-		$this->assertArrayHasKey( 'presence-network-widget-hash', $response );
-		$this->assertSame( 32, strlen( $response['presence-network-widget-hash'] ) );
-	}
-
-	/**
-	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
-	 */
-	public function test_widget_heartbeat_reports_unchanged_when_hash_matches() {
-		$this->become_network_admin();
-
-		$blog_id = $this->create_blog();
-		$this->set_presence_on_site( $blog_id, self::$editor_id );
-
-		$first = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
-			array(),
-			array( 'presence-network-widget-ping' => true ),
-			'dashboard-network'
-		);
-
-		$second = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
-			array(),
-			array(
-				'presence-network-widget-ping' => true,
-				'presence-network-widget-hash' => $first['presence-network-widget-hash'],
-			),
-			'dashboard-network'
-		);
-
-		$this->assertArrayNotHasKey( 'presence-network-widget', $second );
-		$this->assertTrue( $second['presence-network-widget-unchanged'] );
-	}
-
-	/**
-	 * @covers WP_Presence_Network_Widget_Whos_Online::render
-	 */
-	public function test_widget_render_lists_sites_with_online_users() {
-		$blog_id = $this->create_blog();
-		$this->set_presence_on_site( $blog_id, self::$editor_id );
-
-		ob_start();
-		WP_Presence_Network_Widget_Whos_Online::render();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'presence-avatar-stack', $output );
-		$this->assertStringContainsString( 'localhost', $output );
-	}
-
-	/**
-	 * @covers WP_Presence_Network_Widget_Whos_Online::render
-	 */
-	public function test_widget_render_reports_nobody_online() {
-		ob_start();
-		WP_Presence_Network_Widget_Whos_Online::render();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'No users are currently online', $output );
 	}
 }

--- a/tests/test-network-presence-ui.php
+++ b/tests/test-network-presence-ui.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Tests for the network-wide presence UI: the Sites list column, the Users
+ * list view/filter/column, and the network dashboard widget.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Network_Presence_UI extends WP_Presence_UnitTestCase {
+
+	private static $editor_id;
+
+	/**
+	 * Blogs created by the current test, deleted in tear_down().
+	 *
+	 * @var int[]
+	 */
+	private $blog_ids = array();
+
+	/**
+	 * The network's active plugin list as it stood before the test.
+	 *
+	 * @var array|false
+	 */
+	private $network_plugins;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	public function set_up() {
+		global $wpdb;
+
+		parent::set_up();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		// WP_UnitTestCase rewrites DDL to CREATE/DROP TEMPORARY TABLE. The
+		// network summary table is created with real, non-temporary DDL (see
+		// wp_maybe_create_presence_network_summary_table()), so this suite
+		// needs that rewrite disabled to provision it at all.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		// wp_presence_on_initialize_site() only provisions a new blog's table when
+		// the plugin is network active, which the test bootstrap's mu-plugin-style
+		// loading never makes true on its own. A network summary is only
+		// meaningful when every site actually has a table, so fake that here the
+		// same way test-table-creation.php does for its own network-active tests.
+		$this->network_plugins = get_site_option( 'active_sitewide_plugins' );
+		update_site_option( 'active_sitewide_plugins', array( 'presence-api/presence-api.php' => time() ) );
+
+		wp_maybe_create_presence_network_summary_table();
+
+		// Every admin-room write anywhere in the suite now pushes, and this
+		// table is real rather than temporary, so rows can outlive the test that
+		// wrote them. Start from empty rather than trusting the last tear_down.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->presence_network_summary}" );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		global $wpdb;
+
+		foreach ( $this->blog_ids as $blog_id ) {
+			wp_delete_site( $blog_id );
+		}
+		$this->blog_ids = array();
+
+		if ( false === $this->network_plugins ) {
+			delete_site_option( 'active_sitewide_plugins' );
+		} else {
+			update_site_option( 'active_sitewide_plugins', $this->network_plugins );
+		}
+
+		// This class's own set_up() disables the temporary-table DDL rewrite
+		// (see above), so writes to the real, non-temporary network summary
+		// table survive past this test's own transaction rollback -- exactly
+		// why blog_ids and active_sitewide_plugins above are cleaned up by
+		// hand instead of relying on that rollback.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->presence_network_summary}" );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates a blog and schedules it for deletion at the end of the test.
+	 *
+	 * @return int The new blog ID.
+	 */
+	private function create_blog() {
+		$blog_id          = self::factory()->blog->create();
+		$this->blog_ids[] = $blog_id;
+
+		return $blog_id;
+	}
+
+	/**
+	 * Writes a presence entry on a given site, without leaving the site
+	 * switched-to.
+	 *
+	 * The write pushes into the network summary on its own, via
+	 * wp_presence_admin_room_changed.
+	 *
+	 * @param int $blog_id The site to write on.
+	 * @param int $user_id The user the entry belongs to.
+	 */
+	private function set_presence_on_site( $blog_id, $user_id ) {
+		switch_to_blog( $blog_id );
+		wp_set_presence( 'admin/online', 'user-' . $user_id, array( 'screen' => 'dashboard' ), $user_id );
+		restore_current_blog();
+	}
+
+	/**
+	 * Grants the current test a network-capable user, so capability-gated
+	 * hooks (column registration, views, the query filter) actually run.
+	 *
+	 * @return int The admin's user ID.
+	 */
+	private function become_network_admin() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+		wp_set_current_user( $admin_id );
+
+		return $admin_id;
+	}
+
+	// -----------------------------------------------------------------
+	// Network Sites list "Online" column
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wp_presence_register_network_sites_column
+	 */
+	public function test_sites_column_requires_capability() {
+		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
+
+		$this->assertArrayNotHasKey( 'presence_online', $columns, 'A visitor with no capability should not see the column.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_sites_column
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_renders_avatar_stack_and_count() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
+		$this->assertArrayHasKey( 'presence_online', $columns );
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'presence-avatar-stack', $output );
+		$this->assertStringContainsString( '1', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		$output = ob_get_clean();
+
+		$this->assertSame( '&#8212;', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_ignores_other_columns() {
+		$this->become_network_admin();
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'blogname', 1 );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	// -----------------------------------------------------------------
+	// Network Users list "Online" view, filter, and column
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers ::wp_presence_network_users_views
+	 */
+	public function test_users_view_requires_capability() {
+		$views = wp_presence_network_users_views( array() );
+
+		$this->assertArrayNotHasKey( 'presence_online', $views );
+	}
+
+	/**
+	 * @covers ::wp_presence_network_users_views
+	 */
+	public function test_users_view_reports_the_network_wide_count() {
+		$this->become_network_admin();
+
+		$blog_ids = array( $this->create_blog(), $this->create_blog() );
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+		$this->set_presence_on_site( $blog_ids[1], self::$editor_id );
+
+		$views = wp_presence_network_users_views( array() );
+
+		$this->assertArrayHasKey( 'presence_online', $views );
+		// One distinct user online across both sites, not two.
+		$this->assertStringContainsString( '(1)', $views['presence_online'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_filter_network_online_users
+	 */
+	public function test_users_query_filter_requires_network_admin_context() {
+		$args = wp_presence_filter_network_online_users( array( 'number' => 10 ) );
+
+		$this->assertArrayNotHasKey( 'include', $args, 'Outside is_network_admin(), the query should be left alone.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_filter_network_online_users
+	 */
+	public function test_users_query_filter_restricts_to_online_users() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$_GET['presence_status'] = 'online';
+		$_GET['_wpnonce']        = wp_create_nonce( 'presence_online_filter' );
+
+		$args = wp_presence_filter_network_online_users( array( 'number' => 10 ) );
+
+		$this->assertSame( array( self::$editor_id ), $args['include'] );
+	}
+
+	/**
+	 * WP_User_Query treats an empty "include" as no restriction at all, which
+	 * would silently fall through to every network user instead of none.
+	 *
+	 * @covers ::wp_presence_filter_network_online_users
+	 */
+	public function test_users_query_filter_matches_nobody_when_nobody_is_online() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		$_GET['presence_status'] = 'online';
+		$_GET['_wpnonce']        = wp_create_nonce( 'presence_online_filter' );
+
+		$args = wp_presence_filter_network_online_users( array( 'number' => 10 ) );
+
+		$this->assertSame( array( 0 ), $args['include'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_users_column
+	 */
+	public function test_users_column_lists_the_sites_a_user_is_online_on() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
+
+		$this->assertNotSame( '&#8212;', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_users_column
+	 */
+	public function test_users_column_shows_a_dash_for_an_offline_user() {
+		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
+
+		$this->assertSame( '&#8212;', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_users_column
+	 */
+	public function test_users_column_requires_capability() {
+		$columns = wp_presence_register_network_users_column( array( 'username' => 'Username' ) );
+
+		$this->assertArrayNotHasKey( 'presence_online', $columns );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_users_column
+	 */
+	public function test_users_column_is_registered_for_a_network_admin() {
+		$this->become_network_admin();
+
+		$columns = wp_presence_register_network_users_column( array( 'username' => 'Username' ) );
+
+		$this->assertArrayHasKey( 'presence_online', $columns );
+	}
+
+	// -----------------------------------------------------------------
+	// Network dashboard widget
+	// -----------------------------------------------------------------
+
+	/**
+	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_widget_heartbeat_ignores_without_ping() {
+		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received( array( 'existing' => true ), array(), 'dashboard-network' );
+
+		$this->assertSame( array( 'existing' => true ), $response, 'A tick with no ping key should be left untouched.' );
+	}
+
+	/**
+	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_widget_heartbeat_requires_capability() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
+			array(),
+			array( 'presence-network-widget-ping' => true ),
+			'dashboard-network'
+		);
+
+		$this->assertArrayNotHasKey( 'presence-network-widget', $response );
+	}
+
+	/**
+	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_widget_heartbeat_returns_a_hash_on_first_ping() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
+			array(),
+			array( 'presence-network-widget-ping' => true ),
+			'dashboard-network'
+		);
+
+		$this->assertArrayHasKey( 'presence-network-widget', $response );
+		$this->assertArrayHasKey( 'presence-network-widget-hash', $response );
+		$this->assertSame( 32, strlen( $response['presence-network-widget-hash'] ) );
+	}
+
+	/**
+	 * @covers WP_Presence_Network_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_widget_heartbeat_reports_unchanged_when_hash_matches() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$first = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
+			array(),
+			array( 'presence-network-widget-ping' => true ),
+			'dashboard-network'
+		);
+
+		$second = WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
+			array(),
+			array(
+				'presence-network-widget-ping' => true,
+				'presence-network-widget-hash' => $first['presence-network-widget-hash'],
+			),
+			'dashboard-network'
+		);
+
+		$this->assertArrayNotHasKey( 'presence-network-widget', $second );
+		$this->assertTrue( $second['presence-network-widget-unchanged'] );
+	}
+
+	/**
+	 * @covers WP_Presence_Network_Widget_Whos_Online::render
+	 */
+	public function test_widget_render_lists_sites_with_online_users() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'presence-avatar-stack', $output );
+		$this->assertStringContainsString( 'localhost', $output );
+	}
+
+	/**
+	 * @covers WP_Presence_Network_Widget_Whos_Online::render
+	 */
+	public function test_widget_render_reports_nobody_online() {
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'No users are currently online', $output );
+	}
+}

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -685,4 +685,27 @@ class WP_Test_Network_Presence extends WP_Presence_UnitTestCase {
 
 		$this->assertSame( 'manage_sites', wp_presence_network_capability() );
 	}
+	/**
+	 * One person signed in on two sites is one person online, which is the
+	 * distinction the network user list filters on.
+	 *
+	 * @covers ::wp_presence_get_network_online_user_ids
+	 */
+	public function test_online_user_ids_are_deduplicated_across_sites() {
+		$first  = $this->create_blog();
+		$second = $this->create_blog();
+		$other  = self::factory()->user->create();
+
+		$this->set_network_summary_row( $first, array( self::$editor_id ) );
+		$this->set_network_summary_row( $second, array( self::$editor_id, $other ) );
+
+		$ids = wp_presence_get_network_online_user_ids();
+		sort( $ids );
+
+		$expected = array( self::$editor_id, $other );
+		sort( $expected );
+
+		$this->assertSame( $expected, $ids );
+	}
+
 }

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -249,6 +249,62 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_UnitTestCa
 		$this->assertStringContainsString( 'localhost', $output );
 	}
 
+	/**
+	 * The widget draws five sites and links out for the rest, so it asks the
+	 * read path for five rather than pulling the whole network across and
+	 * throwing most of it away. What is left over is then a count off the
+	 * network total, not the length of a list that was already cut.
+	 */
+	public function test_the_widget_sends_only_the_sites_it_draws_and_counts_the_rest() {
+		$this->become_network_admin();
+
+		$visible = WP_Presence_Network_Widget_Whos_Online::VISIBLE_SITES;
+
+		for ( $i = 0; $i <= $visible; $i++ ) {
+			$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+		}
+
+		$response = $this->tick();
+
+		$this->assertCount( $visible, $response['presence-network-widget'] );
+		$this->assertSame( 1, $response['presence-network-widget-overflow'] );
+
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		$this->assertSame( $visible, substr_count( $output, 'presence-site-item' ) );
+		$this->assertStringContainsString( '+1 more site', $output );
+	}
+
+	/**
+	 * The payload carries display names and avatar URLs, not just IDs, so a
+	 * hash over the room's membership alone left a rename on the dashboard for
+	 * as long as the same people stayed online.
+	 */
+	public function test_the_widget_repaints_when_an_online_user_is_renamed() {
+		$this->become_network_admin();
+		$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+
+		$first = $this->tick();
+
+		wp_update_user(
+			array(
+				'ID'           => self::$editor_id,
+				'display_name' => 'Renamed Editor',
+			)
+		);
+
+		// Two ticks are two requests, and the summary is only held for the
+		// length of one. Nothing here changed the room, so nothing dropped it.
+		wp_presence_flush_network_summary_cache();
+
+		$second = $this->tick( array( 'presence-network-widget-hash' => $first['presence-network-widget-hash'] ) );
+
+		$this->assertArrayHasKey( 'presence-network-widget', $second, 'A rename left the old name on the dashboard.' );
+		$this->assertSame( 'Renamed Editor', $second['presence-network-widget'][0]['users'][0]['display_name'] );
+	}
+
 	public function test_render_reports_nobody_online() {
 		ob_start();
 		WP_Presence_Network_Widget_Whos_Online::render();

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Tests for the network Who's Online dashboard widget.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ *
+ * @covers WP_Presence_Network_Widget_Whos_Online
+ */
+class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_UnitTestCase {
+
+	private static $editor_id;
+
+	/**
+	 * Blogs created by the current test, deleted in tear_down().
+	 *
+	 * @var int[]
+	 */
+	private $blog_ids = array();
+
+	/**
+	 * The network's active plugin list as it stood before the test.
+	 *
+	 * @var array|false
+	 */
+	private $network_plugins;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	public function set_up() {
+		global $wpdb;
+
+		parent::set_up();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		// WP_UnitTestCase rewrites DDL to CREATE/DROP TEMPORARY TABLE. The
+		// network summary table is created with real, non-temporary DDL (see
+		// wp_maybe_create_presence_network_summary_table()), so this suite
+		// needs that rewrite disabled to provision it at all.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		// wp_presence_on_initialize_site() only provisions a new blog's table when
+		// the plugin is network active, which the test bootstrap's mu-plugin-style
+		// loading never makes true on its own.
+		$this->network_plugins = get_site_option( 'active_sitewide_plugins' );
+		update_site_option( 'active_sitewide_plugins', array( 'presence-api/presence-api.php' => time() ) );
+
+		wp_maybe_create_presence_network_summary_table();
+
+		// The summary table is real rather than temporary, so rows can outlive
+		// the test that wrote them. Start from empty rather than trusting the
+		// last tear_down.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->presence_network_summary}" );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		global $wpdb;
+
+		foreach ( $this->blog_ids as $blog_id ) {
+			wp_delete_site( $blog_id );
+		}
+		$this->blog_ids = array();
+
+		if ( false === $this->network_plugins ) {
+			delete_site_option( 'active_sitewide_plugins' );
+		} else {
+			update_site_option( 'active_sitewide_plugins', $this->network_plugins );
+		}
+
+		// This class's own set_up() disables the temporary-table DDL rewrite,
+		// so summary rows survive past this test's transaction rollback.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->presence_network_summary}" );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates a blog and schedules it for deletion at the end of the test.
+	 *
+	 * @return int The new blog ID.
+	 */
+	private function create_blog() {
+		$blog_id          = self::factory()->blog->create();
+		$this->blog_ids[] = $blog_id;
+
+		return $blog_id;
+	}
+
+	/**
+	 * Writes a presence entry on a given site, without leaving the site
+	 * switched-to.
+	 *
+	 * The write pushes into the network summary on its own, via
+	 * wp_presence_admin_room_changed.
+	 *
+	 * @param int $blog_id The site to write on.
+	 * @param int $user_id The user the entry belongs to.
+	 */
+	private function set_presence_on_site( $blog_id, $user_id ) {
+		switch_to_blog( $blog_id );
+		wp_set_presence( 'admin/online', 'user-' . $user_id, array( 'screen' => 'dashboard' ), $user_id );
+		restore_current_blog();
+	}
+
+	/**
+	 * Grants the current test a network-capable user.
+	 *
+	 * @return int The admin's user ID.
+	 */
+	private function become_network_admin() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+		wp_set_current_user( $admin_id );
+
+		return $admin_id;
+	}
+
+	/**
+	 * Sends a widget ping through the heartbeat handler.
+	 *
+	 * @param array $extra Additional top-level Heartbeat data keys.
+	 * @return array The Heartbeat response.
+	 */
+	private function tick( $extra = array() ) {
+		return WP_Presence_Network_Widget_Whos_Online::heartbeat_received(
+			array(),
+			array_merge( array( 'presence-network-widget-ping' => true ), $extra ),
+			'dashboard-network'
+		);
+	}
+
+	/**
+	 * The widget reads presence for every site on the network, so a user who
+	 * cannot administer the network must not get it on their dashboard.
+	 */
+	public function test_register_requires_capability() {
+		global $wp_meta_boxes;
+
+		wp_set_current_user( self::$editor_id );
+
+		WP_Presence_Network_Widget_Whos_Online::register();
+
+		$this->assertArrayNotHasKey( 'dashboard-network', (array) $wp_meta_boxes );
+	}
+
+	public function test_register_adds_the_widget_for_a_network_admin() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+
+		$this->become_network_admin();
+		set_current_screen( 'dashboard-network' );
+
+		WP_Presence_Network_Widget_Whos_Online::register();
+
+		$this->assertArrayHasKey(
+			'presence_network_whos_online',
+			$wp_meta_boxes['dashboard-network']['normal']['core']
+		);
+	}
+
+	/**
+	 * The widget only exists on the dashboard, so every other admin screen has
+	 * to load without its script or style.
+	 */
+	public function test_scripts_are_only_enqueued_on_the_dashboard() {
+		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'sites.php' );
+
+		$this->assertFalse( wp_style_is( 'presence-network-widget', 'enqueued' ) );
+
+		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'index.php' );
+
+		$this->assertTrue( wp_script_is( 'heartbeat', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'presence-network-widget', 'enqueued' ) );
+	}
+
+	public function test_heartbeat_ignores_without_ping() {
+		$response = WP_Presence_Network_Widget_Whos_Online::heartbeat_received( array( 'existing' => true ), array(), 'dashboard-network' );
+
+		$this->assertSame( array( 'existing' => true ), $response, 'A tick with no ping key should be left untouched.' );
+	}
+
+	public function test_heartbeat_requires_capability() {
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertArrayNotHasKey( 'presence-network-widget', $this->tick() );
+	}
+
+	public function test_heartbeat_returns_a_hash_on_first_ping() {
+		$this->become_network_admin();
+		$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+
+		$response = $this->tick();
+
+		$this->assertArrayHasKey( 'presence-network-widget', $response );
+		$this->assertSame( 32, strlen( $response['presence-network-widget-hash'] ) );
+	}
+
+	/**
+	 * The hash is what keeps an idle network dashboard from re-sending the
+	 * whole site list every tick.
+	 */
+	public function test_heartbeat_reports_unchanged_when_hash_matches() {
+		$this->become_network_admin();
+		$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+
+		$first  = $this->tick();
+		$second = $this->tick( array( 'presence-network-widget-hash' => $first['presence-network-widget-hash'] ) );
+
+		$this->assertArrayNotHasKey( 'presence-network-widget', $second );
+		$this->assertTrue( $second['presence-network-widget-unchanged'] );
+	}
+
+	public function test_heartbeat_sends_a_fresh_payload_once_someone_comes_online() {
+		$this->become_network_admin();
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$first = $this->tick();
+
+		$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+
+		$second = $this->tick( array( 'presence-network-widget-hash' => $first['presence-network-widget-hash'] ) );
+
+		$this->assertArrayHasKey( 'presence-network-widget', $second );
+		$this->assertNotSame( $first['presence-network-widget-hash'], $second['presence-network-widget-hash'] );
+	}
+
+	public function test_render_lists_sites_with_online_users() {
+		$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'presence-avatar-stack', $output );
+		$this->assertStringContainsString( 'localhost', $output );
+	}
+
+	public function test_render_reports_nobody_online() {
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'No users are currently online', $output );
+	}
+}


### PR DESCRIPTION
The network summary from #299 had no surfaces reading it.

Depends on #299 and targets its branch; will retarget to main once #299 merges.

Fixes #298
Closes #322
Closes #325

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5, Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>