### PR TITLE
feat: add a network-wide presence summary table

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Presence API network functions.
+ *
+ * Reading who is online across a network means reading every site's presence
+ * table, and there is no way to do that from one site without switching into
+ * each of them. This file provisions the alternative: one shared, network-wide
+ * summary table holding a row per site, so the network can be read with a
+ * single query against a single table.
+ *
+ * The table is registered as an ms_global_tables entry on $wpdb->base_prefix
+ * (see wp_presence_register_network_summary_table() in presence-api.php), the
+ * same way core registers blogs and sitemeta, so it is created once per
+ * network rather than once per site.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Checks whether the network-wide presence summary table exists.
+ *
+ * Hits the database, so this is for provisioning only, where the point is to
+ * catch a table dropped out from under the option. Read and write paths use
+ * wp_presence_has_network_summary_table().
+ *
+ * @access private
+ * @return bool
+ */
+function wp_presence_network_summary_table_exists() {
+	global $wpdb;
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+	$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $wpdb->presence_network_summary ) ) );
+
+	return $found === $wpdb->presence_network_summary;
+}
+
+/**
+ * Whether the network has a summary table to read from or push into.
+ *
+ * The network counterpart of wp_presence_has_table(): an option read rather
+ * than a SHOW TABLES, since this is what the hot paths check rather than
+ * something consulted once at provisioning time.
+ *
+ * @access private
+ * @return bool
+ */
+function wp_presence_has_network_summary_table() {
+	return (int) get_site_option( 'wp_presence_network_summary_db_version' ) === WP_PRESENCE_NETWORK_SUMMARY_DB_VERSION;
+}
+
+/**
+ * Creates or updates the network-wide presence summary table if needed.
+ *
+ * One table for the whole network rather than one per site, since it exists
+ * to be read without switching into any of them. Mirrors
+ * wp_maybe_create_presence_table()'s self-healing pattern, using site options
+ * instead of per-site ones since this table is provisioned once per network,
+ * not once per site.
+ *
+ * @access private
+ */
+function wp_maybe_create_presence_network_summary_table() {
+	if ( ! is_multisite() ) {
+		return;
+	}
+
+	$provisioned = (int) get_site_option( 'wp_presence_network_summary_db_version' ) === WP_PRESENCE_NETWORK_SUMMARY_DB_VERSION;
+
+	if ( $provisioned && ( wp_doing_ajax() || wp_presence_network_summary_table_exists() ) ) {
+		return;
+	}
+
+	$lock_option = 'wp_presence_network_summary_table.lock';
+
+	// Mirrors wp_presence_create_lock(), scoped to the network via site
+	// options: add_site_option() only succeeds if the key doesn't already
+	// exist, so two requests racing to provision this table on the same
+	// network resolve to one winner. A stale lock (the holder never released
+	// it) is stolen after a minute rather than blocking forever.
+	if ( ! add_site_option( $lock_option, time() ) ) {
+		$held_since = (int) get_site_option( $lock_option );
+		if ( $held_since && $held_since > time() - MINUTE_IN_SECONDS ) {
+			return;
+		}
+		update_site_option( $lock_option, time() );
+	}
+
+	global $wpdb;
+
+	$charset_collate = $wpdb->get_charset_collate();
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	dbDelta(
+		"CREATE TABLE {$wpdb->presence_network_summary} (
+			blog_id bigint(20) unsigned NOT NULL,
+			data longtext NOT NULL,
+			updated_gmt datetime NOT NULL default '0000-00-00 00:00:00',
+			PRIMARY KEY  (blog_id),
+			KEY updated_gmt (updated_gmt)
+		) {$charset_collate};"
+	);
+
+	update_site_option( 'wp_presence_network_summary_db_version', WP_PRESENCE_NETWORK_SUMMARY_DB_VERSION );
+
+	delete_site_option( $lock_option );
+}
+
+/**
+ * Drops a deleted site's row from the network summary table.
+ *
+ * Runs on wp_delete_site. Without it a row outlives its site indefinitely, in
+ * the one table on the network that a shard router cannot split.
+ *
+ * @access private
+ * @param WP_Site $old_site The site that was deleted.
+ */
+function wp_presence_on_delete_site( $old_site ) {
+	global $wpdb;
+
+	if ( ! wp_presence_has_network_summary_table() ) {
+		return;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$wpdb->delete(
+		$wpdb->presence_network_summary,
+		array( 'blog_id' => (int) $old_site->blog_id ),
+		array( '%d' )
+	);
+}

--- a/presence-api.php
+++ b/presence-api.php
@@ -47,6 +47,7 @@ if ( isset( $wpdb->presence ) ) {
 
 define( 'WP_PRESENCE_VERSION', '0.1.24' );
 define( 'WP_PRESENCE_DB_VERSION', 2 );
+define( 'WP_PRESENCE_NETWORK_SUMMARY_DB_VERSION', 1 );
 define( 'WP_PRESENCE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WP_PRESENCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -73,6 +74,23 @@ function wp_presence_register_table() {
 }
 wp_presence_register_table();
 
+/**
+ * Registers the network-wide presence summary table name on $wpdb.
+ *
+ * One table for the whole network rather than one per site: registered as an
+ * ms_global_tables entry, using base_prefix, the same way core registers
+ * blogs/site/sitemeta.
+ */
+function wp_presence_register_network_summary_table() {
+	if ( ! is_multisite() ) {
+		return;
+	}
+	global $wpdb;
+	$wpdb->presence_network_summary = $wpdb->base_prefix . 'presence_network_summary';
+	$wpdb->ms_global_tables[]       = 'presence_network_summary';
+}
+wp_presence_register_network_summary_table();
+
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/functions.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/class-wp-rest-presence-controller.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/heartbeat.php';
@@ -85,6 +103,10 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/user-list.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/post-list.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget-whos-online.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget-active-posts.php';
+
+if ( is_multisite() ) {
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-functions.php';
+}
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 	// Developer tooling is excluded from the distributed build (see .distignore),
@@ -146,14 +168,18 @@ function wp_presence_provision_site() {
  * @param bool $network_wide Whether the plugin is being activated for the network.
  */
 function wp_presence_activate( $network_wide = false ) {
-	if ( $network_wide && is_multisite() && ! wp_is_large_network() ) {
-		foreach ( wp_presence_get_network_site_ids() as $site_id ) {
-			switch_to_blog( $site_id );
-			wp_presence_provision_site();
-			restore_current_blog();
-		}
+	if ( $network_wide && is_multisite() ) {
+		wp_maybe_create_presence_network_summary_table();
 
-		return;
+		if ( ! wp_is_large_network() ) {
+			foreach ( wp_presence_get_network_site_ids() as $site_id ) {
+				switch_to_blog( $site_id );
+				wp_presence_provision_site();
+				restore_current_blog();
+			}
+
+			return;
+		}
 	}
 
 	wp_presence_provision_site();
@@ -257,6 +283,7 @@ function wp_presence_plugin_action_links( $links ) {
 }
 
 add_action( 'init', 'wp_presence_register_table', 0 );
+add_action( 'init', 'wp_presence_register_network_summary_table', 0 );
 add_action( 'init', 'wp_presence_register_post_type_support' );
 
 // Schema work stays in the admin and CLI, the way core keeps its own upgrade
@@ -264,6 +291,11 @@ add_action( 'init', 'wp_presence_register_post_type_support' );
 // creation instead; this is the fallback for a site that missed both.
 add_action( 'admin_init', 'wp_maybe_create_presence_table' );
 add_action( 'cli_init', 'wp_maybe_create_presence_table' );
+if ( is_multisite() ) {
+	add_action( 'admin_init', 'wp_maybe_create_presence_network_summary_table' );
+	add_action( 'cli_init', 'wp_maybe_create_presence_network_summary_table' );
+	add_action( 'wp_delete_site', 'wp_presence_on_delete_site' );
+}
 // Priority 99 to run after core's wp_initialize_site() at 10.
 add_action( 'wp_initialize_site', 'wp_presence_on_initialize_site', 99 );
 add_action( 'rest_api_init', 'wp_presence_register_rest_routes' );

--- a/tests/test-network-summary-table-creation.php
+++ b/tests/test-network-summary-table-creation.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Tests for how the network-wide presence summary table is provisioned.
+ *
+ * One table for the whole network, so unlike the per-site presence table it is
+ * created once at network activation and never again. That makes the recovery
+ * paths -- a dropped table, a lock nobody released -- the only way it ever gets
+ * rebuilt, which is what this file pins down.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Network_Summary_Table_Creation extends WP_Presence_UnitTestCase {
+
+	/**
+	 * The site option backing the provisioning lock.
+	 */
+	private const LOCK_OPTION = 'wp_presence_network_summary_table.lock';
+
+	/**
+	 * The site option recording the provisioned schema version.
+	 */
+	private const VERSION_OPTION = 'wp_presence_network_summary_db_version';
+
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		// WP_UnitTestCase rewrites DDL to CREATE/DROP TEMPORARY TABLE, which would
+		// make dropping the real summary table a silent no-op. These tests need
+		// the table to genuinely disappear, so they opt out.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		// DDL commits the surrounding transaction, so a lock left behind by an
+		// earlier run survives into this one and would block every test that
+		// provisions. Start from a known-free lock.
+		delete_site_option( self::LOCK_OPTION );
+	}
+
+	public function tear_down() {
+		// DDL commits the surrounding transaction, so put the table back by hand
+		// for whatever runs next. dbDelta is idempotent, so this is safe even
+		// when the test never dropped it.
+		delete_site_option( self::LOCK_OPTION );
+		delete_site_option( self::VERSION_OPTION );
+		wp_maybe_create_presence_network_summary_table();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Removes the summary table and the marker that says it exists.
+	 */
+	private function drop_summary_table() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->presence_network_summary}" );
+		delete_site_option( self::VERSION_OPTION );
+	}
+
+	/**
+	 * Marks the network as provisioned without creating anything.
+	 */
+	private function claim_provisioned() {
+		update_site_option( self::VERSION_OPTION, WP_PRESENCE_NETWORK_SUMMARY_DB_VERSION );
+	}
+
+	/**
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 * @covers ::wp_presence_network_summary_table_exists
+	 * @covers ::wp_presence_has_network_summary_table
+	 */
+	public function test_provisioning_creates_the_table_and_records_the_version() {
+		$this->drop_summary_table();
+
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertTrue( wp_presence_network_summary_table_exists(), 'Provisioning should create the table.' );
+		$this->assertTrue( wp_presence_has_network_summary_table(), 'And record the version the read and write paths check.' );
+	}
+
+	/**
+	 * The version option is a site option, so it outlives any single site's
+	 * table being dropped. Provisioning has to trust the database over the
+	 * option, otherwise the network summary stays dead until someone deletes
+	 * the option by hand.
+	 *
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 * @covers ::wp_presence_network_summary_table_exists
+	 */
+	public function test_a_dropped_table_is_rebuilt_when_the_version_option_survives() {
+		$this->drop_summary_table();
+		$this->claim_provisioned();
+
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertTrue( wp_presence_network_summary_table_exists(), 'Provisioning should rebuild the missing table.' );
+	}
+
+	/**
+	 * Two network admin requests can enter provisioning at the same time. The
+	 * one that arrives second has to return rather than run a second,
+	 * overlapping dbDelta().
+	 *
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 */
+	public function test_a_locked_request_does_not_run_the_schema_change() {
+		$this->drop_summary_table();
+
+		// Stand in for the request that got there first and is still working.
+		add_site_option( self::LOCK_OPTION, time() );
+
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertFalse( wp_presence_network_summary_table_exists(), 'The second request should not have run dbDelta().' );
+		$this->assertFalse( wp_presence_has_network_summary_table(), 'And it should not have claimed the network is provisioned.' );
+	}
+
+	/**
+	 * Holding the lock past the work would block provisioning for every later
+	 * request, which is a worse failure than the race it guards against.
+	 *
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 */
+	public function test_provisioning_releases_the_lock_for_the_next_request() {
+		$this->drop_summary_table();
+		wp_maybe_create_presence_network_summary_table();
+		$this->assertTrue( wp_presence_network_summary_table_exists(), 'Precondition: the first request provisions.' );
+
+		$this->drop_summary_table();
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertTrue( wp_presence_network_summary_table_exists(), 'A later request should not be blocked by a lock nobody holds.' );
+	}
+
+	/**
+	 * A request that dies between taking the lock and releasing it would
+	 * otherwise leave the network unprovisionable. Core's upgrader lock
+	 * reclaims on age for the same reason.
+	 *
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 */
+	public function test_an_abandoned_lock_stops_blocking_once_it_ages_out() {
+		$this->drop_summary_table();
+
+		// A lock left behind by a request that never got to release it.
+		update_site_option( self::LOCK_OPTION, time() - ( 2 * MINUTE_IN_SECONDS ) );
+
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertTrue( wp_presence_network_summary_table_exists(), 'An expired lock should be reclaimed, not respected forever.' );
+	}
+
+	/**
+	 * admin-ajax.php fires admin_init too, and presence heartbeats through it
+	 * every 15 seconds per open admin tab. A SHOW TABLES there would bill the
+	 * whole network continuously for a state it will almost never be in.
+	 *
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 */
+	public function test_ajax_requests_do_not_pay_for_the_table_check() {
+		global $wpdb;
+
+		$this->claim_provisioned();
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$before = $wpdb->num_queries;
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertSame( $before, $wpdb->num_queries, 'A heartbeat request should not query at all.' );
+	}
+
+	/**
+	 * The other half of that trade, stated so it cannot be dropped by accident.
+	 * A network in the broken state stays broken through heartbeat traffic
+	 * alone and waits for the next real network admin page load to repair.
+	 *
+	 * @covers ::wp_maybe_create_presence_network_summary_table
+	 */
+	public function test_ajax_requests_do_not_rebuild_a_dropped_table() {
+		$this->drop_summary_table();
+		$this->claim_provisioned();
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		wp_maybe_create_presence_network_summary_table();
+
+		$this->assertFalse( wp_presence_network_summary_table_exists(), 'Heartbeat should not trigger a rebuild.' );
+	}
+
+	/**
+	 * Rows are keyed by blog_id in the one table on the network that a shard
+	 * router cannot split, so a deleted site's row has to leave with it rather
+	 * than sit there until someone goes looking.
+	 *
+	 * @covers ::wp_presence_on_delete_site
+	 */
+	public function test_deleting_a_site_drops_its_summary_row() {
+		global $wpdb;
+
+		wp_maybe_create_presence_network_summary_table();
+
+		$blog_id = self::factory()->blog->create();
+
+		$wpdb->replace(
+			$wpdb->presence_network_summary,
+			array(
+				'blog_id'     => $blog_id,
+				'data'        => '{"online_user_ids":[1]}',
+				'updated_gmt' => gmdate( 'Y-m-d H:i:s' ),
+			)
+		);
+
+		$this->assertSame( 1, $this->count_summary_rows( $blog_id ), 'Precondition: the site has a row to lose.' );
+
+		wp_delete_site( get_site( $blog_id ) );
+
+		$this->assertSame( 0, $this->count_summary_rows( $blog_id ) );
+	}
+
+	/**
+	 * Counts a site's rows in the summary table.
+	 *
+	 * @param int $blog_id The site to count rows for.
+	 * @return int Row count.
+	 */
+	private function count_summary_rows( $blog_id ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		return (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->presence_network_summary} WHERE blog_id = %d", $blog_id )
+		);
+	}
+}

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -536,6 +536,7 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		$this->assertTrue( $controller->delete_item_permissions_check( $request ) );
 		$this->assertSame( '', $wpdb->last_error, 'The ownership lookup should not have run.' );
 	}
+
 	/**
 	 * The function runs twice on a request, at require time and again on init,
 	 * so an unguarded append leaves core holding the same table name twice.
@@ -562,5 +563,37 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		$wpdb->tables = $tables;
 
 		$this->assertSame( 1, $count, 'Registering twice should leave one entry in $wpdb->tables.' );
+	}
+
+	/**
+	 * The summary is one table for the whole network, so it hangs off
+	 * base_prefix and joins ms_global_tables the way core registers blogs and
+	 * sitemeta. A single site has no network to summarise, and registering the
+	 * name there would point every caller at a table nothing ever creates.
+	 *
+	 * @covers ::wp_presence_register_network_summary_table
+	 */
+	public function test_network_summary_table_is_registered_only_on_a_network() {
+		global $wpdb;
+
+		$global_tables = $wpdb->ms_global_tables;
+		unset( $wpdb->presence_network_summary );
+
+		wp_presence_register_network_summary_table();
+
+		$registered = $wpdb->presence_network_summary ?? null;
+		$is_global  = in_array( 'presence_network_summary', $wpdb->ms_global_tables, true );
+
+		// $wpdb outlives the test, and re-registering appended a second
+		// ms_global_tables entry, so put both back before asserting.
+		$wpdb->ms_global_tables = $global_tables;
+
+		if ( ! is_multisite() ) {
+			$this->assertNull( $registered, 'A single site has no network summary table to name.' );
+			return;
+		}
+
+		$this->assertSame( $wpdb->base_prefix . 'presence_network_summary', $registered );
+		$this->assertTrue( $is_global, 'Core only treats a table as network-wide if it is an ms_global_table.' );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -40,6 +40,8 @@ function wp_presence_uninstall_site() {
 	delete_metadata( 'comment', 0, '_wp_presence_screen_rev', '', true );
 }
 
+global $wpdb;
+
 if ( is_multisite() ) {
 	$sites = get_sites(
 		array(
@@ -53,6 +55,17 @@ if ( is_multisite() ) {
 		wp_presence_uninstall_site();
 		restore_current_blog();
 	}
+
+	// The network summary is one table for the whole network, on base_prefix
+	// rather than a site's own prefix, so it is dropped once out here rather
+	// than once per site above.
+	$summary_table = $wpdb->base_prefix . 'presence_network_summary';
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a controlled value from $wpdb->base_prefix.
+	$wpdb->query( "DROP TABLE IF EXISTS {$summary_table}" );
+
+	delete_site_option( 'wp_presence_network_summary_db_version' );
+	delete_site_option( 'wp_presence_network_summary_table.lock' );
 } else {
 	wp_presence_uninstall_site();
 }


### PR DESCRIPTION
Part of the network presence stack, merged bottom-up:

1. **#332 summary table (this one)**
2. #333 write path
3. #334 read path
4. #335 Sites list column
5. #336 Users list
6. #337 network dashboard widget

---

Reading who is online across a network means reading every site's presence table, and there is no way to do that from one site without switching into each of them.

Part of #298
Closes #326

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5, Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>
