### PR TITLE
feat: add an Online column to the Network Sites list

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -822,3 +822,30 @@ function wp_presence_hydrate_room_users( $rooms, $timeout = WP_PRESENCE_DEFAULT_
 
 	return $rooms;
 }
+
+/**
+ * Renders a small avatar stack for a list of users.
+ *
+ * Shared across every surface that shows an overlapping avatar stack (the
+ * dashboard widget's overflow indicator, the network Sites list column, the
+ * network dashboard widget) so they all render the stack identically.
+ *
+ * @access private
+ * @param array $users Users, each with 'avatar_url' and 'display_name'.
+ * @param int   $max   Optional. Maximum avatars to show. Default 4.
+ * @param int   $size  Optional. Avatar width and height in pixels. Default 20.
+ * @return string HTML markup.
+ */
+function wp_presence_render_avatar_stack( $users, $max = 4, $size = 20 ) {
+	$stack_max = min( count( $users ), $max );
+	$html      = '<span class="presence-avatar-stack">';
+
+	foreach ( array_slice( $users, 0, $stack_max ) as $index => $user ) {
+		$z     = $stack_max - $index;
+		$html .= '<img src="' . esc_url( $user['avatar_url'] ) . '" width="' . (int) $size . '" height="' . (int) $size . '" style="z-index:' . (int) $z . '" alt="' . esc_attr( $user['display_name'] ) . '" />';
+	}
+
+	$html .= '</span>';
+
+	return $html;
+}

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Network Sites list: "Online" column.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds an "Online" column to the Network Admin Sites list table.
+ *
+ * @param array $columns Existing column headers.
+ * @return array Column headers with "Online" added.
+ */
+function wp_presence_register_network_sites_column( $columns ) {
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return $columns;
+	}
+
+	$columns['presence_online'] = __( 'Online', 'presence-api' );
+
+	return $columns;
+}
+
+/**
+ * Renders the "Online" column for a single row of the Sites list table.
+ *
+ * Rendered once per page load, the same as every other column on this table
+ * (e.g. "Last Updated"), rather than kept live via Heartbeat: the table isn't
+ * ours to own the markup or lifecycle of, and a snapshot as of page load
+ * matches how the rest of the table already behaves.
+ *
+ * Called once per row, and asks for that row's site only. The underlying
+ * snapshot is read once for the request; what each row adds is resolving the
+ * handful of people whose avatars it is about to draw.
+ *
+ * @param string $column_name Column being rendered.
+ * @param int    $blog_id     The site ID for the current row.
+ */
+function wp_presence_render_network_sites_column( $column_name, $blog_id ) {
+	if ( 'presence_online' !== $column_name ) {
+		return;
+	}
+
+	$summary = wp_presence_get_network_summary(
+		array(
+			'blog_id'        => (int) $blog_id,
+			'users_per_site' => WP_PRESENCE_NETWORK_AVATARS,
+		)
+	);
+
+	if ( ! $summary['sites'] ) {
+		echo '&#8212;';
+		return;
+	}
+
+	$site = $summary['sites'][0];
+
+	echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'], WP_PRESENCE_NETWORK_AVATARS ) );
+	echo ' ' . (int) $site['user_count'];
+}

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -660,45 +660,35 @@ JS,
 			echo '</ul>';
 
 			if ( ! empty( $overflow ) ) {
-				$stack_max = min( count( $overflow ), 4 );
+				$stack_max   = min( count( $overflow ), 4 );
+				$stack_users = array();
+
+				foreach ( array_slice( $overflow, 0, $stack_max ) as $oentry ) {
+					$ouser = get_userdata( $oentry->user_id );
+
+					if ( ! $ouser ) {
+						continue;
+					}
+
+					$stack_users[] = array(
+						'display_name' => $ouser->display_name,
+						'avatar_url'   => get_avatar_url( $ouser->ID, array( 'size' => 24 ) ),
+					);
+				}
 
 				if ( count( $overflow ) > self::get_overflow_threshold() ) {
 					// Summary mode: avatar stack + count linking to Users page.
 					echo '<a href="' . esc_url( admin_url( 'users.php?presence_status=online' ) ) . '" class="presence-overflow-toggle">';
-					echo '<span class="presence-avatar-stack">';
-
-					foreach ( array_slice( $overflow, 0, $stack_max ) as $index => $oentry ) {
-						$ouser = get_userdata( $oentry->user_id );
-
-						if ( ! $ouser ) {
-							continue;
-						}
-
-						$z = $stack_max - $index;
-						echo '<img src="' . esc_url( get_avatar_url( $ouser->ID, array( 'size' => 24 ) ) ) . '" width="24" height="24" style="z-index:' . (int) $z . '" alt="' . esc_attr( $ouser->display_name ) . '" />';
-					}
-
-					echo '</span><span class="presence-overflow-text">';
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4, 24 ) );
+					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more — view all users', 'presence-api' ), count( $overflow ) ) );
 					echo '</span></a>';
 				} else {
 					// Expandable list mode.
 					echo '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="false" aria-controls="presence-overflow-list">';
-					echo '<span class="presence-avatar-stack">';
-
-					foreach ( array_slice( $overflow, 0, $stack_max ) as $index => $oentry ) {
-						$ouser = get_userdata( $oentry->user_id );
-
-						if ( ! $ouser ) {
-							continue;
-						}
-
-						$z = $stack_max - $index;
-						echo '<img src="' . esc_url( get_avatar_url( $ouser->ID, array( 'size' => 24 ) ) ) . '" width="24" height="24" style="z-index:' . (int) $z . '" alt="' . esc_attr( $ouser->display_name ) . '" />';
-					}
-
-					echo '</span><span class="presence-overflow-text">';
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4, 24 ) );
+					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more', 'presence-api' ), count( $overflow ) ) );
 					echo '</span></button>';

