### PR TITLE
feat: push each site's online set into the network summary

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -116,6 +116,10 @@ function wp_set_presence( $room, $client_id, $state, $user_id = 0 ) {
 		)
 	);
 
+	if ( false !== $result && wp_presence_admin_room() === $room ) {
+		wp_presence_admin_room_changed();
+	}
+
 	return false !== $result;
 }
 
@@ -143,6 +147,10 @@ function wp_remove_presence( $room, $client_id ) {
 		array( '%s', '%s' )
 	);
 
+	if ( false !== $result && wp_presence_admin_room() === $room ) {
+		wp_presence_admin_room_changed();
+	}
+
 	return false !== $result;
 }
 
@@ -166,7 +174,33 @@ function wp_remove_user_presence( $user_id ) {
 		array( '%d' )
 	);
 
+	// Deletes across every room, so the admin room is always among them.
+	if ( false !== $result ) {
+		wp_presence_admin_room_changed();
+	}
+
 	return false !== $result;
+}
+
+/**
+ * Signals that a write may have changed who's online on this site.
+ *
+ * Called from every path that writes the admin room: the heartbeat tick, the
+ * server-side write on page render, login, logout, and the REST set/delete
+ * behind the pagehide handler.
+ *
+ * @access private
+ */
+function wp_presence_admin_room_changed() {
+	/**
+	 * Fires after a write that may have changed who's online on this site.
+	 *
+	 * Fires on every admin-room write, including a tick that refreshes the same
+	 * people; listeners that only want real changes compare state themselves.
+	 *
+	 * @since 0.1.25
+	 */
+	do_action( 'wp_presence_admin_room_changed' );
 }
 
 /**

--- a/includes/lifecycle.php
+++ b/includes/lifecycle.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lifecycle hooks: sets/removes presence on login and logout.
+ * Lifecycle hooks: sets/removes presence on login, logout, and user removal.
  *
  * @package Presence_API
  */
@@ -39,4 +39,18 @@ function wp_presence_on_logout( $user_id ) {
 	if ( $user_id && user_can( $user_id, 'edit_posts' ) ) {
 		wp_remove_user_presence( $user_id );
 	}
+}
+
+/**
+ * Removes a user's presence when their account is deleted or they are
+ * removed from a site.
+ *
+ * Hooked to 'deleted_user' and 'remove_user_from_blog', both of which fire
+ * with the site already switched to the one the user is leaving. No
+ * capability gate, unlike login/logout: their role may already be gone.
+ *
+ * @param int $user_id The ID of the user being deleted or removed.
+ */
+function wp_presence_on_user_removed( $user_id ) {
+	wp_remove_user_presence( $user_id );
 }

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -8,6 +8,9 @@
  * summary table holding a row per site, so the network can be read with a
  * single query against a single table.
  *
+ * Each site keeps its own row current, pushing a snapshot of who is online
+ * there whenever its presence data changes, so nothing has to go looking.
+ *
  * The table is registered as an ms_global_tables entry on $wpdb->base_prefix
  * (see wp_presence_register_network_summary_table() in presence-api.php), the
  * same way core registers blogs and sitemeta, so it is created once per
