### PR TITLE
fix: carry each site's own scheme in the network summary row

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -284,12 +284,17 @@ function wp_presence_record_network_summary_push( array $user_ids ) {
  *
  *     {
  *         "site": "example.com/shop/",
+ *         "scheme": "https",
  *         "online_user_ids": [ 3, 7 ]
  *     }
  *
  * The site label is for that reader; the read path resolves the site from
  * blog_id and ignores it. Logins are left out because resolving them would
  * cost a user query per heartbeat tick.
+ *
+ * The scheme is recorded here because is_ssl() only describes this site's own
+ * request right now; a later read runs in a different request, on whichever
+ * scheme that one happens to be on.
  *
  * @access private
  * @param int   $blog_id  The site the row belongs to.
@@ -302,6 +307,7 @@ function wp_presence_encode_network_summary_row( $blog_id, array $user_ids ) {
 	return (string) wp_json_encode(
 		array(
 			'site'            => $site ? $site->domain . $site->path : '',
+			'scheme'          => is_ssl() ? 'https' : 'http',
 			'online_user_ids' => $user_ids,
 		),
 		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
@@ -323,6 +329,23 @@ function wp_presence_decode_network_summary_row( $data ) {
 	}
 
 	return array_map( 'intval', array_filter( $decoded['online_user_ids'], 'is_numeric' ) );
+}
+
+/**
+ * Decodes a summary row's data column into the scheme it was pushed under.
+ *
+ * See wp_presence_encode_network_summary_row() for why this is captured at
+ * push time rather than read live off the viewing request.
+ *
+ * @access private
+ * @param string $data The row's JSON-encoded data column.
+ * @return string 'http' or 'https'. Defaults to 'https' for a row pushed
+ *                before this field existed, or one that does not decode.
+ */
+function wp_presence_decode_network_summary_scheme( $data ) {
+	$decoded = json_decode( $data, true );
+
+	return isset( $decoded['scheme'] ) && 'http' === $decoded['scheme'] ? 'http' : 'https';
 }
 
 /**
@@ -461,6 +484,10 @@ function wp_presence_get_network_sites_for_user( $user_id ) {
  *                                       first, then by blog_id. Each list is in
  *                                       the order the site pushed it, which is
  *                                       ascending user ID.
+ *     @type array $schemes             'http' or 'https' keyed by blog_id, as
+ *                                       pushed from that site's own request.
+ *                                       Absent when the summary is empty. Read
+ *                                       only by wp_presence_hydrate_network_snapshot().
  *     @type int   $total_sites_online
  *     @type int   $total_users_online  Summed per site, so a user online on two
  *                                       sites counts twice.
@@ -695,12 +722,15 @@ function wp_presence_compute_network_snapshot( $timeout ) {
 	}
 
 	$by_site = array();
+	$schemes = array();
 
 	foreach ( $rows as $row ) {
 		$entries = wp_presence_decode_network_summary_row( $row->data );
 
 		if ( $entries ) {
-			$by_site[ (int) $row->blog_id ] = $entries;
+			$blog_id             = (int) $row->blog_id;
+			$by_site[ $blog_id ] = $entries;
+			$schemes[ $blog_id ] = wp_presence_decode_network_summary_scheme( $row->data );
 		}
 	}
 
@@ -751,6 +781,7 @@ function wp_presence_compute_network_snapshot( $timeout ) {
 
 	return array(
 		'sites'              => $by_site,
+		'schemes'            => array_intersect_key( $schemes, $by_site ),
 		'total_sites_online' => count( $by_site ),
 		'total_users_online' => $total_users,
 	);
@@ -768,6 +799,8 @@ function wp_presence_compute_network_snapshot( $timeout ) {
  */
 function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $users_per_site, $blog_id ) {
 	$by_site = $snapshot['sites'];
+	// Absent from the empty shape wp_presence_empty_network_summary() returns.
+	$schemes = $snapshot['schemes'] ?? array();
 
 	if ( $blog_id ) {
 		$by_site = isset( $by_site[ $blog_id ] ) ? array( $blog_id => $by_site[ $blog_id ] ) : array();
@@ -859,7 +892,8 @@ function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $use
 			'path'       => $site->path,
 			// get_site_url()/get_blog_option() switch blogs on every call; the raw
 			// WP_Site fields don't, at the cost of not reflecting a mapped domain.
-			'url'        => ( is_ssl() ? 'https://' : 'http://' ) . $site->domain . $site->path,
+			// Scheme comes from $schemes, not is_ssl(), for the same reason.
+			'url'        => ( ( $schemes[ $site_id ] ?? 'https' ) === 'http' ? 'http://' : 'https://' ) . $site->domain . $site->path,
 			'users'      => $hydrated,
 			// The site's real total, which users is capped below.
 			'user_count' => count( $by_site[ $site_id ] ),

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -53,6 +53,38 @@ class WP_Test_Network_Presence extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * A site's link must carry the scheme it was pushed under, not whichever
+	 * scheme the viewing request happens to be on.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_encode_network_summary_row
+	 * @covers ::wp_presence_decode_network_summary_scheme
+	 * @covers ::wp_presence_hydrate_network_snapshot
+	 */
+	public function test_site_url_uses_the_scheme_the_site_pushed_under() {
+		$https_blog_id = $this->create_blog();
+		$http_blog_id  = $this->create_blog();
+
+		$_SERVER['HTTPS'] = 'on';
+		$this->set_presence_on_site( $https_blog_id, self::$editor_id );
+
+		unset( $_SERVER['HTTPS'] );
+		$this->set_presence_on_site( $http_blog_id, self::$editor_id );
+
+		// Viewer is on http, same as $http_blog_id's own push -- only
+		// $https_blog_id's link can tell the fix apart from the bug.
+		$summary = wp_presence_get_network_summary();
+
+		$urls = array();
+		foreach ( $summary['sites'] as $site ) {
+			$urls[ $site['blog_id'] ] = $site['url'];
+		}
+
+		$this->assertStringStartsWith( 'https://', $urls[ $https_blog_id ] );
+		$this->assertStringStartsWith( 'http://', $urls[ $http_blog_id ] );
+	}
+
+	/**
 	 * A site that hasn't pushed a row (never had any admin activity yet) has
 	 * to be silently absent from the result rather than fatal the whole
 	 * aggregation.


### PR DESCRIPTION
## Description

Fixes #328

`wp_presence_encode_network_summary_row()` now records `is_ssl()` at push time — the one request that can answer for a site's own scheme — and `wp_presence_hydrate_network_snapshot()` builds each site's `url` from that instead of the viewing request's `is_ssl()`.

Rows pushed before this change have no `scheme`; `wp_presence_decode_network_summary_scheme()` defaults those to `'https'`, and the existing refresh interval rewrites every row within one TTL.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with implementation and testing

</details>