### PR TITLE
ci: run CI and CodeQL on pull requests that do not target main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [ main ]
+  # Unfiltered on purpose. A pull request in a stack is based on its parent
+  # branch rather than main, and `branches: [ main ]` skips it entirely, so
+  # every pull request below the top of a stack would merge unverified.
   pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,8 @@ name: CodeQL
 on:
   push:
     branches: [ main ]
+  # Unfiltered on purpose, see ci.yml.
   pull_request:
-    branches: [ main ]
   schedule:
     - cron: '0 6 * * 1'
 


### PR DESCRIPTION
`ci.yml` and `codeql.yml` filter `pull_request` to `branches: [ main ]`, so a pull request based on anything else runs neither. On the network presence stack that is #333 through #337: 4 checks each, against 17 on #332.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with diagnosis and the fix

</details>