@@ -109,6 +112,204 @@ function wp_maybe_create_presence_network_summary_table() {
 	update_site_option( 'wp_presence_network_summary_db_version', WP_PRESENCE_NETWORK_SUMMARY_DB_VERSION );
 
 	delete_site_option( $lock_option );
+}
+
+/**
+ * Returns how stale a site's summary row may get before a push rewrites it.
+ *
+ * Bounded by the read cutoff minus the idle heartbeat interval, the longest
+ * gap between two pushes, so the next push always lands before the row
+ * expires. Filterable downward; clamped so a filter can't widen it past that.
+ *
+ * @access private
+ * @return int Seconds.
+ */
+function wp_presence_network_summary_refresh_interval() {
+	$timeout = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
+	$maximum = max( 1, $timeout - wp_presence_get_heartbeat_idle_interval() );
+
+	/**
+	 * Filters how stale a site's network summary row may get before a push rewrites it.
+	 *
+	 * Clamped to the read cutoff minus the idle heartbeat interval.
+	 *
+	 * @since 0.1.25
+	 *
+	 * @param int $interval Seconds. Default is the clamp maximum.
+	 */
+	$interval = (int) apply_filters( 'wp_presence_network_summary_refresh_interval', $maximum );
+
+	return max( 1, min( $interval, $maximum ) );
+}
+
+/**
+ * Pushes the current site's online-user snapshot into the network-wide
+ * summary table.
+ *
+ * Runs on wp_presence_admin_room_changed, so an arrival or a departure reaches
+ * the network within the request that caused it: logout and the pagehide delete
+ * clear the site immediately instead of waiting for its entry to age out.
+ *
+ * A tick usually finds the same people as the tick before it, and that case
+ * returns before touching the summary table. See
+ * wp_presence_network_summary_needs_push() for why the test is worth making
+ * here rather than in the upsert.
+ *
+ * The row records no per-user timestamp; its updated_gmt carries freshness for
+ * every ID in it, which wp_get_presence() already TTL-filtered on this site.
+ *
+ * @access private
+ */
+function wp_presence_push_network_summary() {
+	if ( ! is_multisite() || ! wp_presence_has_network_summary_table() ) {
+		return;
+	}
+
+	global $wpdb;
+
+	$user_ids = array();
+	foreach ( wp_get_presence( wp_presence_admin_room() ) as $entry ) {
+		$user_ids[ (int) $entry->user_id ] = true;
+	}
+
+	$user_ids = array_keys( $user_ids );
+
+	// Sorted so an unchanged room always encodes to a byte-identical string;
+	// wp_get_presence() orders by date_gmt, which reshuffles as people tick.
+	sort( $user_ids );
+
+	if ( ! wp_presence_network_summary_needs_push( $user_ids ) ) {
+		return;
+	}
+
+	$blog_id = get_current_blog_id();
+	$now     = gmdate( 'Y-m-d H:i:s' );
+	$refresh = gmdate( 'Y-m-d H:i:s', time() - wp_presence_network_summary_refresh_interval() );
+
+	// updated_gmt is assigned before data because MySQL applies the assignments
+	// in order, so reading `data` after `data = VALUES(data)` would compare the
+	// new value against itself and never detect a change. The gate above already
+	// rules out most unchanged writes; this keeps updated_gmt honest for the
+	// refresh push, which rewrites the same data on purpose.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$result = $wpdb->query(
+		$wpdb->prepare(
+			"INSERT INTO {$wpdb->presence_network_summary} (blog_id, data, updated_gmt)
+			VALUES (%d, %s, %s)
+			ON DUPLICATE KEY UPDATE
+				updated_gmt = IF( data <> VALUES(data) OR updated_gmt < %s, VALUES(updated_gmt), updated_gmt ),
+				data = VALUES(data)",
+			$blog_id,
+			wp_presence_encode_network_summary_row( $blog_id, $user_ids ),
+			$now,
+			$refresh
+		)
+	);
+
+	if ( false !== $result ) {
+		wp_presence_record_network_summary_push( $user_ids );
+	}
+}
+
+/**
+ * Decides whether this site has anything to write into the summary table.
+ *
+ * True when the online set differs from the one this site last pushed, or when
+ * that push is old enough that the row is approaching the read cutoff.
+ *
+ * The summary table is registered into $wpdb->ms_global_tables, which pins it
+ * to the global cluster on a sharded network, so it is the one table here that
+ * cannot be split. Every admin pageview writes the admin room, not just the
+ * heartbeat tick, so testing for a change inside the upsert still sends a
+ * statement to that cluster per pageview per site. This record lives in an
+ * autoloaded option on the site's own options table instead: free to read out
+ * of alloptions, and on the site's own shard when it is written.
+ *
+ * @access private
+ * @param int[] $user_ids Online user IDs, pre-sorted.
+ * @return bool Whether to push.
+ */
+function wp_presence_network_summary_needs_push( array $user_ids ) {
+	$last = get_option( 'wp_presence_network_pushed' );
+
+	if ( ! is_array( $last ) || ! isset( $last['users'], $last['time'] ) ) {
+		return true;
+	}
+
+	if ( implode( ',', $user_ids ) !== $last['users'] ) {
+		return true;
+	}
+
+	return (int) $last['time'] <= time() - wp_presence_network_summary_refresh_interval();
+}
+
+/**
+ * Records what this site just pushed, for the next call to compare against.
+ *
+ * Autoloaded: it is read on every admin-room write and written only by a push,
+ * which the gate it feeds is there to make rare.
+ *
+ * @access private
+ * @param int[] $user_ids Online user IDs, pre-sorted.
+ */
+function wp_presence_record_network_summary_push( array $user_ids ) {
+	update_option(
+		'wp_presence_network_pushed',
+		array(
+			'users' => implode( ',', $user_ids ),
+			'time'  => time(),
+		),
+		true
+	);
+}
+
+/**
+ * Encodes a site's online user IDs for the summary row's data column.
+ *
+ * Shaped to be read in a database client, the only place this column is looked
+ * at directly:
+ *
+ *     {
+ *         "site": "example.com/shop/",
+ *         "online_user_ids": [ 3, 7 ]
+ *     }
+ *
+ * The site label is for that reader; the read path resolves the site from
+ * blog_id and ignores it. Logins are left out because resolving them would
+ * cost a user query per heartbeat tick.
+ *
+ * @access private
+ * @param int   $blog_id  The site the row belongs to.
+ * @param int[] $user_ids Online user IDs, pre-sorted.
+ * @return string JSON for the data column.
+ */
+function wp_presence_encode_network_summary_row( $blog_id, array $user_ids ) {
+	$site = get_site( $blog_id );
+
+	return (string) wp_json_encode(
+		array(
+			'site'            => $site ? $site->domain . $site->path : '',
+			'online_user_ids' => $user_ids,
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	);
+}
+
+/**
+ * Decodes a summary row's data column into a list of user IDs.
+ *
+ * @access private
+ * @param string $data The row's JSON-encoded data column.
+ * @return int[] User IDs, empty if the column is empty or malformed.
+ */
+function wp_presence_decode_network_summary_row( $data ) {
+	$decoded = json_decode( $data, true );
+
+	if ( ! isset( $decoded['online_user_ids'] ) || ! is_array( $decoded['online_user_ids'] ) ) {
+		return array();
+	}
+
+	return array_map( 'intval', array_filter( $decoded['online_user_ids'], 'is_numeric' ) );
 }
 
 /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
 			<exclude>tests/stubs</exclude>
 			<exclude>tests/bootstrap.php</exclude>
 			<exclude>tests/class-wp-presence-unittestcase.php</exclude>
+			<exclude>tests/class-wp-presence-network-unittestcase.php</exclude>
 		</testsuite>
 	</testsuites>
 	<coverage>

--- a/presence-api.php
+++ b/presence-api.php
@@ -294,6 +294,7 @@ add_action( 'cli_init', 'wp_maybe_create_presence_table' );
 if ( is_multisite() ) {
 	add_action( 'admin_init', 'wp_maybe_create_presence_network_summary_table' );
 	add_action( 'cli_init', 'wp_maybe_create_presence_network_summary_table' );
+	add_action( 'wp_presence_admin_room_changed', 'wp_presence_push_network_summary' );
 	add_action( 'wp_delete_site', 'wp_presence_on_delete_site' );
 }
 // Priority 99 to run after core's wp_initialize_site() at 10.

--- a/presence-api.php
+++ b/presence-api.php
@@ -323,6 +323,8 @@ add_action( 'edit_comment', 'wp_presence_on_edit_comment' );
 
 add_action( 'wp_login', 'wp_presence_on_login', 10, 2 );
 add_action( 'wp_logout', 'wp_presence_on_logout', 10, 1 );
+add_action( 'deleted_user', 'wp_presence_on_user_removed', 10, 1 );
+add_action( 'remove_user_from_blog', 'wp_presence_on_user_removed', 10, 1 );
 
 add_action( 'admin_bar_menu', 'wp_presence_admin_bar_node', 80 );
 add_action( 'admin_enqueue_scripts', 'wp_presence_admin_bar_assets' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,8 +32,9 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
 
-// Shared base test case, extended by the plugin's test classes.
+// Shared base test cases, extended by the plugin's test classes.
 require __DIR__ . '/class-wp-presence-unittestcase.php';
+require __DIR__ . '/class-wp-presence-network-unittestcase.php';
 
 // The suite reinstalls WordPress on every run, which empties the options table
 // but leaves the plugin's own table in place. Provision the site the way

--- a/tests/class-wp-presence-network-unittestcase.php
+++ b/tests/class-wp-presence-network-unittestcase.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Shared scaffolding for tests that exercise the network summary table.
+ *
+ * The table is network-wide and created with real, non-temporary DDL, so it
+ * does not behave like the rest of the suite: rows survive a test's transaction
+ * rollback, and a blog left behind by one test lands in the next test's totals.
+ * Every network test needs the same setup and the same cleanup to work around
+ * that, so it lives here rather than being copied per file.
+ *
+ * @package Presence_API
+ */
+
+abstract class WP_Presence_Network_UnitTestCase extends WP_Presence_UnitTestCase {
+
+	/**
+	 * Blogs created by the current test, deleted in tear_down().
+	 *
+	 * A network summary sums every site on the network, so a blog left behind
+	 * by one test would otherwise leak into the next test's totals, unlike the
+	 * rest of this suite, which only ever asserts against specific blog IDs and
+	 * so doesn't care what else exists.
+	 *
+	 * @var int[]
+	 */
+	private $blog_ids = array();
+
+	/**
+	 * The network's active plugin list as it stood before the test.
+	 *
+	 * @var array|false
+	 */
+	private $network_plugins;
+
+	public function set_up() {
+		global $wpdb;
+
+		parent::set_up();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		// WP_UnitTestCase rewrites DDL to CREATE/DROP TEMPORARY TABLE. The
+		// network summary table is created with real, non-temporary DDL (see
+		// wp_maybe_create_presence_network_summary_table()), so this suite
+		// needs that rewrite disabled to provision it at all.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		// wp_presence_on_initialize_site() only provisions a new blog's table when
+		// the plugin is network active, which the test bootstrap's mu-plugin-style
+		// loading never makes true on its own. A network summary is only
+		// meaningful when every site actually has a table, so fake that here the
+		// same way test-table-creation.php does for its own network-active tests.
+		$this->network_plugins = get_site_option( 'active_sitewide_plugins' );
+		update_site_option( 'active_sitewide_plugins', array( 'presence-api/presence-api.php' => time() ) );
+
+		wp_maybe_create_presence_network_summary_table();
+
+		// Every admin-room write anywhere in the suite now pushes, and this
+		// table is real rather than temporary, so rows can outlive the test that
+		// wrote them. Start from empty rather than trusting the last tear_down.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->presence_network_summary}" );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		global $wpdb;
+
+		foreach ( $this->blog_ids as $blog_id ) {
+			wp_delete_site( $blog_id );
+		}
+		$this->blog_ids = array();
+
+		if ( false === $this->network_plugins ) {
+			delete_site_option( 'active_sitewide_plugins' );
+		} else {
+			update_site_option( 'active_sitewide_plugins', $this->network_plugins );
+		}
+
+		// set_up() disables the temporary-table DDL rewrite (see above), so
+		// writes to the real, non-temporary network summary table survive past
+		// this test's own transaction rollback -- exactly why blog_ids and
+		// active_sitewide_plugins above are cleaned up by hand instead of
+		// relying on that rollback. Rows pushed mid-test need the same
+		// treatment; the table itself stays (dbDelta is idempotent).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query( "DELETE FROM {$wpdb->presence_network_summary}" );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates a blog and schedules it for deletion at the end of the test.
+	 *
+	 * @return int The new blog ID.
+	 */
+	protected function create_blog() {
+		$blog_id          = self::factory()->blog->create();
+		$this->blog_ids[] = $blog_id;
+
+		return $blog_id;
+	}
+
+	/**
+	 * Writes a presence entry on a given site, without leaving the site
+	 * switched-to.
+	 *
+	 * No explicit push: wp_set_presence() fires wp_presence_admin_room_changed,
+	 * which is what the push hangs off, so calling one by hand here would test
+	 * a path production doesn't take.
+	 *
+	 * @param int $blog_id The site to write on.
+	 * @param int $user_id The user the entry belongs to.
+	 */
+	protected function set_presence_on_site( $blog_id, $user_id ) {
+		switch_to_blog( $blog_id );
+		wp_set_presence( 'admin/online', 'user-' . $user_id, array( 'screen' => 'dashboard' ), $user_id );
+		restore_current_blog();
+	}
+
+	/**
+	 * Removes a user's presence entry on a given site, without leaving the site
+	 * switched-to.
+	 *
+	 * @param int $blog_id The site to remove on.
+	 * @param int $user_id The user whose entry to remove.
+	 */
+	protected function remove_presence_on_site( $blog_id, $user_id ) {
+		switch_to_blog( $blog_id );
+		wp_remove_presence( 'admin/online', 'user-' . $user_id );
+		restore_current_blog();
+	}
+
+	/**
+	 * Overwrites a site's pushed row in the network summary table directly,
+	 * for tests that need to control its content or age precisely rather
+	 * than going through a real presence write.
+	 *
+	 * @param int    $blog_id     The site whose row to overwrite.
+	 * @param int[]  $user_ids    User IDs for the data column.
+	 * @param string $updated_gmt Optional. Value for the updated_gmt column. Default now.
+	 */
+	protected function set_network_summary_row( $blog_id, array $user_ids, $updated_gmt = null ) {
+		global $wpdb;
+
+		$updated_gmt = $updated_gmt ?? gmdate( 'Y-m-d H:i:s' );
+
+		$wpdb->replace(
+			$wpdb->presence_network_summary,
+			array(
+				'blog_id'     => $blog_id,
+				'data'        => wp_presence_encode_network_summary_row( $blog_id, $user_ids ),
+				'updated_gmt' => $updated_gmt,
+			)
+		);
+
+		// A real push also leaves a record of itself on the site that pushed,
+		// which is what wp_presence_network_summary_needs_push() reads. Writing
+		// only the row would leave the two disagreeing about when this site last
+		// pushed, a state no push produces. Skipped for a blog_id with no site
+		// behind it, which is a row left over from a deleted site and has no
+		// options table to record anything in.
+		if ( ! get_site( $blog_id ) ) {
+			return;
+		}
+
+		sort( $user_ids );
+
+		switch_to_blog( $blog_id );
+		update_option(
+			'wp_presence_network_pushed',
+			array(
+				'users' => implode( ',', $user_ids ),
+				'time'  => strtotime( $updated_gmt . ' UTC' ),
+			),
+			true
+		);
+		restore_current_blog();
+	}
+
+	/**
+	 * Counts the statements naming the summary table that a callback produces.
+	 *
+	 * @param callable $during Code to run while counting.
+	 * @return int Statement count.
+	 */
+	protected function count_summary_table_statements( callable $during ) {
+		global $wpdb;
+
+		$count = 0;
+		$table = $wpdb->presence_network_summary;
+
+		$counter = static function ( $query ) use ( &$count, $table ) {
+			if ( false !== strpos( $query, $table ) ) {
+				++$count;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $counter );
+		$during();
+		remove_filter( 'query', $counter );
+
+		return $count;
+	}
+
+	/**
+	 * Returns a site's raw summary row.
+	 *
+	 * @param int $blog_id The site whose row to read.
+	 * @return object|null Row with data and updated_gmt, null if the site never pushed.
+	 */
+	protected function get_network_summary_row( $blog_id ) {
+		global $wpdb;
+
+		return $wpdb->get_row(
+			$wpdb->prepare( "SELECT data, updated_gmt FROM {$wpdb->presence_network_summary} WHERE blog_id = %d", $blog_id )
+		);
+	}
+}

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -655,4 +655,56 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		$this->assertCount( 1, $entries );
 		$this->assertSame( $data, $entries[0]->data );
 	}
+
+	/**
+	 * Everything that mirrors who's online hangs off this action, so an admin
+	 * room write has to announce itself. Presence writes land on every tick from
+	 * every open tab and most are for other rooms, so the announcement is
+	 * confined to the one room that matters.
+	 *
+	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_admin_room_changed
+	 */
+	public function test_only_an_admin_room_write_announces_a_change() {
+		$fired = 0;
+		add_action(
+			'wp_presence_admin_room_changed',
+			function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
+		$this->assertSame( 0, $fired, 'A write to another room must stay quiet.' );
+
+		wp_set_presence( wp_presence_admin_room(), 'client-1', array(), self::$editor_id );
+		$this->assertSame( 1, $fired );
+	}
+
+	/**
+	 * The pagehide delete removes a single client from the admin room, and it
+	 * has to announce the change too, or a user who closed their tab stays on
+	 * screen elsewhere until their entry ages out.
+	 *
+	 * @covers ::wp_remove_presence
+	 * @covers ::wp_presence_admin_room_changed
+	 */
+	public function test_only_an_admin_room_removal_announces_a_change() {
+		wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
+		wp_set_presence( wp_presence_admin_room(), 'client-1', array(), self::$editor_id );
+
+		$fired = 0;
+		add_action(
+			'wp_presence_admin_room_changed',
+			function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		wp_remove_presence( 'test/room', 'client-1' );
+		$this->assertSame( 0, $fired, 'A removal from another room must stay quiet.' );
+
+		wp_remove_presence( wp_presence_admin_room(), 'client-1' );
+		$this->assertSame( 1, $fired );
+	}
 }

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -85,4 +85,39 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 		$this->assertCount( 0, $this->presence_for_user( self::$editor_id ) );
 		$this->assertCount( 1, $this->presence_for_user( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
+
+	/**
+	 * @covers ::wp_presence_on_user_removed
+	 */
+	public function test_deleted_user_clears_presence() {
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'user-' . $temp_user_id, array(), $temp_user_id );
+		wp_set_presence( 'postType/post:1', 'lock-' . $temp_user_id, array(), $temp_user_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
+
+		wp_delete_user( $temp_user_id );
+
+		$this->assertCount( 0, $this->presence_for_user( $temp_user_id ), 'Deleting a user should clear their presence rows.' );
+		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
+	}
+
+	/**
+	 * Isolates remove_user_from_blog() from deleted_user.
+	 *
+	 * @covers ::wp_presence_on_user_removed
+	 */
+	public function test_remove_user_from_blog_clears_presence_on_that_site_only() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'user-' . $temp_user_id, array(), $temp_user_id );
+
+		remove_user_from_blog( $temp_user_id, get_current_blog_id() );
+
+		$this->assertCount( 0, $this->presence_for_user( $temp_user_id ), 'Removing a user from a site should clear their presence there.' );
+	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Tests for how a site keeps its network summary row current.
+ *
+ * The push runs on every admin-room write, which on a busy site is every
+ * pageview and every heartbeat tick, against the one table on the network that
+ * a shard router cannot split. How often it declines to write is therefore as
+ * much of the contract as what it writes, and both are pinned down here.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_push_network_summary
+	 */
+	public function test_push_upserts_rather_than_duplicates() {
+		global $wpdb;
+
+		$blog_id = $this->create_blog();
+
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$row_count = $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->presence_network_summary} WHERE blog_id = %d", $blog_id )
+		);
+
+		$this->assertSame( '1', $row_count, 'A second push for the same site should replace its row, not add another.' );
+	}
+
+	/**
+	 * The defect this push model had at first: only the heartbeat handler
+	 * pushed, so the pagehide delete and logout left the summary showing people
+	 * who were gone until their entry aged out. Removal has to clear the site
+	 * with no heartbeat tick anywhere in the picture.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_decode_network_summary_row
+	 */
+	public function test_removing_the_last_user_clears_the_site_without_a_tick() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$this->remove_presence_on_site( $blog_id, self::$editor_id );
+
+		$row = $this->get_network_summary_row( $blog_id );
+
+		$this->assertSame( array(), wp_presence_decode_network_summary_row( $row->data ) );
+	}
+
+	/**
+	 * wp_remove_user_presence() deletes across every room at once, which is the
+	 * logout path.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_decode_network_summary_row
+	 */
+	public function test_removing_all_of_a_users_presence_clears_the_site() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		switch_to_blog( $blog_id );
+		wp_remove_user_presence( self::$editor_id );
+		restore_current_blog();
+
+		$row = $this->get_network_summary_row( $blog_id );
+
+		$this->assertSame( array(), wp_presence_decode_network_summary_row( $row->data ) );
+	}
+
+	/**
+	 * A tick that finds the same people online as the last one must not rewrite
+	 * the row. Presence writes happen on every tick from every open tab, so a
+	 * push that always wrote would put one row update per tab per tick on a
+	 * single network-wide table.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 */
+	public function test_push_does_not_rewrite_the_row_when_nobody_changed() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		// Age the row enough to tell a rewrite apart from the original write,
+		// but not past the refresh interval, which would license a rewrite.
+		$stamp = gmdate( 'Y-m-d H:i:s', time() - 1 );
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ), $stamp );
+
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$this->assertSame( $stamp, $this->get_network_summary_row( $blog_id )->updated_gmt );
+	}
+
+	/**
+	 * Same case, one level down. An unchanged row proves the upsert resolved to
+	 * no change, not that it was skipped, and the statement itself is the cost
+	 * on a sharded network: the summary table is pinned to the global cluster,
+	 * and every admin pageview writes the admin room. See #310.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_summary_needs_push
+	 * @covers ::wp_presence_record_network_summary_push
+	 */
+	public function test_an_unchanged_tick_sends_no_statement_to_the_summary_table() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$statements = $this->count_summary_table_statements(
+			function () use ( $blog_id ) {
+				$this->set_presence_on_site( $blog_id, self::$editor_id );
+			}
+		);
+
+		$this->assertSame( 0, $statements );
+	}
+
+	/**
+	 * The flip side: a row older than the refresh interval has to be rewritten
+	 * even though nobody changed, or it ages past the read cutoff and the site
+	 * drops out of the network view while people are still on it.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_summary_refresh_interval
+	 */
+	public function test_push_refreshes_a_stale_row_when_nobody_changed() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$stamp = gmdate( 'Y-m-d H:i:s', time() - wp_presence_network_summary_refresh_interval() - 1 );
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ), $stamp );
+
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$this->assertGreaterThan( $stamp, $this->get_network_summary_row( $blog_id )->updated_gmt );
+	}
+
+	/**
+	 * A membership change is not subject to the refresh interval; it writes
+	 * straight away.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_summary_needs_push
+	 * @covers ::wp_presence_decode_network_summary_row
+	 */
+	public function test_push_rewrites_the_row_as_soon_as_the_user_set_changes() {
+		$blog_id  = $this->create_blog();
+		$second   = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$expected = array( self::$editor_id, $second );
+		sort( $expected );
+
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$stamp = gmdate( 'Y-m-d H:i:s', time() - 1 );
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ), $stamp );
+
+		$this->set_presence_on_site( $blog_id, $second );
+
+		$row = $this->get_network_summary_row( $blog_id );
+
+		$this->assertGreaterThan( $stamp, $row->updated_gmt );
+		$this->assertSame( $expected, wp_presence_decode_network_summary_row( $row->data ) );
+	}
+
+	/**
+	 * The refresh interval has to stay under the read cutoff by at least the
+	 * longest gap between two pushes, or a site with only idle tabs flickers
+	 * out of the network view between refreshes.
+	 *
+	 * @covers ::wp_presence_network_summary_refresh_interval
+	 */
+	public function test_refresh_interval_leaves_room_for_the_slowest_heartbeat() {
+		$slack = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) - wp_presence_get_heartbeat_idle_interval();
+
+		$this->assertLessThanOrEqual( $slack, wp_presence_network_summary_refresh_interval() );
+
+		add_filter( 'wp_presence_network_summary_refresh_interval', '__return_zero' );
+		$this->assertSame( 1, wp_presence_network_summary_refresh_interval(), 'Must not fall to zero.' );
+		remove_filter( 'wp_presence_network_summary_refresh_interval', '__return_zero' );
+
+		add_filter( 'wp_presence_network_summary_refresh_interval', fn() => YEAR_IN_SECONDS );
+		$this->assertSame( $slack, wp_presence_network_summary_refresh_interval(), 'A filter must not widen it.' );
+	}
+
+	/**
+	 * The data column is read by people with a database client open, so it
+	 * names what it holds rather than storing a bare list of numbers.
+	 *
+	 * @covers ::wp_presence_encode_network_summary_row
+	 */
+	public function test_row_data_is_readable_on_its_own() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$data    = $this->get_network_summary_row( $blog_id )->data;
+		$decoded = json_decode( $data, true );
+		$site    = get_site( $blog_id );
+
+		$this->assertSame( $site->domain . $site->path, $decoded['site'] );
+		$this->assertSame( array( self::$editor_id ), $decoded['online_user_ids'] );
+		$this->assertStringContainsString( "\n", $data, 'Stored pretty-printed to stay readable.' );
+	}
+}

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -208,4 +208,43 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 		$this->assertSame( array( self::$editor_id ), $decoded['online_user_ids'] );
 		$this->assertStringContainsString( "\n", $data, 'Stored pretty-printed to stay readable.' );
 	}