--- a/presence-api.php
+++ b/presence-api.php
@@ -106,6 +106,7 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget
 
 if ( is_multisite() ) {
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-functions.php';
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-sites-list.php';
 }
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -353,6 +354,11 @@ add_action( 'wp_dashboard_setup', array( 'WP_Presence_Widget_Whos_Online', 'regi
 add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Whos_Online', 'heartbeat_received' ), 10, 3 );
 add_action( 'wp_dashboard_setup', array( 'WP_Presence_Widget_Active_Posts', 'register' ) );
 add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Active_Posts', 'heartbeat_received' ), 10, 3 );
+
+if ( is_multisite() ) {
+	add_filter( 'wpmu_blogs_columns', 'wp_presence_register_network_sites_column' );
+	add_action( 'manage_sites_custom_column', 'wp_presence_render_network_sites_column', 10, 2 );
+}
 
 if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG )
 	&& function_exists( 'wp_presence_heartbeat_widget_register' )

--- a/tests/class-wp-presence-network-unittestcase.php
+++ b/tests/class-wp-presence-network-unittestcase.php
@@ -136,6 +136,20 @@ abstract class WP_Presence_Network_UnitTestCase extends WP_Presence_UnitTestCase
 	}
 
 	/**
+	 * Grants the current test a network-capable user, so capability-gated
+	 * hooks (column registration, views, the query filter) actually run.
+	 *
+	 * @return int The admin's user ID.
+	 */
+	protected function become_network_admin() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $admin_id );
+		wp_set_current_user( $admin_id );
+
+		return $admin_id;
+	}
+
+	/**
 	 * Overwrites a site's pushed row in the network summary table directly,
 	 * for tests that need to control its content or age precisely rather
 	 * than going through a real presence write.

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -707,4 +707,58 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		wp_remove_presence( wp_presence_admin_room(), 'client-1' );
 		$this->assertSame( 1, $fired );
 	}
+
+	/**
+	 * The avatars overlap, so the first user has to paint on top of the ones
+	 * after them rather than under.
+	 *
+	 * @covers ::wp_presence_render_avatar_stack
+	 */
+	public function test_avatar_stack_paints_the_first_user_on_top() {
+		$html = wp_presence_render_avatar_stack(
+			array(
+				array(
+					'avatar_url'   => 'https://example.com/ana.png',
+					'display_name' => 'Ana & Co',
+				),
+				array(
+					'avatar_url'   => 'https://example.com/bo.png',
+					'display_name' => 'Bo',
+				),
+			)
+		);
+
+		$this->assertSame( 2, substr_count( $html, '<img ' ) );
+		$this->assertLessThan(
+			strpos( $html, 'z-index:1' ),
+			strpos( $html, 'z-index:2' ),
+			'The first avatar in the list needs the highest z-index.'
+		);
+		$this->assertStringContainsString( 'alt="Ana &amp; Co"', $html );
+		$this->assertStringContainsString( 'width="20" height="20"', $html );
+	}
+
+	/**
+	 * The stack stands in for a crowd rather than showing all of it, so a busy
+	 * room renders the same handful of avatars as a quiet one.
+	 *
+	 * @covers ::wp_presence_render_avatar_stack
+	 */
+	public function test_avatar_stack_stops_at_the_maximum() {
+		$users = array_fill(
+			0,
+			10,
+			array(
+				'avatar_url'   => 'https://example.com/ana.png',
+				'display_name' => 'Ana',
+			)
+		);
+
+		$this->assertSame( 4, substr_count( wp_presence_render_avatar_stack( $users ), '<img ' ) );
+
+		$sized = wp_presence_render_avatar_stack( $users, 2, 24 );
+
+		$this->assertSame( 2, substr_count( $sized, '<img ' ) );
+		$this->assertStringContainsString( 'width="24" height="24"', $sized );
+	}
 }

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for the "Online" column on the Network Admin Sites list.
+ *
+ * The column is drawn once per row on a table that can be paged fifty sites at
+ * a time, so it asks the read path for that row's site only. What it must not
+ * do is pull the network across to render one line of it.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_sites_column
+	 */
+	public function test_sites_column_requires_capability() {
+		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
+
+		$this->assertArrayNotHasKey( 'presence_online', $columns, 'A visitor with no capability should not see the column.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_sites_column
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_renders_avatar_stack_and_count() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
+		$this->assertArrayHasKey( 'presence_online', $columns );
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'presence-avatar-stack', $output );
+		$this->assertStringContainsString( '1', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		$output = ob_get_clean();
+
+		$this->assertSame( '&#8212;', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_ignores_other_columns() {
+		$this->become_network_admin();
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'blogname', 1 );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+}


### PR DESCRIPTION
Part of the network presence stack, merged bottom-up:

1. #332 summary table
2. #333 write path
3. #334 read path
4. **#335 Sites list column (this one)**
5. #336 Users list
6. #337 network dashboard widget

---

First surface on the read path in #334.

Part of #298

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5, Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>
