### PR TITLE
test: cover the dashboard widgets, the stale-screen banner, and the admin bar

### DIFF
--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -7,6 +7,7 @@
  * @group presence
  *
  * @covers ::wp_presence_admin_bar_node
+ * @covers ::wp_presence_admin_bar_assets
  */
 class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 
@@ -30,6 +31,16 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 		parent::set_up();
 		// Only loaded on requests that actually render the bar.
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+	}
+
+	public function tear_down() {
+		unset( $GLOBALS['pagenow'] );
+		// is_admin_bar_showing() memoizes into this global, so removing the
+		// filter that set it is not enough to undo it.
+		$GLOBALS['show_admin_bar'] = null;
+		// is_admin() reads $current_screen, which outlives the test that set it.
+		set_current_screen( 'dashboard' );
+		parent::tear_down();
 	}
 
 	/**
@@ -58,11 +69,8 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 	 * @return string Concatenated node titles and hrefs.
 	 */
 	private function render_node_markup() {
-		$bar = new WP_Admin_Bar();
-		wp_presence_admin_bar_node( $bar );
-
 		$markup = '';
-		foreach ( $bar->get_nodes() as $node ) {
+		foreach ( $this->render_nodes() as $node ) {
 			$markup .= $node->title;
 			if ( is_string( $node->href ) ) {
 				$markup .= $node->href;
@@ -70,6 +78,38 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 		}
 
 		return $markup;
+	}
+
+	/**
+	 * Renders the node and returns the admin bar's nodes, keyed by id.
+	 *
+	 * @return array Node objects.
+	 */
+	private function render_nodes() {
+		$bar = new WP_Admin_Bar();
+		wp_presence_admin_bar_node( $bar );
+
+		return $bar->get_nodes() ?? array();
+	}
+
+	/**
+	 * Puts a user online on a given screen.
+	 *
+	 * @param string $screen The screen slug to record.
+	 * @param array  $data   Extra presence data to record alongside it.
+	 * @return int The new user's ID.
+	 */
+	private function put_user_on_screen( $screen, $data = array() ) {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence(
+			'admin/online',
+			'user-' . $user_id,
+			array_merge( array( 'screen' => $screen ), $data ),
+			$user_id
+		);
+
+		return $user_id;
 	}
 
 	/**
@@ -137,5 +177,179 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 				"Node '{$node->id}' has no href and needs meta.tabindex => 0 to stay reachable by Tab."
 			);
 		}
+	}
+
+	/**
+	 * The indicator counts other people, so on your own it says nothing rather
+	 * than reporting a room of one.
+	 */
+	public function test_no_indicator_when_you_are_the_only_one_online() {
+		wp_set_current_user( self::$editor_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array( 'screen' => 'dashboard' ), self::$editor_id );
+
+		$this->assertSame( array(), $this->render_nodes() );
+	}
+
+	public function test_no_indicator_for_a_user_without_edit_posts() {
+		$this->put_user_on_screen( 'dashboard' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertSame( array(), $this->render_nodes() );
+	}
+
+	/**
+	 * Puts the current request on an admin screen so presence recorded against
+	 * the same slug counts as "on this page".
+	 *
+	 * @param string $pagenow The admin file being requested.
+	 * @param string $base    The screen base to register it under.
+	 */
+	private function view_admin_page( $pagenow, $base ) {
+		set_current_screen( $base );
+		$GLOBALS['pagenow'] = $pagenow;
+	}
+
+	public function test_users_on_the_same_admin_page_are_grouped_here() {
+		$this->view_admin_page( 'upload.php', 'upload' );
+
+		$here = get_userdata( $this->put_user_on_screen( 'upload' ) );
+		$this->put_user_on_screen( 'edit-comments' );
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$this->assertArrayHasKey( 'presence-group-here', $nodes );
+		$this->assertArrayHasKey( 'presence-group-elsewhere', $nodes );
+		$this->assertArrayHasKey( 'presence-user-' . $here->ID, $nodes );
+		// The avatar stack is built from the people on this page only.
+		$this->assertStringContainsString( 'alt="' . esc_attr( $here->display_name ) . '"', $nodes['presence-online']->title );
+	}
+
+	/**
+	 * An admin page with no entry in the map still groups correctly, keyed on
+	 * its filename, which is what the client reports as window.pagenow.
+	 */
+	public function test_an_unmapped_admin_page_is_keyed_by_its_filename() {
+		$this->view_admin_page( 'site-health.php', 'site-health' );
+
+		$user_id = $this->put_user_on_screen( 'site-health' );
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$this->assertArrayHasKey( 'presence-user-' . $user_id, $nodes );
+		$this->assertArrayNotHasKey( 'presence-group-elsewhere', $nodes );
+	}
+
+	/**
+	 * Both groups are capped so a busy site cannot grow the dropdown past the
+	 * height of the screen.
+	 */
+	public function test_each_group_is_capped_at_ten_with_a_count_for_the_rest() {
+		$this->view_admin_page( 'upload.php', 'upload' );
+
+		for ( $i = 0; $i < 11; $i++ ) {
+			$this->put_user_on_screen( 'upload' );
+			$this->put_user_on_screen( 'edit-comments' );
+		}
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$this->assertStringContainsString( '+1 more', $nodes['presence-here-overflow']->title );
+		$this->assertStringContainsString( '+1 more', $nodes['presence-elsewhere-overflow']->title );
+		// The "elsewhere" overflow is the one that can be acted on.
+		$this->assertSame( admin_url( 'users.php?presence_status=online' ), $nodes['presence-elsewhere-overflow']->href );
+	}
+
+	/**
+	 * Someone reading the site is shown the page they are on, linked to it,
+	 * rather than the generic "Front end" label.
+	 */
+	public function test_a_user_reading_the_site_is_shown_the_page_they_are_on() {
+		$this->view_admin_page( 'upload.php', 'upload' );
+
+		$user_id = $this->put_user_on_screen(
+			'front',
+			array(
+				'title'   => 'Hello World',
+				'post_id' => self::$post_id,
+			)
+		);
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$node = $nodes[ 'presence-user-' . $user_id ];
+		$this->assertStringContainsString( 'Hello World', $node->title );
+		$this->assertSame( get_permalink( self::$post_id ), $node->href );
+	}
+
+	/**
+	 * The label's leading verb is italicised to separate it from the object it
+	 * acts on, which leaves nothing to italicise in a one-word label.
+	 */
+	public function test_a_one_word_screen_label_is_left_unstyled() {
+		$this->view_admin_page( 'upload.php', 'upload' );
+
+		$user_id = $this->put_user_on_screen( 'plugins' );
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$title = $nodes[ 'presence-user-' . $user_id ]->title;
+		$this->assertStringContainsString( 'Plugins', $title );
+		$this->assertStringNotContainsString( '<em>', $title );
+	}
+
+	/**
+	 * A presence row outlives the user record it points at when an account is
+	 * deleted mid-session, and every list here has to survive that.
+	 */
+	public function test_an_entry_for_a_user_who_no_longer_exists_is_skipped() {
+		$this->view_admin_page( 'upload.php', 'upload' );
+
+		wp_set_presence( 'admin/online', 'user-999901', array( 'screen' => 'upload' ), 999901 );
+		wp_set_presence( 'admin/online', 'user-999902', array( 'screen' => 'plugins' ), 999902 );
+		$real = get_userdata( $this->put_user_on_screen( 'upload' ) );
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$this->assertArrayNotHasKey( 'presence-user-999901', $nodes );
+		$this->assertArrayNotHasKey( 'presence-user-999902', $nodes );
+		$this->assertArrayHasKey( 'presence-user-' . $real->ID, $nodes );
+	}
+
+	public function test_the_indicator_styles_load_for_a_user_who_can_see_it() {
+		wp_set_current_user( self::$editor_id );
+		add_filter( 'show_admin_bar', '__return_true' );
+
+		wp_presence_admin_bar_assets();
+
+		$this->assertTrue( wp_style_is( 'presence-admin-bar', 'enqueued' ) );
+		$this->assertStringContainsString(
+			'#wp-admin-bar-presence-online',
+			implode( '', (array) wp_styles()->get_data( 'presence-admin-bar', 'after' ) )
+		);
+
+		remove_filter( 'show_admin_bar', '__return_true' );
+	}
+
+	public function test_the_indicator_styles_stay_off_when_the_bar_is_hidden() {
+		wp_deregister_style( 'presence-admin-bar' );
+		$wp_styles        = wp_styles();
+		$wp_styles->queue = array();
+		$wp_styles->done  = array();
+
+		wp_set_current_user( self::$editor_id );
+		add_filter( 'show_admin_bar', '__return_false' );
+
+		wp_presence_admin_bar_assets();
+
+		$this->assertFalse( wp_style_is( 'presence-admin-bar', 'enqueued' ) );
+
+		remove_filter( 'show_admin_bar', '__return_false' );
 	}
 }

--- a/tests/test-screen-revisions.php
+++ b/tests/test-screen-revisions.php
@@ -18,6 +18,8 @@
  * @covers ::wp_presence_is_admin_screen_save
  * @covers ::wp_presence_current_user_can_access_screen
  * @covers ::wp_presence_enqueue_stale_screen_banner
+ * @covers ::wp_presence_bump_screen_revision
+ * @covers ::wp_presence_current_screen_key
  */
 class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 
@@ -44,6 +46,9 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 			delete_user_meta( $user_id, '_wp_presence_screen_rev' );
 		}
 		unset( $_POST['option_page'] );
+		unset( $_GET['user_id'], $_GET['taxonomy'], $_GET['tag_ID'], $_GET['c'] );
+		// is_admin() reads $current_screen, which outlives the test that set it.
+		set_current_screen( 'dashboard' );
 		parent::tear_down();
 	}
 
