### PR TITLE
fix: clear a user's presence when their account or site membership ends

### DIFF
--- a/includes/lifecycle.php
+++ b/includes/lifecycle.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Lifecycle hooks: sets/removes presence on login and logout.
+ * Lifecycle hooks: sets/removes presence on login, logout, and user removal.
  *
  * @package Presence_API
  */
@@ -39,4 +39,18 @@ function wp_presence_on_logout( $user_id ) {
 	if ( $user_id && user_can( $user_id, 'edit_posts' ) ) {
 		wp_remove_user_presence( $user_id );
 	}
+}
+
+/**
+ * Removes a user's presence when their account is deleted or they are
+ * removed from a site.
+ *
+ * Hooked to 'deleted_user' and 'remove_user_from_blog', both of which fire
+ * with the site already switched to the one the user is leaving. No
+ * capability gate, unlike login/logout: their role may already be gone.
+ *
+ * @param int $user_id The ID of the user being deleted or removed.
+ */
+function wp_presence_on_user_removed( $user_id ) {
+	wp_remove_user_presence( $user_id );
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -319,6 +319,8 @@ add_action( 'edit_comment', 'wp_presence_on_edit_comment' );
 
 add_action( 'wp_login', 'wp_presence_on_login', 10, 2 );
 add_action( 'wp_logout', 'wp_presence_on_logout', 10, 1 );
+add_action( 'deleted_user', 'wp_presence_on_user_removed', 10, 1 );
+add_action( 'remove_user_from_blog', 'wp_presence_on_user_removed', 10, 1 );
 
 add_action( 'admin_bar_menu', 'wp_presence_admin_bar_node', 80 );
 add_action( 'admin_enqueue_scripts', 'wp_presence_admin_bar_assets' );

--- a/tests/test-lifecycle.php
+++ b/tests/test-lifecycle.php
@@ -85,4 +85,39 @@ class WP_Test_Presence_Lifecycle extends WP_Presence_UnitTestCase {
 		$this->assertCount( 0, $this->presence_for_user( self::$editor_id ) );
 		$this->assertCount( 1, $this->presence_for_user( self::$subscriber_id ), 'Logging one user out should not clear anybody else.' );
 	}
+
+	/**
+	 * @covers ::wp_presence_on_user_removed
+	 */
+	public function test_deleted_user_clears_presence() {
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'user-' . $temp_user_id, array(), $temp_user_id );
+		wp_set_presence( 'postType/post:1', 'lock-' . $temp_user_id, array(), $temp_user_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array(), self::$editor_id );
+
+		wp_delete_user( $temp_user_id );
+
+		$this->assertCount( 0, $this->presence_for_user( $temp_user_id ), 'Deleting a user should clear their presence rows.' );
+		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
+	}
+
+	/**
+	 * Isolates remove_user_from_blog() from deleted_user.
+	 *
+	 * @covers ::wp_presence_on_user_removed
+	 */
+	public function test_remove_user_from_blog_clears_presence_on_that_site_only() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_presence( 'admin/online', 'user-' . $temp_user_id, array(), $temp_user_id );
+
+		remove_user_from_blog( $temp_user_id, get_current_blog_id() );
+
+		$this->assertCount( 0, $this->presence_for_user( $temp_user_id ), 'Removing a user from a site should clear their presence there.' );
+	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -208,4 +208,43 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 		$this->assertSame( array( self::$editor_id ), $decoded['online_user_ids'] );
 		$this->assertStringContainsString( "\n", $data, 'Stored pretty-printed to stay readable.' );
 	}
+
+	/**
+	 * A network-wide deletion should clear, and re-push, presence on every
+	 * site the user was online on.
+	 *
+	 * @covers ::wp_presence_on_user_removed
+	 * @covers ::wp_presence_push_network_summary
+	 */
+	public function test_deleting_a_user_clears_their_presence_on_every_site() {
+		require_once ABSPATH . 'wp-admin/includes/ms.php';
+
+		$user_id  = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$blog_ids = array( $this->create_blog(), $this->create_blog() );
+
+		foreach ( $blog_ids as $blog_id ) {
+			add_user_to_blog( $blog_id, $user_id, 'editor' );
+			$this->set_presence_on_site( $blog_id, $user_id );
+		}
+		$this->set_presence_on_site( $blog_ids[0], self::$editor_id );
+
+		wpmu_delete_user( $user_id );
+
+		foreach ( $blog_ids as $blog_id ) {
+			switch_to_blog( $blog_id );
+			$this->assertCount( 0, $this->presence_for_user( $user_id ), "Presence should be cleared on blog {$blog_id}." );
+			restore_current_blog();
+
+			$row = $this->get_network_summary_row( $blog_id );
+			$this->assertNotContains(
+				$user_id,
+				json_decode( $row->data, true )['online_user_ids'],
+				"The network summary row for blog {$blog_id} should no longer list the deleted user."
+			);
+		}
+
+		switch_to_blog( $blog_ids[0] );
+		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
+		restore_current_blog();
+	}
 }

--- a/tests/test-post-list.php
+++ b/tests/test-post-list.php
@@ -124,6 +124,9 @@ class WP_Test_Presence_Post_List extends WP_Presence_UnitTestCase {
 			wp_delete_user( $deleted_id );
 		}
 
+		// Deletion now clears this row; re-write it to test the fallback rendering.
+		wp_set_presence( wp_presence_post_room( $post_deleted ), 'lock-3', array(), $deleted_id );
+
 		$this->assertSame( '', $this->render_column( $post_none ) );
 
 		$one_output = $this->render_column( $post_one );

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -499,6 +499,9 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 			wp_delete_user( $temp_user_id );
 		}
 
+		// Deletion now clears this row; re-write it to test the fallback fields.
+		wp_set_presence( 'admin/online', 'client-temp', array(), $temp_user_id );
+
 		$request = new WP_REST_Request( 'GET', '/wp-presence/v1/presence' );
 		$request->set_param( 'room', 'admin/online' );
 


### PR DESCRIPTION
Based on #333, off to the side of the network presence stack rather than in the line of it:

1. #332 summary table
2. #333 write path
   - **#342 user and site cleanup (this one)**
3. #334 read path
4. #335 Sites list column
5. #336 Users list
6. #337 network dashboard widget

Merges any time after #333, independent of #334 and above.

---

@i-am-chitti wrote this in #339, which merged into `feature/network-presence-screen` after that branch was closed along with #313, so the commits are cherry-picked here with authorship intact. The only change is that the network test moved from `tests/test-network-presence.php` to `tests/test-network-summary-push.php`, since the restructure split that file into four.

Fixes #327

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with rebasing and testing

</details>
