### PR TITLE
chore: bump the minor version for features while pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
 	"include-component-in-tag": false,
 	"include-v-in-tag": true,
 	"bump-minor-pre-major": true,
-	"bump-patch-for-minor-pre-major": true,
 	"changelog-sections": [
 		{ "type": "feat",     "section": "Features" },
 		{ "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
The stack in #298 is six `feat:` pull requests, and `bump-patch-for-minor-pre-major` would land all of it as 0.1.26.

Removing it leaves `feat:` on a minor bump, which is what `.github/CONTRIBUTING.md` already documents. `bump-minor-pre-major` stays, so a breaking change is still a minor while under 1.0. Pending release #346 is two `fix:` commits and is unaffected.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the release configuration

</details>