### PR TITLE
feat: add an Online view and column to the Network Users list

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -367,6 +367,74 @@ function wp_presence_network_capability() {
 }
 
 /**
+ * Returns the distinct user IDs online anywhere on the network.
+ *
+ * Reads the snapshot rather than the summary: the Users list column asks only
+ * whether a given row's user is in this set, so resolving a display name and
+ * an avatar URL for everyone online to answer that would be the whole cost of
+ * the read for none of its output.
+ *
+ * @access private
+ * @return int[] User IDs.
+ */
+function wp_presence_get_network_online_user_ids() {
+	$user_ids = array();
+
+	foreach ( wp_presence_get_network_snapshot()['sites'] as $site_user_ids ) {
+		foreach ( $site_user_ids as $user_id ) {
+			$user_ids[ $user_id ] = true;
+		}
+	}
+
+	return array_keys( $user_ids );
+}
+
+/**
+ * Returns the sites a given user is currently online on.
+ *
+ * The summary is keyed by site, and the Network Users list needs it keyed by
+ * user, so the inversion is built once for the request and shared by every row
+ * rather than rescanning the network per row.
+ *
+ * @access private
+ * @param int $user_id The user to look up.
+ * @return WP_Site[] Sites the user is online on, busiest site first.
+ */
+function wp_presence_get_network_sites_for_user( $user_id ) {
+	$by_user = wp_presence_network_cached(
+		'sites-by-user',
+		static function () {
+			$by_user = array();
+
+			foreach ( wp_presence_get_network_snapshot()['sites'] as $blog_id => $site_user_ids ) {
+				foreach ( $site_user_ids as $site_user_id ) {
+					$by_user[ $site_user_id ][] = $blog_id;
+				}
+			}
+
+			return $by_user;
+		}
+	);
+
+	$blog_ids = $by_user[ (int) $user_id ] ?? array();
+
+	if ( ! $blog_ids ) {
+		return array();
+	}
+
+	// Resolved here rather than in the index above, so a network where nobody
+	// is looked up pays for no sites at all. get_sites() primes the site cache,
+	// so rows sharing a site resolve it once.
+	return get_sites(
+		array(
+			'site__in' => $blog_ids,
+			'number'   => 0,
+			'orderby'  => 'site__in',
+		)
+	);
+}
+
+/**
  * Returns every site's online user IDs, without resolving any of them.
  *
  * One query against the shared wp_presence_network_summary table -- one row

--- a/includes/network-user-list.php
+++ b/includes/network-user-list.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Network Users list: "Online" view, filter, and column.
+ *
+ * Mirrors the single-site Users list "Online" view in includes/user-list.php,
+ * scoped to users online anywhere on the network rather than the current site.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds an "Online" view to the Network Users list table.
+ *
+ * @param array $views Existing views.
+ * @return array Modified views.
+ */
+function wp_presence_network_users_views( $views ) {
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return $views;
+	}
+
+	$online_count = count( wp_presence_get_network_online_user_ids() );
+	$is_current   = isset( $_GET['presence_status'] ) && 'online' === $_GET['presence_status']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+	$class = $is_current ? 'current' : '';
+	$url   = wp_nonce_url( network_admin_url( 'users.php?presence_status=online' ), 'presence_online_filter' );
+
+	$views['presence_online'] = sprintf(
+		'<a href="%s" class="%s">%s <span class="count">(%d)</span></a>',
+		esc_url( $url ),
+		$class,
+		esc_html__( 'Online', 'presence-api' ),
+		$online_count
+	);
+
+	if ( $is_current && isset( $views['all'] ) ) {
+		$views['all'] = str_replace( 'class="current"', '', $views['all'] );
+	}
+
+	return $views;
+}
+
+/**
+ * Restricts the Network Users list query to users online anywhere on the
+ * network, when the "Online" view is active.
+ *
+ * @param array $args Query args passed to WP_User_Query.
+ * @return array Modified query args.
+ */
+function wp_presence_filter_network_online_users( $args ) {
+	if ( ! is_network_admin() || ! current_user_can( wp_presence_network_capability() ) ) {
+		return $args;
+	}
+
+	if ( empty( $_GET['presence_status'] ) || 'online' !== $_GET['presence_status'] ) {
+		return $args;
+	}
+
+	if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'presence_online_filter' ) ) {
+		return $args;
+	}
+
+	$args['include'] = wp_presence_get_network_online_user_ids();
+
+	if ( ! $args['include'] ) {
+		// WP_User_Query treats an empty include as "no restriction", not "match
+		// nothing," so force a result set of zero rather than falling through
+		// to every network user.
+		$args['include'] = array( 0 );
+	}
+
+	return $args;
+}
+
+/**
+ * Adds an "Online" column to the Network Users list table.
+ *
+ * @param array $columns Existing column headers.
+ * @return array Column headers with "Online" added.
+ */
+function wp_presence_register_network_users_column( $columns ) {
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return $columns;
+	}
+
+	$columns['presence_online'] = __( 'Online', 'presence-api' );
+
+	return $columns;
+}
+
+/**
+ * Renders the "Online" column for a single row of the Network Users list table.
+ *
+ * Called once per row. The column names sites, not people, so it reads the
+ * user-to-site index rather than the summary: resolving a display name and an
+ * avatar URL for everyone online would be the whole cost of the read for
+ * output this column never uses.
+ *
+ * @param string $output      Existing column output.
+ * @param string $column_name Column being rendered.
+ * @param int    $user_id     The user ID for the current row.
+ * @return string Column output.
+ */
+function wp_presence_render_network_users_column( $output, $column_name, $user_id ) {
+	if ( 'presence_online' !== $column_name ) {
+		return $output;
+	}
+
+	$sites = wp_presence_get_network_sites_for_user( $user_id );
+
+	if ( ! $sites ) {
+		return '&#8212;';
+	}
+
+	$names = array();
+
+	foreach ( $sites as $site ) {
+		$names[] = $site->domain . $site->path;
+	}
+
+	return esc_html( implode( ', ', $names ) );
+}

