### PR TITLE
refactor: drop the unused wp_get_user_presence()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -269,45 +269,6 @@ function wp_presence_get_timeout( $timeout ) {
 }
 
 /**
- * Gets all presence entries for a given user across all rooms.
- *
- * @access private
- * @param int $user_id The user ID.
- * @param int $timeout Optional. Timeout in seconds. Default WP_PRESENCE_DEFAULT_TTL.
- * @return array Array of presence entry objects.
- */
-function wp_get_user_presence( $user_id, $timeout = WP_PRESENCE_DEFAULT_TTL ) {
-	global $wpdb;
-
-	if ( ! wp_presence_has_table() ) {
-		return array();
-	}
-
-	$timeout = wp_presence_get_timeout( $timeout );
-	$cutoff  = gmdate( 'Y-m-d H:i:s', time() - $timeout );
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$results = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT room, client_id, user_id, data, date_gmt FROM {$wpdb->presence} WHERE user_id = %d AND date_gmt > %s ORDER BY date_gmt DESC",
-			$user_id,
-			$cutoff
-		)
-	);
-
-	if ( ! $results ) {
-		return array();
-	}
-
-	foreach ( $results as $row ) {
-		$decoded   = json_decode( $row->data, true );
-		$row->data = is_array( $decoded ) ? $decoded : array();
-	}
-
-	return $results;
-}
-
-/**
  * Gets all presence entries for rooms matching a prefix.
  *
  * @access private

--- a/tests/class-wp-presence-unittestcase.php
+++ b/tests/class-wp-presence-unittestcase.php
@@ -16,4 +16,35 @@ abstract class WP_Presence_UnitTestCase extends WP_UnitTestCase {
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
 		parent::tear_down();
 	}
+
+	/**
+	 * Returns every live presence entry for one user, across all rooms.
+	 *
+	 * Reads the table directly. Nothing in the plugin needs a per-user view, so
+	 * this stays a test affordance rather than an API function kept alive only
+	 * by the assertions below it.
+	 *
+	 * @param int $user_id The user whose entries to read.
+	 * @param int $timeout Optional. TTL in seconds. Default WP_PRESENCE_DEFAULT_TTL.
+	 * @return object[] Entries with room, client_id, user_id, data (array), date_gmt.
+	 */
+	protected function presence_for_user( $user_id, $timeout = WP_PRESENCE_DEFAULT_TTL ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT room, client_id, user_id, data, date_gmt FROM {$wpdb->presence} WHERE user_id = %d AND date_gmt > %s ORDER BY date_gmt DESC",
+				$user_id,
+				gmdate( 'Y-m-d H:i:s', time() - wp_presence_get_timeout( $timeout ) )
+			)
+		);
+
+		foreach ( $rows as $row ) {
+			$decoded   = json_decode( $row->data, true );
+			$row->data = is_array( $decoded ) ? $decoded : array();
+		}
+
+		return $rows;
+	}
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -127,31 +127,11 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 		wp_remove_user_presence( self::$editor_id );
 
-		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
-		$this->assertCount( 1, wp_get_user_presence( self::$subscriber_id ), 'Another user\'s entries should be left alone.' );
+		$this->assertCount( 0, $this->presence_for_user( self::$editor_id ) );
+		$this->assertCount( 1, $this->presence_for_user( self::$subscriber_id ), 'Another user\'s entries should be left alone.' );
 	}
 
-	/**
-	 * @covers ::wp_get_user_presence
-	 */
-	public function test_get_user_presence_across_rooms() {
-		wp_set_presence( 'room/a', 'user-' . self::$editor_id, array(), self::$editor_id );
-		wp_set_presence( 'room/b', 'lock-' . self::$editor_id, array(), self::$editor_id );
 
-		$entries = wp_get_user_presence( self::$editor_id );
-
-		$this->assertCount( 2, $entries );
-	}
-
-	/**
-	 * @covers ::wp_get_user_presence
-	 */
-	public function test_get_user_presence_returns_empty_array_when_none_present() {
-		wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
-
-		$this->assertCount( 1, wp_get_user_presence( self::$editor_id ) );
-		$this->assertSame( array(), wp_get_user_presence( self::$subscriber_id ) );
-	}
 
 	/**
 	 * @covers ::wp_can_access_presence_room

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -23,7 +23,7 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 		$user = get_userdata( self::$editor_id );
 		wp_presence_on_login( $user->user_login, $user );
 
-		$entries = wp_get_user_presence( self::$editor_id );
+		$entries = $this->presence_for_user( self::$editor_id );
 		$this->assertCount( 1, $entries );
 		$this->assertSame( 'admin/online', $entries[0]->room );
 		$this->assertSame( 'login', $entries[0]->data['screen'] );
@@ -36,7 +36,7 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 		$user = get_userdata( self::$subscriber_id );
 		wp_presence_on_login( $user->user_login, $user );
 
-		$entries = wp_get_user_presence( self::$subscriber_id );
+		$entries = $this->presence_for_user( self::$subscriber_id );
 		$this->assertCount( 0, $entries );
 	}
 
@@ -50,8 +50,8 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 
 		wp_presence_on_logout( self::$editor_id );
 
-		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
-		$this->assertCount( 1, wp_get_user_presence( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
+		$this->assertCount( 0, $this->presence_for_user( self::$editor_id ) );
+		$this->assertCount( 1, $this->presence_for_user( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 		wp_presence_on_logout( self::$subscriber_id );
 
 		// Entry should remain because logout skips users without edit_posts.
-		$entries = wp_get_user_presence( self::$subscriber_id );
+		$entries = $this->presence_for_user( self::$subscriber_id );
 		$this->assertCount( 1, $entries );
 	}
 
@@ -82,7 +82,7 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 
 		wp_presence_on_logout( self::$editor_id );
 
-		$this->assertCount( 0, wp_get_user_presence( self::$editor_id ) );
-		$this->assertCount( 1, wp_get_user_presence( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
+		$this->assertCount( 0, $this->presence_for_user( self::$editor_id ) );
+		$this->assertCount( 1, $this->presence_for_user( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
 }

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -429,7 +429,6 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 	 * @covers ::wp_remove_presence
 	 * @covers ::wp_remove_user_presence
 	 * @covers ::wp_get_presence
-	 * @covers ::wp_get_user_presence
 	 * @covers ::wp_get_presence_by_room_prefix
 	 * @covers ::wp_get_active_rooms
 	 * @covers ::wp_get_presence_summary
@@ -447,7 +446,6 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		$this->assertFalse( wp_remove_presence( 'admin/online', 'user-1' ) );
 		$this->assertFalse( wp_remove_user_presence( self::$editor_id ) );
 		$this->assertSame( array(), wp_get_presence( 'admin/online' ) );
-		$this->assertSame( array(), wp_get_user_presence( self::$editor_id ) );
 		$this->assertSame( array(), wp_get_presence_by_room_prefix( 'postType/' ) );
 		$this->assertSame( array(), wp_get_active_rooms() );
 		$this->assertSame( 0, wp_get_presence_summary()['total_entries'] );
@@ -473,7 +471,7 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		wp_presence_on_login( $user->user_login, $user );
 
 		$this->assertSame( '', $wpdb->last_error, 'Logging in should not query a missing table.' );
-		$this->assertSame( array(), wp_get_user_presence( self::$editor_id ) );
+		$this->assertSame( array(), wp_get_presence( 'admin/online' ) );
 	}
 
 	/**


### PR DESCRIPTION
Nothing in the plugin has ever called this function, so the tests were the only thing keeping it alive.

Closes #319

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with the unused-function audit and the test refactor

</details>
