### PR TITLE
perf: push the network summary only when the site's online set changes

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -138,18 +138,17 @@ function wp_presence_network_summary_refresh_interval() {
  * Pushes the current site's online-user snapshot into the network-wide
  * summary table.
  *
- * Runs on wp_presence_admin_room_changed, so every admin-room write pushes,
- * not just the heartbeat tick: logout and the pagehide delete clear the site
- * immediately instead of waiting for its entry to age out.
+ * Runs on wp_presence_admin_room_changed, so an arrival or a departure reaches
+ * the network within the request that caused it: logout and the pagehide delete
+ * clear the site immediately instead of waiting for its entry to age out.
  *
- * A tick usually finds the same people as the tick before it, so the upsert
- * rewrites the row only when the user set changes or the row is older than
- * wp_presence_network_summary_refresh_interval(). Both tests run in SQL, so an
- * unchanged push resolves to zero changed rows.
+ * A tick usually finds the same people as the tick before it, and that case
+ * returns before touching the summary table. See
+ * wp_presence_network_summary_needs_push() for why the test is worth making
+ * here rather than in the upsert.
  *
- * The row records no per-user timestamp for that reason; its updated_gmt
- * carries freshness for every ID in it, which wp_get_presence() already
- * TTL-filtered on this site.
+ * The row records no per-user timestamp; its updated_gmt carries freshness for
+ * every ID in it, which wp_get_presence() already TTL-filtered on this site.
  *
  * @access private
  */
@@ -171,15 +170,21 @@ function wp_presence_push_network_summary() {
 	// wp_get_presence() orders by date_gmt, which reshuffles as people tick.
 	sort( $user_ids );
 
+	if ( ! wp_presence_network_summary_needs_push( $user_ids ) ) {
+		return;
+	}
+
 	$blog_id = get_current_blog_id();
 	$now     = gmdate( 'Y-m-d H:i:s' );
 	$refresh = gmdate( 'Y-m-d H:i:s', time() - wp_presence_network_summary_refresh_interval() );
 
 	// updated_gmt is assigned before data because MySQL applies the assignments
 	// in order, so reading `data` after `data = VALUES(data)` would compare the
-	// new value against itself and never detect a change.
+	// new value against itself and never detect a change. The gate above already
+	// rules out most unchanged writes; this keeps updated_gmt honest for the
+	// refresh push, which rewrites the same data on purpose.
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$wpdb->query(
+	$result = $wpdb->query(
 		$wpdb->prepare(
 			"INSERT INTO {$wpdb->presence_network_summary} (blog_id, data, updated_gmt)
 			VALUES (%d, %s, %s)
@@ -191,6 +196,63 @@ function wp_presence_push_network_summary() {
 			$now,
 			$refresh
 		)
+	);
+
+	if ( false !== $result ) {
+		wp_presence_record_network_summary_push( $user_ids );
+	}
+}
+
+/**
+ * Decides whether this site has anything to write into the summary table.
+ *
+ * True when the online set differs from the one this site last pushed, or when
+ * that push is old enough that the row is approaching the read cutoff in
+ * wp_presence_compute_network_summary().
+ *
+ * The summary table is registered into $wpdb->ms_global_tables, which pins it
+ * to the global cluster on a sharded network, so it is the one table here that
+ * cannot be split. Every admin pageview writes the admin room, not just the
+ * heartbeat tick, so testing for a change inside the upsert still sends a
+ * statement to that cluster per pageview per site. This record lives in an
+ * autoloaded option on the site's own options table instead: free to read out
+ * of alloptions, and on the site's own shard when it is written.
+ *
+ * @access private
+ * @param int[] $user_ids Online user IDs, pre-sorted.
+ * @return bool Whether to push.
+ */
+function wp_presence_network_summary_needs_push( array $user_ids ) {
+	$last = get_option( 'wp_presence_network_pushed' );
+
+	if ( ! is_array( $last ) || ! isset( $last['users'], $last['time'] ) ) {
+		return true;
+	}
+
+	if ( implode( ',', $user_ids ) !== $last['users'] ) {
+		return true;
+	}
+
+	return (int) $last['time'] <= time() - wp_presence_network_summary_refresh_interval();
+}
+
+/**
+ * Records what this site just pushed, for the next call to compare against.
+ *
+ * Autoloaded: it is read on every admin-room write and written only by a push,
+ * which the gate it feeds is there to make rare.
+ *
+ * @access private
+ * @param int[] $user_ids Online user IDs, pre-sorted.
+ */
+function wp_presence_record_network_summary_push( array $user_ids ) {
+	update_option(
+		'wp_presence_network_pushed',
+		array(
+			'users' => implode( ',', $user_ids ),
+			'time'  => time(),
+		),
+		true
 	);
 }
 

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -153,14 +153,66 @@ class WP_Test_Network_Presence extends WP_Presence_UnitTestCase {
 	private function set_network_summary_row( $blog_id, array $user_ids, $updated_gmt = null ) {
 		global $wpdb;
 
+		$updated_gmt = $updated_gmt ?? gmdate( 'Y-m-d H:i:s' );
+
 		$wpdb->replace(
 			$wpdb->presence_network_summary,
 			array(
 				'blog_id'     => $blog_id,
 				'data'        => wp_presence_encode_network_summary_row( $blog_id, $user_ids ),
-				'updated_gmt' => $updated_gmt ?? gmdate( 'Y-m-d H:i:s' ),
+				'updated_gmt' => $updated_gmt,
 			)
 		);
+
+		// A real push also leaves a record of itself on the site that pushed,
+		// which is what wp_presence_network_summary_needs_push() reads. Writing
+		// only the row would leave the two disagreeing about when this site last
+		// pushed, a state no push produces. Skipped for a blog_id with no site
+		// behind it, which is a row left over from a deleted site and has no
+		// options table to record anything in.
+		if ( ! get_site( $blog_id ) ) {
+			return;
+		}
+
+		sort( $user_ids );
+
+		switch_to_blog( $blog_id );
+		update_option(
+			'wp_presence_network_pushed',
+			array(
+				'users' => implode( ',', $user_ids ),
+				'time'  => strtotime( $updated_gmt . ' UTC' ),
+			),
+			true
+		);
+		restore_current_blog();
+	}
+
+	/**
+	 * Counts the statements naming the summary table that a callback produces.
+	 *
+	 * @param callable $during Code to run while counting.
+	 * @return int Statement count.
+	 */
+	private function count_summary_table_statements( callable $during ) {
+		global $wpdb;
+
+		$count = 0;
+		$table = $wpdb->presence_network_summary;
+
+		$counter = static function ( $query ) use ( &$count, $table ) {
+			if ( false !== strpos( $query, $table ) ) {
+				++$count;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $counter );
+		$during();
+		remove_filter( 'query', $counter );
+
+		return $count;
 	}
 
 	/**
@@ -333,6 +385,28 @@ class WP_Test_Network_Presence extends WP_Presence_UnitTestCase {
 		$this->set_presence_on_site( $blog_id, self::$editor_id );
 
 		$this->assertSame( $stamp, $this->get_network_summary_row( $blog_id )->updated_gmt );
+	}
+
+	/**
+	 * Same case, one level down. An unchanged row proves the upsert resolved to
+	 * no change, not that it was skipped, and the statement itself is the cost
+	 * on a sharded network: the summary table is pinned to the global cluster,
+	 * and every admin pageview writes the admin room. See #310.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_summary_needs_push
+	 */
+	public function test_an_unchanged_tick_sends_no_statement_to_the_summary_table() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$statements = $this->count_summary_table_statements(
+			function () use ( $blog_id ) {
+				$this->set_presence_on_site( $blog_id, self::$editor_id );
+			}
+		);
+
+		$this->assertSame( 0, $statements );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -28,6 +28,7 @@ function wp_presence_uninstall_site() {
 
 	delete_option( 'wp_presence_db_version' );
 	delete_option( 'wp_presence_screen_revisions' );
+	delete_option( 'wp_presence_network_pushed' );
 
 	// Matches wp_presence_known_options_pages() in includes/screen-revisions.php.
 	// Not required here, since this file runs standalone without the rest of


### PR DESCRIPTION
The summary table is pinned to the global cluster on a sharded network, and #299 pushed to it on every admin pageview.

Depends on #299 and targets its branch.

Closes #310

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>