+
+	/**
+	 * A network-wide deletion should clear, and re-push, presence on every
+	 * site the user was online on.
+	 *
+	 * @covers ::wp_presence_on_user_removed
+	 * @covers ::wp_presence_push_network_summary
+	 */
+	public function test_deleting_a_user_clears_their_presence_on_every_site() {
+		require_once ABSPATH . 'wp-admin/includes/ms.php';
+
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$blog_ids = array( $this->create_blog(), $this->create_blog() );
+
+		foreach ( $blog_ids as $blog_id ) {
+			add_user_to_blog( $blog_id, $user_id, 'editor' );
+			$this->set_presence_on_site( $blog_id, $user_id );
+		}
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+
+		wpmu_delete_user( $user_id );
+
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+			$this->assertCount( 0, $this->presence_for_user( $user_id ), "Presence should be cleared on blog {$blog_id}." );
+			restore_current_blog();
+
+			$row = $this->get_network_summary_row( $blog_id );
+			$this->assertNotContains(
+				$user_id,
+				json_decode( $row->data, true )['online_user_ids'],
+				"The network summary row for blog {$blog_id} should no longer list the deleted user."
+			);
+		}
+
+		switch_to_blog( $blog_ids[0] );
+		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
+		restore_current_blog();
+	}
 }

