### PR TITLE
fix: clear a user's presence when their account or site membership ends

### DIFF
--- a/includes/lifecycle.php
+++ b/includes/lifecycle.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lifecycle hooks: sets/removes presence on login and logout.
+ * Lifecycle hooks: sets/removes presence on login, logout, and user removal.
  *
  * @package Presence_API
  */
@@ -39,4 +39,18 @@ function wp_presence_on_logout( $user_id ) {
 	if ( $user_id && user_can( $user_id, 'edit_posts' ) ) {
 		wp_remove_user_presence( $user_id );
 	}
+}
+
+/**
+ * Removes a user's presence when their account is deleted or they are
+ * removed from a site.
+ *
+ * Hooked to 'deleted_user' and 'remove_user_from_blog', both of which fire
+ * with the site already switched to the one the user is leaving. No
+ * capability gate, unlike login/logout: their role may already be gone.
+ *
+ * @param int $user_id The ID of the user being deleted or removed.
+ */
+function wp_presence_on_user_removed( $user_id ) {
+	wp_remove_user_presence( $user_id );
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -332,6 +332,8 @@ add_action( 'edit_comment', 'wp_presence_on_edit_comment' );
 
 add_action( 'wp_login', 'wp_presence_on_login', 10, 2 );
 add_action( 'wp_logout', 'wp_presence_on_logout', 10, 1 );
+add_action( 'deleted_user', 'wp_presence_on_user_removed', 10, 1 );
+add_action( 'remove_user_from_blog', 'wp_presence_on_user_removed', 10, 1 );
 
 add_action( 'admin_bar_menu', 'wp_presence_admin_bar_node', 80 );
 add_action( 'admin_enqueue_scripts', 'wp_presence_admin_bar_assets' );

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -85,4 +85,39 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 		$this->assertCount( 0, $this->presence_for_user( self::$editor_id ) );
 		$this->assertCount( 1, $this->presence_for_user( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
+
+	/**
+	 * @covers ::wp_presence_on_user_removed
+	 */
+	public function test_deleted_user_clears_presence() {
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'user-' . $temp_user_id, array(), $temp_user_id );
+		wp_set_presence( 'postType/post:1', 'lock-' . $temp_user_id, array(), $temp_user_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
+
+		wp_delete_user( $temp_user_id );
+
+		$this->assertCount( 0, $this->presence_for_user( $temp_user_id ), 'Deleting a user should clear their presence rows.' );
+		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
+	}
+
+	/**
+	 * Isolates remove_user_from_blog() from deleted_user.
+	 *
+	 * @covers ::wp_presence_on_user_removed
+	 */
+	public function test_remove_user_from_blog_clears_presence_on_that_site_only() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'user-' . $temp_user_id, array(), $temp_user_id );
+
+		remove_user_from_blog( $temp_user_id, get_current_blog_id() );
+
+		$this->assertCount( 0, $this->presence_for_user( $temp_user_id ), 'Removing a user from a site should clear their presence there.' );
+	}
 }

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -368,6 +368,45 @@ class WP_Test_Network_Presence extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * A network-wide deletion should clear -- and re-push -- presence on
+	 * every site the user was online on.
+	 *
+	 * @covers ::wp_presence_on_user_removed
+	 * @covers ::wp_presence_push_network_summary
+	 */
+	public function test_deleting_a_user_clears_their_presence_on_every_site() {
+		require_once ABSPATH . 'wp-admin/includes/ms.php';
+
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$blog_ids = array( $this->create_blog(), $this->create_blog() );
+
+		foreach ( $blog_ids as $blog_id ) {
+			add_user_to_blog( $blog_id, $user_id, 'editor' );
+			$this->set_presence_on_site( $blog_id, $user_id );
+		}
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+
+		wpmu_delete_user( $user_id );
+
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+			$this->assertCount( 0, $this->presence_for_user( $user_id ), "Presence should be cleared on blog {$blog_id}." );
+			restore_current_blog();
+
+			$row = $this->get_network_summary_row( $blog_id );
+			$this->assertNotContains(
+				$user_id,
+				json_decode( $row->data, true )['online_user_ids'],
+				"The network summary row for blog {$blog_id} should no longer list the deleted user."
+			);
+		}
+
+		switch_to_blog( $blog_ids[0] );
+		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
+		restore_current_blog();
+	}
+
+	/**
 	 * A tick that finds the same people online as the last one must not rewrite
 	 * the row. Presence writes happen on every tick from every open tab, so a
 	 * push that always wrote would put one row update per tab per tick on a

--- a/tests/test-post-list.php
+++ b/tests/test-post-list.php
@@ -124,6 +124,9 @@ class WP_Test_Presence_Post_List extends WP_Presence_UnitTestCase {
 			wp_delete_user( $deleted_id );
 		}
 
+		// Deletion now clears this row; re-write it to test the fallback rendering.
+		wp_set_presence( wp_presence_post_room( $post_deleted ), 'lock-3', array(), $deleted_id );
+
 		$this->assertSame( '', $this->render_column( $post_none ) );
 
 		$one_output = $this->render_column( $post_one );

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -499,6 +499,9 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 			wp_delete_user( $temp_user_id );
 		}
 
+		// Deletion now clears this row; re-write it to test the fallback fields.
+		wp_set_presence( 'admin/online', 'client-temp', array(), $temp_user_id );
+
 		$request = new WP_REST_Request( 'GET', '/wp-presence/v1/presence' );
 		$request->set_param( 'room', 'admin/online' );
 


### PR DESCRIPTION
### Description

Fixes #327

Hooks `deleted_user` and `remove_user_from_blog` to clear a user's presence immediately instead of leaving rows to age out on TTL. Re-pushing the network summary falls out for free — `wp_remove_user_presence()` already fires the change signal the push is wired to.

### Testing
- Added unit tests for both hooks in isolation, plus an integration test covering `wpmu_delete_user()` clearing presence across every site a user belonged to.
- Updated two existing tests (post list, REST controller) that had relied on a deleted user's row surviving deletion to exercise their own fallback-rendering paths.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation and tests