### PR TITLE
feat: read the network summary as a capped snapshot

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -16,11 +16,24 @@
  * same way core registers blogs and sitemeta, so it is created once per
  * network rather than once per site.
  *
+ * Reading splits in two. The snapshot is one query returning user IDs and
+ * nothing else, and it is what most callers want. Resolving those IDs into
+ * display names and avatar URLs is the part that costs, and no surface draws
+ * every user online, so callers ask the summary for the slice they are about
+ * to render rather than taking the whole network and cutting it afterwards.
+ *
  * @package Presence_API
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+// How many people a network surface draws per site. Every one of them costs a
+// user load and an avatar URL, so this is also what the read path is asked to
+// resolve; the headcount beside the stack is the site's real total.
+if ( ! defined( 'WP_PRESENCE_NETWORK_AVATARS' ) ) {
+	define( 'WP_PRESENCE_NETWORK_AVATARS', 4 );
 }
 
 /**
@@ -333,5 +346,475 @@ function wp_presence_on_delete_site( $old_site ) {
 		$wpdb->presence_network_summary,
 		array( 'blog_id' => (int) $old_site->blog_id ),
 		array( '%d' )
+	);
+
+	wp_presence_flush_network_summary_cache();
+}
+
+/**
+ * Returns the capability required to see network-wide presence data.
+ *
+ * @access private
+ * @return string
+ */
+function wp_presence_network_capability() {
+	/**
+	 * Filters the capability required to see network-wide presence data.
+	 *
+	 * @param string $capability Default 'manage_network'.
+	 */
+	return apply_filters( 'wp_presence_network_capability', 'manage_network' );
+}
+
+/**
+ * Returns every site's online user IDs, without resolving any of them.
+ *
+ * One query against the shared wp_presence_network_summary table -- one row
+ * per site, kept current by wp_presence_push_network_summary() -- rather than
+ * querying every site's own presence table.
+ *
+ * This is the cheap half of the read path and the one most callers want.
+ * Resolving a display name and an avatar URL for every user on every site is
+ * what costs, and no surface renders all of them. Callers that need names and
+ * avatars ask wp_presence_get_network_summary() for the slice they are about
+ * to render.
+ *
+ * Held for the rest of the request. The push invalidates it, so a read after a
+ * write on this site still sees the write.
+ *
+ * @access private
+ * @param array $args {
+ *     Optional.
+ *
+ *     @type int $timeout TTL in seconds. Default WP_PRESENCE_DEFAULT_TTL.
+ * }
+ * @return array {
+ *     @type array $sites               User IDs keyed by blog_id, busiest site
+ *                                       first, then by blog_id. Each list is in
+ *                                       the order the site pushed it, which is
+ *                                       ascending user ID.
+ *     @type int   $total_sites_online
+ *     @type int   $total_users_online  Summed per site, so a user online on two
+ *                                       sites counts twice.
+ * }
+ */
+function wp_presence_get_network_snapshot( array $args = array() ) {
+	$timeout = wp_presence_get_timeout( $args['timeout'] ?? WP_PRESENCE_DEFAULT_TTL );
+
+	return wp_presence_network_cached(
+		'snapshot:' . $timeout,
+		static function () use ( $timeout ) {
+			return wp_presence_compute_network_snapshot( $timeout );
+		}
+	);
+}
+
+/**
+ * Returns the network-wide presence summary, with names and avatars resolved.
+ *
+ * Bounded on purpose. Hydration is linear in the number of users asked for, so
+ * a caller passes the slice it is about to render rather than taking the whole
+ * network and slicing afterwards.
+ *
+ * @access private
+ * @param array $args {
+ *     Optional.
+ *
+ *     @type int $timeout        TTL in seconds. Default WP_PRESENCE_DEFAULT_TTL.
+ *     @type int $sites          Maximum sites to resolve, busiest first. Default 0, every site.
+ *     @type int $users_per_site Maximum users to resolve per site. Default 0, every user.
+ *     @type int $blog_id        Resolve this site only. Default 0, no restriction.
+ * }
+ * @return array {
+ *     @type array $sites               blog_id, domain, path, url, users
+ *                                       (user_id, display_name, avatar_url),
+ *                                       user_count. Ordered by user_count
+ *                                       descending, then by blog_id.
+ *                                       user_count is the site's real total,
+ *                                       which users is capped below.
+ *     @type int   $total_sites_online  Network-wide, not the resolved count.
+ *     @type int   $total_users_online  Network-wide, not the resolved count.
+ * }
+ */
+function wp_presence_get_network_summary( array $args = array() ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'timeout'        => WP_PRESENCE_DEFAULT_TTL,
+			'sites'          => 0,
+			'users_per_site' => 0,
+			'blog_id'        => 0,
+		)
+	);
+
+	$timeout = wp_presence_get_timeout( $args['timeout'] );
+	$key     = sprintf(
+		'summary:%d:%d:%d:%d',
+		$timeout,
+		(int) $args['sites'],
+		(int) $args['users_per_site'],
+		(int) $args['blog_id']
+	);
+
+	return wp_presence_network_cached(
+		$key,
+		static function () use ( $args, $timeout ) {
+			return wp_presence_hydrate_network_snapshot(
+				wp_presence_get_network_snapshot( array( 'timeout' => $timeout ) ),
+				(int) $args['sites'],
+				(int) $args['users_per_site'],
+				(int) $args['blog_id']
+			);
+		}
+	);
+}
+
+/**
+ * Returns a built network read, building it on first ask.
+ *
+ * Keyed by what was asked for, since a caller may want a different window or a
+ * different slice than the one already built.
+ *
+ * The group is registered non-persistent in presence-api.php, so this holds for
+ * the request and no longer: a summary is derived from rows every site on the
+ * network writes, and there is no invalidation event a single site could see.
+ *
+ * @access private
+ * @param string   $key   What is being asked for.
+ * @param callable $build Builds the value when it is not already held.
+ * @return mixed The held value.
+ */
+function wp_presence_network_cached( $key, callable $build ) {
+	$group = wp_presence_network_cache_group();
+	$key   = $key . ':' . wp_cache_get_last_changed( $group );
+	$found = false;
+	$value = wp_cache_get( $key, $group, false, $found );
+
+	if ( $found ) {
+		return $value;
+	}
+
+	$value = $build();
+
+	wp_cache_set( $key, $value, $group );
+
+	return $value;
+}
+
+/**
+ * Returns the object cache group the built network reads live in.
+ *
+ * @access private
+ * @return string Cache group.
+ */
+function wp_presence_network_cache_group() {
+	return 'presence_network';
+}
+
+/**
+ * Drops the request's built network reads.
+ *
+ * Runs on wp_presence_admin_room_changed, alongside the push that gave this
+ * site a new row. Bumps last_changed rather than deleting keys, the same way
+ * core invalidates its own derived query caches, so every slice and window
+ * built from the old rows is left behind at once.
+ *
+ * @access private
+ */
+function wp_presence_flush_network_summary_cache() {
+	wp_cache_set_last_changed( wp_presence_network_cache_group() );
+}
+
+/**
+ * Drops user IDs that no longer name an account from a snapshot.
+ *
+ * A summary row stores user IDs and nothing else, and no hook clears a
+ * deleted user's presence from the other sites they were online on, so a row
+ * outlives the account until that site's next push. Counting one would
+ * overstate the network and rendering one would give an empty avatar.
+ *
+ * IDs only, in one query for the whole snapshot. Loading the accounts is the
+ * expensive half and is left to wp_presence_hydrate_network_snapshot(), which
+ * runs against a handful of users rather than every user online.
+ *
+ * @since 0.1.25
+ *
+ * @param array $by_site Blog ID to array of user IDs.
+ * @return array The same map with unknown users, and any site left empty by
+ *               their removal, dropped.
+ */
+function wp_presence_filter_network_snapshot_users( array $by_site ) {
+	$all_ids = array();
+
+	foreach ( $by_site as $user_ids ) {
+		foreach ( $user_ids as $user_id ) {
+			$all_ids[ $user_id ] = true;
+		}
+	}
+
+	$existing = array_flip(
+		array_map(
+			'intval',
+			get_users(
+				array(
+					'include' => array_keys( $all_ids ),
+					'fields'  => 'ID',
+					'blog_id' => 0,
+				)
+			)
+		)
+	);
+
+	if ( count( $existing ) === count( $all_ids ) ) {
+		return $by_site;
+	}
+
+	$filtered = array();
+
+	foreach ( $by_site as $blog_id => $user_ids ) {
+		$kept = array_values(
+			array_filter(
+				$user_ids,
+				static function ( $user_id ) use ( $existing ) {
+					return isset( $existing[ $user_id ] );
+				}
+			)
+		);
+
+		if ( $kept ) {
+			$filtered[ $blog_id ] = $kept;
+		}
+	}
+
+	return $filtered;
+}
+
+/**
+ * Reads every site's pushed row from the network summary table.
+ *
+ * A single query against one small, indexed table, not one query per site.
+ * $timeout applies once, against each row's updated_gmt; there is no second
+ * per-user cutoff to disagree with it, since a row's IDs are what that site's
+ * TTL-filtered read returned when it pushed, and a membership change pushes
+ * again immediately.
+ *
+ * Sites and users are checked against the network here, while the result is
+ * still a list of IDs, so a stale row is dropped before anything gets loaded.
+ *
+ * @access private
+ * @param int $timeout TTL in seconds; rows untouched longer than this are skipped.
+ * @return array See wp_presence_get_network_snapshot().
+ */
+function wp_presence_compute_network_snapshot( $timeout ) {
+	global $wpdb;
+
+	if ( ! wp_presence_has_network_summary_table() ) {
+		return wp_presence_empty_network_summary();
+	}
+
+	$cutoff = gmdate( 'Y-m-d H:i:s', time() - $timeout );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT blog_id, data FROM {$wpdb->presence_network_summary} WHERE updated_gmt > %s",
+			$cutoff
+		)
+	);
+
+	if ( ! $rows ) {
+		return wp_presence_empty_network_summary();
+	}
+
+	$by_site = array();
+
+	foreach ( $rows as $row ) {
+		$entries = wp_presence_decode_network_summary_row( $row->data );
+
+		if ( $entries ) {
+			$by_site[ (int) $row->blog_id ] = $entries;
+		}
+	}
+
+	if ( ! $by_site ) {
+		return wp_presence_empty_network_summary();
+	}
+
+	// IDs only. A row outlives the site it belongs to until cleanup runs, and
+	// counting one would overstate the network. Resolving the domain and path
+	// is left to whichever sites a caller goes on to render.
+	$live = get_sites(
+		array(
+			'site__in' => array_keys( $by_site ),
+			'fields'   => 'ids',
+			'number'   => 0,
+		)
+	);
+
+	$by_site = array_intersect_key( $by_site, array_flip( array_map( 'intval', $live ) ) );
+
+	if ( ! $by_site ) {
+		return wp_presence_empty_network_summary();
+	}
+
+	$by_site = wp_presence_filter_network_snapshot_users( $by_site );
+
+	if ( ! $by_site ) {
+		return wp_presence_empty_network_summary();
+	}
+
+	// Busiest first, which is the order every caller renders in, then by
+	// blog_id so a tie holds still from one tick to the next. Ordering on
+	// domain would mean resolving every site to place five of them.
+	uksort(
+		$by_site,
+		static function ( $a, $b ) use ( $by_site ) {
+			$by_count = count( $by_site[ $b ] ) <=> count( $by_site[ $a ] );
+
+			return 0 !== $by_count ? $by_count : $a <=> $b;
+		}
+	);
+
+	$total_users = 0;
+
+	foreach ( $by_site as $entries ) {
+		$total_users += count( $entries );
+	}
+
+	return array(
+		'sites'              => $by_site,
+		'total_sites_online' => count( $by_site ),
+		'total_users_online' => $total_users,
+	);
+}
+
+/**
+ * Resolves names, avatars, and site details for a slice of a snapshot.
+ *
+ * @access private
+ * @param array $snapshot       Return value of wp_presence_get_network_snapshot().
+ * @param int   $max_sites      Maximum sites to resolve. 0 for every site.
+ * @param int   $users_per_site Maximum users to resolve per site. 0 for every user.
+ * @param int   $blog_id        Resolve this site only. 0 for no restriction.
+ * @return array See wp_presence_get_network_summary().
+ */
+function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $users_per_site, $blog_id ) {
+	$by_site = $snapshot['sites'];
+
+	if ( $blog_id ) {
+		$by_site = isset( $by_site[ $blog_id ] ) ? array( $blog_id => $by_site[ $blog_id ] ) : array();
+	}
+
+	if ( $max_sites > 0 ) {
+		$by_site = array_slice( $by_site, 0, $max_sites, true );
+	}
+
+	if ( ! $by_site ) {
+		return array(
+			'sites'              => array(),
+			'total_sites_online' => $snapshot['total_sites_online'],
+			'total_users_online' => $snapshot['total_users_online'],
+		);
+	}
+
+	// Capped before resolving, not after. The cap is what makes this bounded,
+	// and the users it keeps are the lowest IDs on the site, which is stable
+	// across ticks in a way an alphabetical cut would not be.
+	$shown  = array();
+	$needed = array();
+
+	foreach ( $by_site as $site_id => $entries ) {
+		$shown[ $site_id ] = $users_per_site > 0 ? array_slice( $entries, 0, $users_per_site ) : $entries;
+
+		foreach ( $shown[ $site_id ] as $user_id ) {
+			$needed[ $user_id ] = true;
+		}
+	}
+
+	cache_users( array_keys( $needed ) );
+
+	// One site query for the slice. get_site() per row is one query each on a
+	// cold cache, which is the shape this table exists to avoid.
+	$found_sites = array();
+
+	$found = get_sites(
+		array(
+			'site__in' => array_keys( $by_site ),
+			'number'   => 0,
+		)
+	);
+
+	foreach ( $found as $found_site ) {
+		$found_sites[ (int) $found_site->blog_id ] = $found_site;
+	}
+
+	$sites = array();
+
+	foreach ( $shown as $site_id => $entries ) {
+		$site = $found_sites[ $site_id ] ?? null;
+
+		if ( ! $site ) {
+			continue;
+		}
+
+		$hydrated = array();
+
+		foreach ( $entries as $user_id ) {
+			$user = get_userdata( $user_id );
+
+			if ( ! $user ) {
+				continue;
+			}
+
+			$hydrated[] = array(
+				'user_id'      => $user_id,
+				'display_name' => $user->display_name,
+				'avatar_url'   => get_avatar_url( $user->ID, array( 'size' => 32 ) ),
+			);
+		}
+
+		if ( ! $hydrated ) {
+			continue;
+		}
+
+		// No per-user timestamp to order by, so order by name.
+		usort(
+			$hydrated,
+			static function ( $a, $b ) {
+				return strcmp( $a['display_name'], $b['display_name'] );
+			}
+		);
+
+		$sites[] = array(
+			'blog_id'    => $site_id,
+			'domain'     => $site->domain,
+			'path'       => $site->path,
+			// get_site_url()/get_blog_option() switch blogs on every call; the raw
+			// WP_Site fields don't, at the cost of not reflecting a mapped domain.
+			'url'        => ( is_ssl() ? 'https://' : 'http://' ) . $site->domain . $site->path,
+			'users'      => $hydrated,
+			// The site's real total, which users is capped below.
+			'user_count' => count( $by_site[ $site_id ] ),
+		);
+	}
+
+	return array(
+		'sites'              => $sites,
+		'total_sites_online' => $snapshot['total_sites_online'],
+		'total_users_online' => $snapshot['total_users_online'],
+	);
+}
+
+/**
+ * Returns the shape wp_presence_get_network_summary() returns when nobody is online.
+ *
+ * @access private
+ * @return array See wp_presence_get_network_summary().
+ */
+function wp_presence_empty_network_summary() {
+	return array(
+		'sites'              => array(),
+		'total_sites_online' => 0,
+		'total_users_online' => 0,
 	);
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -292,9 +292,22 @@ add_action( 'init', 'wp_presence_register_post_type_support' );
 add_action( 'admin_init', 'wp_maybe_create_presence_table' );
 add_action( 'cli_init', 'wp_maybe_create_presence_table' );
 if ( is_multisite() ) {
+	// Global so the keys are not prefixed with a blog ID. The push runs inside
+	// switch_to_blog(), and a per-site group would file the invalidation under
+	// the switched-to site while the reader looks under the current one.
+	wp_cache_add_global_groups( wp_presence_network_cache_group() );
+
+	// Non-persistent on purpose. Every site's push invalidates the group, so on
+	// a network of any size last_changed moves faster than a shared cache could
+	// be read, and a persistent store would take the writes and the evicted
+	// keys for a hit rate near zero. Deduplicating within the request is the
+	// part worth having.
+	wp_cache_add_non_persistent_groups( wp_presence_network_cache_group() );
+
 	add_action( 'admin_init', 'wp_maybe_create_presence_network_summary_table' );
 	add_action( 'cli_init', 'wp_maybe_create_presence_network_summary_table' );
 	add_action( 'wp_presence_admin_room_changed', 'wp_presence_push_network_summary' );
+	add_action( 'wp_presence_admin_room_changed', 'wp_presence_flush_network_summary_cache' );
 	add_action( 'wp_delete_site', 'wp_presence_on_delete_site' );
 }
 // Priority 99 to run after core's wp_initialize_site() at 10.

--- a/tests/class-wp-presence-unittestcase.php
+++ b/tests/class-wp-presence-unittestcase.php
@@ -14,6 +14,13 @@ abstract class WP_Presence_UnitTestCase extends WP_UnitTestCase {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
+
+		// The network summary is held for the life of a request, which in a
+		// test run is the whole suite. Nothing in production needs this.
+		if ( function_exists( 'wp_presence_flush_network_summary_cache' ) ) {
+			wp_presence_flush_network_summary_cache();
+		}
+
 		parent::tear_down();
 	}
 

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Tests for reading network-wide presence.
+ *
+ * The whole point of the aggregation layer is reading across sites without
+ * paying for switch_to_blog() on every page load or heartbeat tick, so that
+ * property is asserted directly rather than only implied by correct output.
+ * The same goes for the cap: what a caller asks to resolve and what the
+ * network really holds are two different numbers, and the read reports both.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Network_Presence extends WP_Presence_Network_UnitTestCase {
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_get_network_snapshot
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_filter_network_snapshot_users
+	 * @covers ::wp_presence_decode_network_summary_row
+	 */
+	public function test_summary_aggregates_across_sites() {
+		$blog_ids = array(
+			$this->create_blog(),
+			$this->create_blog(),
+		);
+
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+		$this->set_presence_on_site( $blog_ids[1], self::$editor_id );
+
+		$summary = wp_presence_get_network_summary();
+
+		$this->assertSame( 2, $summary['total_sites_online'] );
+		$this->assertSame( 2, $summary['total_users_online'] );
+
+		$seen_blog_ids = wp_list_pluck( $summary['sites'], 'blog_id' );
+		sort( $seen_blog_ids );
+		$this->assertSame( $blog_ids, $seen_blog_ids );
+
+		foreach ( $summary['sites'] as $site ) {
+			$this->assertSame( self::$editor_id, $site['users'][0]['user_id'] );
+			$this->assertArrayHasKey( 'avatar_url', $site['users'][0] );
+		}
+	}
+
+	/**
+	 * A site that hasn't pushed a row (never had any admin activity yet) has
+	 * to be silently absent from the result rather than fatal the whole
+	 * aggregation.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_compute_network_snapshot
+	 */
+	public function test_summary_tolerates_a_site_with_no_pushed_row() {
+		$blog_ids = array(
+			$this->create_blog(),
+			$this->create_blog(),
+		);
+
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+		// blog_ids[1] is created but never pushes anything.
+
+		$summary = wp_presence_get_network_summary();
+
+		$this->assertSame( array( $blog_ids[0] ), wp_list_pluck( $summary['sites'], 'blog_id' ) );
+	}
+
+	/**
+	 * The property this whole aggregation layer exists to have: reading across
+	 * sites must not switch blogs, even transiently. A before/after comparison
+	 * alone could miss a switch that nets out to no visible state change, so
+	 * this listens for the action both switch_to_blog() and
+	 * restore_current_blog() fire.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 */
+	public function test_summary_never_switches_blogs() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$switch_count = 0;
+		add_action(
+			'switch_blog',
+			function () use ( &$switch_count ) {
+				++$switch_count;
+			}
+		);
+
+		$blog_id_before = get_current_blog_id();
+		$prefix_before  = $GLOBALS['wpdb']->prefix;
+
+		wp_presence_get_network_summary();
+
+		$this->assertSame( 0, $switch_count, 'Aggregation must never fire switch_blog.' );
+		$this->assertSame( $blog_id_before, get_current_blog_id() );
+		$this->assertSame( $prefix_before, $GLOBALS['wpdb']->prefix );
+	}
+
+	/**
+	 * A row whose data column will not decode must drop out rather than fatal
+	 * the whole aggregation.
+	 *
+	 * @covers ::wp_presence_decode_network_summary_row
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_empty_network_summary
+	 */
+	public function test_summary_tolerates_a_malformed_row() {
+		global $wpdb;
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$wpdb->update(
+			$wpdb->presence_network_summary,
+			array( 'data' => 'not json' ),
+			array( 'blog_id' => $blog_id )
+		);
+
+		$this->assertSame( array(), wp_presence_get_network_summary()['sites'] );
+	}
+
+	/**
+	 * A row not pushed to within the live timeout is excluded at the SQL level,
+	 * which is the only freshness cutoff the read path applies.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_empty_network_summary
+	 */
+	public function test_summary_excludes_a_row_not_pushed_within_the_timeout() {
+		$blog_id = $this->create_blog();
+
+		$this->set_network_summary_row(
+			$blog_id,
+			array( self::$editor_id ),
+			gmdate( 'Y-m-d H:i:s', time() - WP_PRESENCE_DEFAULT_TTL - 1 )
+		);
+
+		$summary = wp_presence_get_network_summary();
+
+		$this->assertSame( array(), $summary['sites'] );
+	}
+
+	/**
+	 * The read path is reached on a network whose table has not been provisioned
+	 * yet -- the plugin is network activated one request before the first push --
+	 * so it answers from the empty shape rather than querying a missing table.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_empty_network_summary
+	 */
+	public function test_summary_is_empty_before_the_table_is_provisioned() {
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		$version = get_site_option( 'wp_presence_network_summary_db_version' );
+		delete_site_option( 'wp_presence_network_summary_db_version' );
+
+		$summary = wp_presence_get_network_summary();
+
+		update_site_option( 'wp_presence_network_summary_db_version', $version );
+
+		$this->assertSame( wp_presence_empty_network_summary(), $summary );
+	}
+
+	/**
+	 * Deleting a site leaves its row behind until it ages out, so the row can
+	 * outlive the site it names.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 */
+	public function test_summary_skips_a_row_for_a_site_that_no_longer_exists() {
+		$this->set_network_summary_row( 999901, array( self::$editor_id ) );
+
+		$this->assertSame( array(), wp_presence_get_network_summary()['sites'] );
+	}
+
+	/**
+	 * A row names user IDs and nothing else, so it outlives the accounts it
+	 * points at. A deleted account has to drop out of its site rather than out
+	 * of the whole aggregation, and a site left with nobody real drops out
+	 * entirely rather than showing as online with an empty list.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_filter_network_snapshot_users
+	 */
+	public function test_summary_skips_users_who_no_longer_exist() {
+		$kept    = $this->create_blog();
+		$emptied = $this->create_blog();
+
+		$this->set_network_summary_row( $kept, array( 999902, self::$editor_id ) );
+		$this->set_network_summary_row( $emptied, array( 999903 ) );
+
+		$summary = wp_presence_get_network_summary();
+
+		$this->assertSame( array( $kept ), wp_list_pluck( $summary['sites'], 'blog_id' ) );
+		$this->assertSame( array( self::$editor_id ), wp_list_pluck( $summary['sites'][0]['users'], 'user_id' ) );
+		$this->assertSame( 1, $summary['total_users_online'] );
+	}
+
+	/**
+	 * A row carries no per-user timestamp to order by, so the people on a site
+	 * are ordered by name to keep the list from reshuffling between reads.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 */
+	public function test_summary_lists_the_users_on_a_site_by_name() {
+		$blog_id = $this->create_blog();
+		$zoe     = self::factory()->user->create( array( 'display_name' => 'Zoe' ) );
+		$ana     = self::factory()->user->create( array( 'display_name' => 'Ana' ) );
+
+		$this->set_network_summary_row( $blog_id, array( $zoe, $ana ) );
+
+		$summary = wp_presence_get_network_summary();
+
+		$this->assertSame( array( 'Ana', 'Zoe' ), wp_list_pluck( $summary['sites'][0]['users'], 'display_name' ) );
+	}
+
+	/**
+	 * The network view is a list of where the activity is, so the busiest site
+	 * leads it, and a capped read keeps the sites worth showing. Sites tied on
+	 * headcount fall back to blog ID, which is what keeps the order stable
+	 * without resolving every site to order them.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 */
+	public function test_summary_lists_the_busiest_site_first() {
+		$quiet  = $this->create_blog();
+		$busy   = $this->create_blog();
+		$second = self::factory()->user->create();
+
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+		$this->set_network_summary_row( $busy, array( self::$editor_id, $second ) );
+
+		$summary = wp_presence_get_network_summary();
+
+		$this->assertSame( array( $busy, $quiet ), wp_list_pluck( $summary['sites'], 'blog_id' ) );
+		$this->assertSame( 2, $summary['total_sites_online'] );
+		$this->assertSame( 3, $summary['total_users_online'] );
+	}
+
+	/**
+	 * The Sites and Users list columns call this once per row, and a build
+	 * resolves a display name and an avatar URL for every user on every site,
+	 * so a second read in the same request must not repeat it.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_network_cached
+	 * @covers ::wp_presence_network_cache_group
+	 * @covers ::wp_presence_flush_network_summary_cache
+	 */
+	public function test_the_summary_is_built_once_per_request_and_dropped_by_a_push() {
+		global $wpdb;
+
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		$first = wp_presence_get_network_summary();
+
+		$queries = $wpdb->num_queries;
+		$second  = wp_presence_get_network_summary();
+
+		$this->assertSame( $queries, $wpdb->num_queries, 'A second read in the same request rebuilt the summary.' );
+		$this->assertSame( $first, $second );
+
+		// A real write on this site pushes a fresh row, which the held build
+		// would otherwise hide for the rest of the request.
+		$arriving_id = self::factory()->user->create();
+		$this->set_presence_on_site( $blog_id, $arriving_id );
+
+		$after = wp_presence_get_network_summary();
+
+		$this->assertSame(
+			array( $arriving_id ),
+			wp_list_pluck( $after['sites'][0]['users'], 'user_id' ),
+			'A read after a push returned the build from before it.'
+		);
+	}
+
+	/**
+	 * Every caller renders a slice: the widget shows five sites with a few
+	 * avatars each. Resolving a display name and an avatar URL for every user
+	 * on every site to render twenty of them is what made the read scale with
+	 * the network rather than with the view, so the caps apply before anything
+	 * is loaded. The counts stay network-wide, since they are what tells a
+	 * network admin the slice is a slice.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_hydrate_network_snapshot
+	 */
+	public function test_summary_caps_what_it_resolves_without_capping_what_it_reports() {
+		$busy  = $this->create_blog();
+		$quiet = $this->create_blog();
+
+		$this->set_network_summary_row( $busy, self::factory()->user->create_many( 3 ) );
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+
+		$summary = wp_presence_get_network_summary(
+			array(
+				'sites'          => 1,
+				'users_per_site' => 2,
+			)
+		);
+
+		$this->assertSame( array( $busy ), wp_list_pluck( $summary['sites'], 'blog_id' ) );
+		$this->assertCount( 2, $summary['sites'][0]['users'] );
+		$this->assertSame( 3, $summary['sites'][0]['user_count'], 'A capped list reported its own length as the headcount.' );
+		$this->assertSame( 2, $summary['total_sites_online'] );
+		$this->assertSame( 4, $summary['total_users_online'] );
+	}
+
+	/**
+	 * The Sites list column renders one row at a time, so it asks for one site
+	 * rather than filtering the whole network down in PHP on every row.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_hydrate_network_snapshot
+	 */
+	public function test_summary_can_be_narrowed_to_one_site() {
+		$wanted = $this->create_blog();
+		$other  = $this->create_blog();
+
+		$this->set_network_summary_row( $wanted, array( self::$editor_id ) );
+		$this->set_network_summary_row( $other, array( self::$editor_id ) );
+
+		$summary = wp_presence_get_network_summary( array( 'blog_id' => $wanted ) );
+
+		$this->assertSame( array( $wanted ), wp_list_pluck( $summary['sites'], 'blog_id' ) );
+		$this->assertSame( 2, $summary['total_sites_online'] );
+
+		// Most rows on a Sites list are quiet ones, and that narrowing still has
+		// a network behind it to report totals for.
+		$quiet = wp_presence_get_network_summary( array( 'blog_id' => $this->create_blog() ) );
+
+		$this->assertSame( array(), $quiet['sites'] );
+		$this->assertSame( 2, $quiet['total_sites_online'] );
+	}
+
+	/**
+	 * Network presence data spans every site on the install, so the bar to see
+	 * it is a network capability, and a network that delegates differently can
+	 * move it.
+	 *
+	 * @covers ::wp_presence_network_capability
+	 */
+	public function test_the_network_capability_is_filterable() {
+		$this->assertSame( 'manage_network', wp_presence_network_capability() );
+
+		add_filter( 'wp_presence_network_capability', fn() => 'manage_sites' );
+
+		$this->assertSame( 'manage_sites', wp_presence_network_capability() );
+	}
+}


### PR DESCRIPTION
Part of the network presence stack, merged bottom-up:

1. #332 summary table
2. #333 write path
3. **#334 read path (this one)**
4. #335 Sites list column
5. #336 Users list
6. #337 network dashboard widget

---

The rows #333 writes have nothing reading them, and #310 asked whether that read holds up at large-network scale.

Part of #298
Closes #321
Closes #324

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5, Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>