@@ -481,5 +486,388 @@ class WP_Test_Presence_Screen_Revisions extends WP_UnitTestCase {
 		$this->assertSame( 'custom-screen', wp_presence_current_screen_key() );
 
 		remove_filter( 'wp_presence_current_screen_key', $callback );
+	}
+
+	/**
+	 * The post editor keys off the post being edited, not the request.
+	 *
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_current_screen_key_reads_the_post_being_edited() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'post' );
+
+		$post_id                = self::factory()->post->create();
+		$GLOBALS['post']        = get_post( $post_id );
+
+		$this->assertSame( 'post/' . $post_id, wp_presence_current_screen_key() );
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_current_screen_key_reads_the_user_being_edited() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'user-edit' );
+
+		$_GET['user_id'] = self::$editor_id;
+
+		$this->assertSame( 'user-edit/' . self::$editor_id, wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * Your own profile is the same screen as another user's edit screen, so it
+	 * keys the same way and a change made elsewhere still marks it stale.
+	 *
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_your_own_profile_keys_to_your_user_edit_screen() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'profile' );
+
+		$this->assertSame( 'user-edit/' . self::$admin_id, wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_current_screen_key_reads_the_term_being_edited() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'edit-tags' );
+
+		$term_id            = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
+		$_GET['taxonomy']   = 'category';
+		$_GET['tag_ID']     = $term_id;
+
+		$this->assertSame( 'term/category/' . $term_id, wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_current_screen_key_reads_the_comment_being_edited() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'comment' );
+
+		$comment_id = self::factory()->comment->create();
+		$_GET['c']  = $comment_id;
+
+		$this->assertSame( 'comment/' . $comment_id, wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * A covered screen base with nothing to key off produces no key rather than
+	 * a partial one like `post/`.
+	 *
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_a_covered_screen_with_no_object_produces_no_key() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'user-edit' );
+
+		$this->assertSame( '', wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * @covers ::wp_presence_current_screen_key
+	 */
+	public function test_there_is_no_screen_key_outside_the_admin() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'front' );
+
+		$this->assertSame( '', wp_presence_current_screen_key() );
+	}
+
+	/**
+	 * Enqueues the banner against empty registries.
+	 *
+	 * wp_scripts() and wp_styles() are process globals, so without this a
+	 * later test reads what an earlier one enqueued.
+	 */
+	private function enqueue_banner() {
+		wp_deregister_script( 'wp-presence-stale-screen' );
+		wp_deregister_script( 'wp-presence-tab-coordinator' );
+		wp_deregister_style( 'wp-presence-stale-screen' );
+
+		$scripts        = wp_scripts();
+		$scripts->queue = array();
+		$scripts->done  = array();
+
+		$styles        = wp_styles();
+		$styles->queue = array();
+		$styles->done  = array();
+
+		wp_presence_enqueue_stale_screen_banner();
+	}
+
+	/**
+	 * Reads back the config object the banner script is handed.
+	 *
+	 * @return array|null Decoded config, or null when nothing was printed.
+	 */
+	private function banner_config() {
+		$inline = wp_scripts()->get_data( 'wp-presence-stale-screen', 'before' );
+
+		foreach ( (array) $inline as $script ) {
+			if ( is_string( $script ) && preg_match( '/window\.wpPresenceStaleScreen = (.*);$/', $script, $m ) ) {
+				return json_decode( $m[1], true );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @covers ::wp_presence_enqueue_stale_screen_banner
+	 */
+	public function test_the_banner_carries_the_screen_key_and_the_revision_it_starts_from() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'options-general' );
+
+		$rev = wp_presence_bump_screen_revision( 'options/general', self::$admin2_id );
+
+		$this->enqueue_banner();
+
+		$this->assertTrue( wp_style_is( 'wp-presence-stale-screen', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'wp-presence-stale-screen', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'wp-presence-tab-coordinator', 'enqueued' ) );
+
+		$config = $this->banner_config();
+		$this->assertSame( 'options/general', $config['screenKey'] );
+		$this->assertSame( $rev, $config['baselineRev'] );
+		$this->assertArrayHasKey( 'reload', $config['strings'] );
+	}
+
+	/**
+	 * An unvisited screen starts from zero, so the first bump is a change.
+	 *
+	 * @covers ::wp_presence_enqueue_stale_screen_banner
+	 */
+	public function test_a_screen_with_no_revision_yet_starts_the_baseline_at_zero() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'options-writing' );
+
+		$this->enqueue_banner();
+
+		$this->assertSame( 0, $this->banner_config()['baselineRev'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_enqueue_stale_screen_banner
+	 */
+	public function test_the_banner_stays_off_screens_with_no_stale_detection() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'dashboard' );
+
+		$this->enqueue_banner();
+
+		$this->assertFalse( wp_script_is( 'wp-presence-stale-screen', 'enqueued' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_enqueue_stale_screen_banner
+	 */
+	public function test_the_banner_stays_off_the_front_end() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'front' );
+
+		$this->enqueue_banner();
+
+		$this->assertFalse( wp_script_is( 'wp-presence-stale-screen', 'enqueued' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_enqueue_stale_screen_banner
+	 */
+	public function test_a_user_without_edit_posts_gets_no_banner() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		set_current_screen( 'options-general' );
+
+		$this->enqueue_banner();
+
+		$this->assertFalse( wp_script_is( 'wp-presence-stale-screen', 'enqueued' ) );
+	}
+
+	/**
+	 * The revision of a screen is only disclosed to someone who can already
+	 * reach the object behind it.
+	 *
+	 * @dataProvider data_screens_out_of_reach
+	 *
+	 * @covers ::wp_presence_current_user_can_access_screen
+	 *
+	 * @param string $key_template Screen key with %d standing in for the object ID.
+	 */
+	public function test_a_screen_the_user_cannot_reach_is_not_disclosed( $key_template ) {
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$ids = array(
+			'user-edit/%d' => self::$admin_id,
+			'term/category/%d' => self::factory()->term->create( array( 'taxonomy' => 'category' ) ),
+			'comment/%d'   => self::factory()->comment->create(),
+			'anything/%d'  => 1,
+		);
+
+		$this->assertFalse( wp_presence_current_user_can_access_screen( sprintf( $key_template, $ids[ $key_template ] ) ) );
+	}
+
+	public function data_screens_out_of_reach() {
+		return array(
+			'another user'  => array( 'user-edit/%d' ),
+			'a term'        => array( 'term/category/%d' ),
+			'a comment'     => array( 'comment/%d' ),
+			'an unknown key' => array( 'anything/%d' ),
+		);
+	}
+
+	/**
+	 * Cron runs as no one on a schedule, so a revision bumped there would name
+	 * a bystander as the actor.
+	 *
+	 * @covers ::wp_presence_is_admin_screen_save
+	 * @covers ::wp_presence_on_profile_update
+	 * @covers ::wp_presence_on_edited_term
+	 * @covers ::wp_presence_on_edit_comment
+	 * @covers ::wp_presence_on_post_updated
+	 * @covers ::wp_presence_on_updated_option
+	 */
+	public function test_a_save_during_cron_bumps_nothing() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'user-edit' );
+
+		add_filter( 'wp_doing_cron', '__return_true' );
+
+		wp_presence_on_profile_update( self::$editor_id );
+		wp_presence_on_edited_term( 1, 1, 'category' );
+		wp_presence_on_edit_comment( 1 );
+		wp_presence_on_post_updated( 1, get_post( self::factory()->post->create() ), null );
+		$_POST['option_page'] = 'media';
+		wp_presence_on_updated_option( 'blogname' );
+
+		remove_filter( 'wp_doing_cron', '__return_true' );
+
+		$this->assertNull( wp_presence_get_screen_revision( 'user-edit/' . self::$editor_id ) );
+		$this->assertNull( wp_presence_get_screen_revision( 'options/media' ) );
+		$this->assertSame( array(), wp_presence_get_screen_revisions() );
+	}
+
+	/**
+	 * Saving a Settings page fires updated_option once per changed option, and
+	 * each would otherwise bump the same screen again.
+	 *
+	 * @covers ::wp_presence_on_updated_option
+	 */
+	public function test_one_settings_save_bumps_the_screen_once() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'options-reading' );
+
+		$_POST['option_page'] = 'reading';
+
+		wp_presence_on_updated_option( 'blogname' );
+		$first = wp_presence_get_screen_revision( 'options/reading' );
+
+		wp_presence_on_updated_option( 'blogdescription' );
+		$second = wp_presence_get_screen_revision( 'options/reading' );
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * A revision is a change to the post everyone is looking at, and a stored
+	 * revision is a separate row that nobody has open.
+	 *
+	 * @covers ::wp_presence_on_post_updated
+	 */
+	public function test_a_stored_revision_is_not_a_change_to_its_parent() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'post' );
+
+		$post_id     = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$revision_id = wp_save_post_revision( $post_id );
+
+		wp_presence_on_post_updated( $revision_id, get_post( $revision_id ), null );
+
+		$this->assertSame( array(), wp_presence_get_screen_revisions() );
+	}
+
+	/**
+	 * @covers ::wp_presence_on_post_updated
+	 */
+	public function test_an_auto_draft_is_not_a_change_anyone_needs_to_see() {
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'post' );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'auto-draft' ) );
+
+		wp_presence_on_post_updated( $post_id, get_post( $post_id ), null );
+
+		$this->assertSame( array(), wp_presence_get_screen_revisions() );
+	}
+
+	/**
+	 * @covers ::wp_presence_get_screen_revision
+	 */
+	public function test_an_empty_screen_key_has_no_revision() {
+		$this->assertNull( wp_presence_get_screen_revision( '' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_get_screen_revision
+	 */
+	public function test_a_deleted_post_has_no_revision() {
+		$post_id = self::factory()->post->create();
+		wp_delete_post( $post_id, true );
+
+		$this->assertNull( wp_presence_get_screen_revision( 'post/' . $post_id ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_says_nothing_about_a_screen_nobody_has_saved() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/discussion' ) ),
+			'dashboard'
+		);
+
+		$this->assertArrayNotHasKey( 'presence-screen-rev', $response );
+	}
+
+	/**
+	 * A revision with no actor still reports the change, just without a name or
+	 * a relative time to attribute it to.
+	 *
+	 * @covers ::wp_presence_screen_heartbeat_received
+	 */
+	public function test_heartbeat_reports_an_unattributed_change() {
+		wp_set_current_user( self::$admin_id );
+
+		update_option(
+			'wp_presence_screen_rev_options_media',
+			array(
+				'rev'      => 7,
+				'actor_id' => 0,
+				'time'     => 0,
+			),
+			false
+		);
+
+		$response = wp_presence_screen_heartbeat_received(
+			array(),
+			array( 'presence-screen-ping' => array( 'key' => 'options/media' ) ),
+			'dashboard'
+		);
+
+		$rev = $response['presence-screen-rev'];
+		$this->assertSame( 7, $rev['rev'] );
+		$this->assertSame( '', $rev['actor_name'] );
+		$this->assertSame( '', $rev['time_ago'] );
+		$this->assertFalse( $rev['actor_is_me'] );
 	}
 }

--- a/tests/widgets/test-widget-active-posts.php
+++ b/tests/widgets/test-widget-active-posts.php
@@ -361,4 +361,101 @@ class WP_Test_Presence_Widget_Active_Posts extends WP_Presence_UnitTestCase {
 
 		$this->assertFalse( wp_script_is( 'wp-presence-active-posts', 'enqueued' ) );
 	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::register
+	 */
+	public function test_register_adds_the_widget_for_a_user_who_can_edit_posts() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+
+		wp_set_current_user( self::$editor_id );
+		set_current_screen( 'dashboard' );
+
+		WP_Presence_Widget_Active_Posts::register();
+
+		$this->assertArrayHasKey( 'presence_active_posts', $wp_meta_boxes['dashboard']['normal']['default'] );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::register
+	 */
+	public function test_register_skips_a_user_who_cannot_edit_posts() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+
+		$wp_meta_boxes = array();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		set_current_screen( 'dashboard' );
+
+		WP_Presence_Widget_Active_Posts::register();
+
+		$this->assertArrayNotHasKey( 'presence_active_posts', $wp_meta_boxes['dashboard']['normal']['default'] ?? array() );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::render
+	 */
+	public function test_render_says_all_quiet_when_nothing_is_being_edited() {
+		wp_set_current_user( self::$editor_id );
+
+		ob_start();
+		WP_Presence_Widget_Active_Posts::render();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'All quiet.', $html );
+		$this->assertStringNotContainsString( '<ul', $html );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::render
+	 */
+	public function test_render_names_a_lone_editor_and_links_the_post() {
+		wp_set_current_user( self::$editor_id );
+
+		$room = wp_presence_post_room( self::$post_id );
+		wp_set_presence( $room, 'lock-' . self::$editor_id, array(), self::$editor_id );
+
+		ob_start();
+		WP_Presence_Widget_Active_Posts::render();
+		$html = ob_get_clean();
+
+		$user = get_userdata( self::$editor_id );
+		$this->assertStringContainsString( esc_html( $user->display_name ), $html );
+		$this->assertStringContainsString( 'Test Post', $html );
+		$this->assertStringContainsString( 'post=' . self::$post_id, $html );
+		// An active editor is the default state, so no status text is rendered.
+		$this->assertStringContainsString( '<span class="presence-status-text"></span>', $html );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::render
+	 */
+	public function test_render_counts_a_crowd_and_labels_it_idle_once_everyone_goes_quiet() {
+		global $wpdb;
+
+		wp_set_current_user( self::$editor_id );
+
+		$room = wp_presence_post_room( self::$post_id );
+		wp_set_presence( $room, 'lock-' . self::$editor_id, array(), self::$editor_id );
+		wp_set_presence( $room, 'lock-' . self::$editor2_id, array(), self::$editor2_id );
+
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 45 ) ),
+			array( 'room' => $room ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		ob_start();
+		WP_Presence_Widget_Active_Posts::render();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( '2 editors', $html );
+		$this->assertStringContainsString( '<span class="presence-status-text">Idle</span>', $html );
+	}
 }

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -290,4 +290,197 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 		$this->assertStringContainsString( 'class="presence-user-item"', $output );
 		$this->assertMatchesRegularExpression( '/alt=["\']John Doe["\']/', $output );
 	}
+
+	/**
+	 * Renders the widget with the current user excluded, as the widget does.
+	 *
+	 * @return string The rendered markup.
+	 */
+	private function render() {
+		wp_set_current_user( self::$editor_id );
+
+		ob_start();
+		WP_Presence_Widget_Whos_Online::render();
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::register
+	 */
+	public function test_register_adds_the_widget_for_a_user_who_can_edit_posts() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+
+		wp_set_current_user( self::$editor_id );
+		set_current_screen( 'dashboard' );
+
+		WP_Presence_Widget_Whos_Online::register();
+
+		$this->assertArrayHasKey( 'presence_whos_online', $wp_meta_boxes['dashboard']['normal']['default'] );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::register
+	 */
+	public function test_register_skips_a_user_who_cannot_edit_posts() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+
+		$wp_meta_boxes = array();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		set_current_screen( 'dashboard' );
+
+		WP_Presence_Widget_Whos_Online::register();
+
+		$this->assertArrayNotHasKey( 'presence_whos_online', $wp_meta_boxes['dashboard']['normal']['default'] ?? array() );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::enqueue_scripts
+	 */
+	public function test_the_dashboard_gets_the_widget_style_and_heartbeat_script() {
+		WP_Presence_Widget_Whos_Online::enqueue_scripts( 'index.php' );
+
+		$this->assertTrue( wp_style_is( 'presence-dashboard-widget', 'enqueued' ) );
+
+		$css = wp_styles()->get_data( 'presence-dashboard-widget', 'after' );
+		$this->assertStringContainsString( '#presence-whos-online-list', implode( '', (array) $css ) );
+
+		$script = implode( '', (array) wp_scripts()->get_data( 'heartbeat', 'after' ) );
+		$this->assertStringContainsString( 'presence-whos-online-list', $script );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::enqueue_scripts
+	 */
+	public function test_other_admin_pages_do_not_load_the_widget_style() {
+		$wp_styles        = wp_styles();
+		$wp_styles->queue = array();
+		$wp_styles->done  = array();
+
+		WP_Presence_Widget_Whos_Online::enqueue_scripts( 'edit.php' );
+
+		$this->assertFalse( wp_style_is( 'presence-dashboard-widget', 'enqueued' ) );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::render
+	 */
+	public function test_render_reports_when_nobody_else_is_online() {
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'No other users are online.', $html );
+		$this->assertStringNotContainsString( '<ul', $html );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::render_user_row
+	 * @covers WP_Presence_Widget_Whos_Online::get_screen_url
+	 */
+	public function test_render_links_a_users_screen_to_the_matching_admin_page() {
+		$this->add_user_to_room( 'post-new', 0 );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( esc_url( admin_url( 'post-new.php' ) ), $html );
+		// The verb leading a multi-word label is italicised.
+		$this->assertStringContainsString( '<em>Writing</em> post', $html );
+	}
+
+	/**
+	 * A screen with no admin page still names what the user is doing, just
+	 * without a link to follow.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::render_user_row
+	 * @covers WP_Presence_Widget_Whos_Online::get_screen_url
+	 */
+	public function test_render_names_an_unmapped_screen_without_linking_it() {
+		$this->add_user_to_room( 'site-health', 0 );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( '<span class="presence-screen">', $html );
+		$this->assertStringNotContainsString( '<span class="presence-screen"><a', $html );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Whos_Online::render_user_row
+	 */
+	public function test_render_marks_a_stale_entry_idle_with_a_relative_timestamp() {
+		// Past IDLE_THRESHOLD but inside the TTL, so the entry is still listed.
+		$this->add_user_to_room( 'dashboard', 45 );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'presence-online-dot is-idle', $html );
+		$this->assertStringContainsString( 'seconds ago', $html );
+	}
+
+	/**
+	 * Up to the overflow threshold the extra users stay on the page behind a
+	 * toggle, so the markup carries the full list rather than a link away.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::render
+	 */
+	public function test_render_hides_a_short_overflow_behind_an_expand_toggle() {
+		for ( $i = 0; $i < WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + 2; $i++ ) {
+			$this->add_user_to_room( 'dashboard', 0 );
+		}
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'data-action="expand"', $html );
+		$this->assertStringContainsString( 'id="presence-overflow-list"', $html );
+		$this->assertStringContainsString( '+2 more', $html );
+		$this->assertStringContainsString( 'Show less', $html );
+	}
+
+	/**
+	 * Past the threshold the list would be longer than the widget, so it
+	 * collapses to a count that links to the filtered Users screen.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::render
+	 */
+	public function test_render_collapses_a_long_overflow_into_a_link_to_all_users() {
+		$overflow = WP_Presence_Widget_Whos_Online::get_overflow_threshold() + 1;
+
+		for ( $i = 0; $i < WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + $overflow; $i++ ) {
+			$this->add_user_to_room( 'dashboard', 0 );
+		}
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( esc_url( admin_url( 'users.php?presence_status=online' ) ), $html );
+		$this->assertStringContainsString( sprintf( '+%d more', $overflow ), $html );
+		$this->assertStringNotContainsString( 'data-action="expand"', $html );
+	}
+
+	/**
+	 * @dataProvider data_rich_screen_labels
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::get_rich_screen_label
+	 *
+	 * @param string $screen      The pagenow slug.
+	 * @param string $post_status The post status recorded alongside it.
+	 * @param string $expected    The label the pair should produce.
+	 */
+	public function test_a_post_status_sharpens_the_screen_label( $screen, $post_status, $expected ) {
+		$this->assertSame( $expected, WP_Presence_Widget_Whos_Online::get_rich_screen_label( $screen, $post_status ) );
+	}
+
+	public function data_rich_screen_labels() {
+		return array(
+			'draft post'      => array( 'post', 'draft', 'Drafting post' ),
+			'auto-draft page' => array( 'page', 'auto-draft', 'Drafting page' ),
+			'pending post'    => array( 'edit-post', 'pending', 'Pending post' ),
+			'private page'    => array( 'page', 'private', 'Editing private page' ),
+			'scheduled post'  => array( 'post', 'future', 'Editing scheduled post' ),
+			'published page'  => array( 'page', 'publish', 'Editing page' ),
+			'unrelated screen' => array( 'upload', 'draft', 'Media' ),
+		);
+	}
 }


### PR DESCRIPTION
The four lowest-covered units in the plugin, none of which had a test reaching their render or enqueue paths.

Closes #315
Closes #316

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with coverage measurement and test authoring

</details>