--- a/includes/user-list.php
+++ b/includes/user-list.php
@@ -56,10 +56,15 @@ function wp_presence_users_views( $views ) {
 /**
  * Filters the users query to only include online users when presence_status=online.
  *
+ * Stands down in Network Admin. is_admin() is true there too, and the Network
+ * Users list runs its own WP_User_Query, so without this the network "Online"
+ * view would have its network-wide set of IDs replaced with the ones online on
+ * whichever site the request resolved to.
+ *
  * @param WP_User_Query $query The user query.
  */
 function wp_presence_filter_online_users( $query ) {
-	if ( ! is_admin() || ! current_user_can( 'edit_posts' ) ) {
+	if ( ! is_admin() || is_network_admin() || ! current_user_can( 'edit_posts' ) ) {
 		return;
 	}
 

--- a/presence-api.php
+++ b/presence-api.php
@@ -107,6 +107,7 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget
 if ( is_multisite() ) {
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-functions.php';
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-sites-list.php';
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-user-list.php';
 }
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -358,6 +359,11 @@ add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Active_Posts', 'hea
 if ( is_multisite() ) {
 	add_filter( 'wpmu_blogs_columns', 'wp_presence_register_network_sites_column' );
 	add_action( 'manage_sites_custom_column', 'wp_presence_render_network_sites_column', 10, 2 );
+
+	add_filter( 'views_users-network', 'wp_presence_network_users_views' );
+	add_filter( 'users_list_table_query_args', 'wp_presence_filter_network_online_users' );
+	add_filter( 'wpmu_users_columns', 'wp_presence_register_network_users_column' );
+	add_filter( 'manage_users-network_custom_column', 'wp_presence_render_network_users_column', 10, 3 );
 }
 
 if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG )

--- a/tests/test-network-users-list.php
+++ b/tests/test-network-users-list.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Tests for the "Online" view, query filter, and column on the Network Admin
+ * Users list.
+ *
+ * This screen asks a different question of the summary than the rest of the
+ * network UI does. It is keyed by user rather than by site, and the answer for
+ * one row has to hold for every other row on the page without rereading the
+ * network, so most of what is asserted here is that inversion.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Network_Users_List extends WP_Presence_Network_UnitTestCase {
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * One person signed in on two sites is one person online, which is the
+	 * distinction the network user list filters on.
+	 *
+	 * @covers ::wp_presence_get_network_online_user_ids
+	 */
+	public function test_online_user_ids_are_deduplicated_across_sites() {
+		$first  = $this->create_blog();
+		$second = $this->create_blog();
+		$other  = self::factory()->user->create();
+
+		$this->set_network_summary_row( $first, array( self::$editor_id ) );
+		$this->set_network_summary_row( $second, array( self::$editor_id, $other ) );
+
+		$ids = wp_presence_get_network_online_user_ids();
+		sort( $ids );
+
+		$expected = array( self::$editor_id, $other );
+		sort( $expected );
+
+		$this->assertSame( $expected, $ids );
+	}
+
+	/**
+	 * @covers ::wp_presence_network_users_views
+	 */
+	public function test_users_view_requires_capability() {
+		$views = wp_presence_network_users_views( array() );
+
+		$this->assertArrayNotHasKey( 'presence_online', $views );
+	}
+
+	/**
+	 * @covers ::wp_presence_network_users_views
+	 */
+	public function test_users_view_reports_the_network_wide_count() {
+		$this->become_network_admin();
+
+		$blog_ids = array( $this->create_blog(), $this->create_blog() );
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+		$this->set_presence_on_site( $blog_ids[1], self::$editor_id );
+
+		$views = wp_presence_network_users_views( array() );
+
+		$this->assertArrayHasKey( 'presence_online', $views );
+		// One distinct user online across both sites, not two.
+		$this->assertStringContainsString( '(1)', $views['presence_online'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_filter_network_online_users
+	 */
+	public function test_users_query_filter_requires_network_admin_context() {
+		$args = wp_presence_filter_network_online_users( array( 'number' => 10 ) );
+
+		$this->assertArrayNotHasKey( 'include', $args, 'Outside is_network_admin(), the query should be left alone.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_filter_network_online_users
+	 */
+	public function test_users_query_filter_restricts_to_online_users() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$_GET['presence_status'] = 'online';
+		$_GET['_wpnonce']        = wp_create_nonce( 'presence_online_filter' );
+
+		$args = wp_presence_filter_network_online_users( array( 'number' => 10 ) );
+
+		$this->assertSame( array( self::$editor_id ), $args['include'] );
+	}
+
+	/**
+	 * WP_User_Query treats an empty "include" as no restriction at all, which
+	 * would silently fall through to every network user instead of none.
+	 *
+	 * @covers ::wp_presence_filter_network_online_users
+	 */
+	public function test_users_query_filter_matches_nobody_when_nobody_is_online() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		$_GET['presence_status'] = 'online';
+		$_GET['_wpnonce']        = wp_create_nonce( 'presence_online_filter' );
+
+		$args = wp_presence_filter_network_online_users( array( 'number' => 10 ) );
+
+		$this->assertSame( array( 0 ), $args['include'] );
+	}
+
+	/**
+	 * The single-site filter runs on this screen too, since is_admin() is true
+	 * in Network Admin, and the list table's own WP_User_Query fires
+	 * pre_get_users after users_list_table_query_args has already set the
+	 * network-wide IDs. Asserted through a real query rather than the filter's
+	 * return value, because the collision only shows up downstream of it.
+	 *
+	 * @covers ::wp_presence_filter_network_online_users
+	 * @covers ::wp_presence_filter_online_users
+	 */
+	public function test_the_network_online_view_is_not_narrowed_to_the_current_site() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		// Online on another site, and deliberately not on the one this request
+		// resolved to.
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$_GET['presence_status'] = 'online';
+		$_GET['_wpnonce']        = wp_create_nonce( 'presence_online_filter' );
+
+		$args = wp_presence_filter_network_online_users(
+			array(
+				'number' => 10,
+				'fields' => 'ID',
+			)
+		);
+
+		$query = new WP_User_Query( $args );
+
+		$this->assertSame(
+			array( self::$editor_id ),
+			array_map( 'intval', $query->get_results() ),
+			'pre_get_users narrowed the network view to the current site.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_users_column
+	 * @covers ::wp_presence_get_network_sites_for_user
+	 */
+	public function test_users_column_lists_the_sites_a_user_is_online_on() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
+
+		$this->assertNotSame( '&#8212;', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_users_column
+	 * @covers ::wp_presence_get_network_sites_for_user
+	 */
+	public function test_users_column_shows_a_dash_for_an_offline_user() {
+		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
+
+		$this->assertSame( '&#8212;', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_users_column
+	 */
+	public function test_users_column_requires_capability() {
+		$columns = wp_presence_register_network_users_column( array( 'username' => 'Username' ) );
+
+		$this->assertArrayNotHasKey( 'presence_online', $columns );
+	}
+
+	/**
+	 * @covers ::wp_presence_register_network_users_column
+	 */
+	public function test_users_column_is_registered_for_a_network_admin() {
+		$this->become_network_admin();
+
+		$columns = wp_presence_register_network_users_column( array( 'username' => 'Username' ) );
+
+		$this->assertArrayHasKey( 'presence_online', $columns );
+	}
+}


### PR DESCRIPTION
Part of the network presence stack, merged bottom-up:

1. #332 summary table
2. #333 write path
3. #334 read path
4. #335 Sites list column
5. **#336 Users list (this one)**
6. #337 network dashboard widget

---

The summary is keyed by site and this screen is keyed by user.

Part of #298
Closes #322

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5, Claude Opus 5
Used for: Assisting with design, implementation, and testing

</details>