--- a/tests/test-post-list.php
+++ b/tests/test-post-list.php
@@ -124,6 +124,9 @@ class WP_Test_Presence_Post_List extends WP_Presence_UnitTestCase {
 			wp_delete_user( $deleted_id );
 		}
 
+		// Deletion now clears this row; re-write it to test the fallback rendering.
+		wp_set_presence( wp_presence_post_room( $post_deleted ), 'lock-3', array(), $deleted_id );
+
 		$this->assertSame( '', $this->render_column( $post_none ) );
 
 		$one_output = $this->render_column( $post_one );

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -499,6 +499,9 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 			wp_delete_user( $temp_user_id );
 		}
 
+		// Deletion now clears this row; re-write it to test the fallback fields.
+		wp_set_presence( 'admin/online', 'client-temp', array(), $temp_user_id );
+
 		$request = new WP_REST_Request( 'GET', '/wp-presence/v1/presence' );
 		$request->set_param( 'room', 'admin/online' );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -28,6 +28,7 @@ function wp_presence_uninstall_site() {
 
 	delete_option( 'wp_presence_db_version' );
 	delete_option( 'wp_presence_screen_revisions' );
+	delete_option( 'wp_presence_network_pushed' );
 
 	// Matches wp_presence_known_options_pages() in includes/screen-revisions.php.
 	// Not required here, since this file runs standalone without the rest of


### PR DESCRIPTION
Part of the network presence stack, merged bottom-up:

1. #332 summary table
2. **#333 write path (this one)**
3. #334 read path
4. #335 Sites list column
5. #336 Users list
6. #337 network dashboard widget

---

The table in #332 has nothing writing into it.

Part of #298
Closes #327

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5, Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>

