### PR TITLE
fix: register the presence table name idempotently

### DIFF
--- a/presence-api.php
+++ b/presence-api.php
@@ -65,7 +65,11 @@ if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
 function wp_presence_register_table() {
 	global $wpdb;
 	$wpdb->presence = $wpdb->prefix . 'presence';
-	$wpdb->tables[] = 'presence';
+
+	// Runs at require time and again on init, so the append has to be idempotent.
+	if ( ! in_array( 'presence', $wpdb->tables, true ) ) {
+		$wpdb->tables[] = 'presence';
+	}
 }
 wp_presence_register_table();
 

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -536,4 +536,31 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		$this->assertTrue( $controller->delete_item_permissions_check( $request ) );
 		$this->assertSame( '', $wpdb->last_error, 'The ownership lookup should not have run.' );
 	}
+	/**
+	 * The function runs twice on a request, at require time and again on init,
+	 * so an unguarded append leaves core holding the same table name twice.
+	 * wpdb::tables() rekeys by name and hides that, but callers reading
+	 * $wpdb->tables directly, or passing $prefix false, see both.
+	 *
+	 * @covers ::wp_presence_register_table
+	 */
+	public function test_registering_the_presence_table_is_idempotent() {
+		global $wpdb;
+
+		$tables = $wpdb->tables;
+
+		// Start from an array that has never seen the entry, since the real
+		// double registration at load time has already added it.
+		$wpdb->tables = array_values( array_diff( $wpdb->tables, array( 'presence' ) ) );
+
+		wp_presence_register_table();
+		wp_presence_register_table();
+
+		$count = count( array_keys( $wpdb->tables, 'presence', true ) );
+
+		// $wpdb outlives the test.
+		$wpdb->tables = $tables;
+
+		$this->assertSame( 1, $count, 'Registering twice should leave one entry in $wpdb->tables.' );
+	}
 }


### PR DESCRIPTION
`wp_presence_register_table()` appends to `$wpdb->tables` with no guard and runs twice, at require time and again on `init` priority 0, so `presence` is in the array twice on every install. Measured on a running site: 2 before, 1 after.

Most of core never notices. `wpdb::tables()` rekeys each entry by table name when `$prefix` is true, which is the default, so duplicates collapse. The only core caller passing `false` is `update.php:131`, and it breaks on the first match. What does see it is code reading `$wpdb->tables` directly or calling `tables( 'blog', false )`, which backup and migration plugins do.

Guarding the append rather than dropping one of the two call sites: both date to 9c55888 with no recorded reason for the pair, so removing one would be a load-order guess, and making the function idempotent fixes the class rather than one instance.

This is the per-site half of #330. The network half is the same unguarded append in `wp_presence_register_network_summary_table()`, which exists only in #332, so landing it here would force a rebase of the stack above it. Left out deliberately: once this is on `main`, #332 picks it up on its next rebase and needs only the equivalent one-line guard. Say if you would rather have both in one PR against `feature/network-summary-table` and I will move it.

Related: #330

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the duplicate and drafting the guard and its test; I verified the behaviour on a running multisite install and reviewed the change.

</details>
