### PR TITLE
perf: gate network presence aggregation on wp_is_large_network()

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -70,6 +70,39 @@ function wp_presence_has_network_summary_table() {
 }
 
 /**
+ * Whether this network aggregates presence into the summary table.
+ *
+ * An ms_global_tables entry pins the summary table to the global cluster on a
+ * sharded network, so write concentration grows with the site count however
+ * rarely any single site pushes. Defaults off above wp_is_large_network()
+ * rather than having a network inherit that cost from installing the plugin.
+ *
+ * The read path checks this too, or a network that stopped aggregating would go
+ * on drawing the rows it already had with nothing to say the feed had stopped.
+ *
+ * @access private
+ * @return bool
+ */
+function wp_presence_network_aggregation_enabled() {
+	// Load-bearing rather than redundant: wp_is_large_network() is undefined
+	// outside multisite, and callers here do not check first.
+	if ( ! is_multisite() ) {
+		return false;
+	}
+
+	/**
+	 * Filters whether network-wide presence aggregation runs.
+	 *
+	 * Gates the push and the reads behind the Network Admin screens.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @param bool $enabled Default false above wp_is_large_network().
+	 */
+	return (bool) apply_filters( 'wp_presence_network_aggregation_enabled', ! wp_is_large_network() );
+}
+
+/**
  * Creates or updates the network-wide presence summary table if needed.
  *
  * One table for the whole network rather than one per site, since it exists
@@ -174,7 +207,7 @@ function wp_presence_network_summary_refresh_interval() {
  * @access private
  */
 function wp_presence_push_network_summary() {
-	if ( ! is_multisite() || ! wp_presence_has_network_summary_table() ) {
+	if ( ! wp_presence_network_aggregation_enabled() || ! wp_presence_has_network_summary_table() ) {
 		return;
 	}
 

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -702,6 +702,9 @@ function wp_presence_filter_network_snapshot_users( array $by_site ) {
  * Sites and users are checked against the network here, while the result is
  * still a list of IDs, so a stale row is dropped before anything gets loaded.
  *
+ * A network that does not aggregate reads as empty rather than as whatever its
+ * rows last said, since nothing is keeping them current.
+ *
  * @access private
  * @param int $timeout TTL in seconds; rows untouched longer than this are skipped.
  * @return array See wp_presence_get_network_snapshot().
@@ -709,7 +712,7 @@ function wp_presence_filter_network_snapshot_users( array $by_site ) {
 function wp_presence_compute_network_snapshot( $timeout ) {
 	global $wpdb;
 
-	if ( ! wp_presence_has_network_summary_table() ) {
+	if ( ! wp_presence_network_aggregation_enabled() || ! wp_presence_has_network_summary_table() ) {
 		return wp_presence_empty_network_summary();
 	}
 

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -172,6 +172,50 @@ class WP_Test_Network_Presence extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * Rows outlive the push that wrote them, so a network that stopped
+	 * aggregating would keep serving a snapshot frozen at whatever the last push
+	 * left, with nothing on the screen to say the feed behind it had stopped.
+	 * Reading empty is the only honest answer once nothing is keeping it current.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_network_aggregation_enabled
+	 */
+	public function test_summary_is_empty_on_a_large_network() {
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		add_filter( 'wp_is_large_network', '__return_true' );
+		wp_presence_flush_network_summary_cache();
+
+		$this->assertSame( wp_presence_empty_network_summary(), wp_presence_get_network_summary() );
+		$this->assertSame( array(), wp_presence_get_network_online_user_ids() );
+		$this->assertSame( array(), wp_presence_get_network_sites_for_user( self::$editor_id ) );
+	}
+
+	/**
+	 * Every read funnels through one snapshot, so the gate has to be answerable
+	 * without a query even when rows are sitting there to be read.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_network_aggregation_enabled
+	 */
+	public function test_a_gated_read_sends_no_statement() {
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$statements = $this->count_summary_table_statements(
+			static function () {
+				wp_presence_get_network_summary();
+			}
+		);
+
+		$this->assertSame( 0, $statements );
+	}
+
+	/**
 	 * Deleting a site leaves its row behind until it ages out, so the row can
 	 * outlive the site it names.
 	 *

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -191,6 +191,70 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * The coalescing above bounds how often one site rewrites its row, not how
+	 * many sites write into the one table a shard router cannot split.
+	 *
+	 * Asserted as a statement count rather than an absent row: declining after a
+	 * SELECT against the global cluster still costs what the gate exists to avoid.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_aggregation_enabled
+	 */
+	public function test_push_sends_no_statement_on_a_large_network() {
+		add_filter( 'wp_is_large_network', '__return_true' );
+
+		$blog_id = $this->create_blog();
+
+		$statements = $this->count_summary_table_statements(
+			function () use ( $blog_id ) {
+				$this->set_presence_on_site( $blog_id, self::$editor_id );
+			}
+		);
+
+		$this->assertSame( 0, $statements, 'A large network should not touch the summary table at all.' );
+		$this->assertNull( $this->get_network_summary_row( $blog_id ) );
+	}
+
+	/**
+	 * The gate is a default, not a verdict: a large network sized to carry the
+	 * writes has to be able to say so, which the clamped
+	 * wp_presence_network_summary_refresh_interval() cannot express.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_aggregation_enabled
+	 */
+	public function test_filter_can_aggregate_on_a_large_network() {
+		add_filter( 'wp_is_large_network', '__return_true' );
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_true' );
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$row = $this->get_network_summary_row( $blog_id );
+
+		$this->assertNotNull( $row );
+		$this->assertSame( array( self::$editor_id ), wp_presence_decode_network_summary_row( $row->data ) );
+	}
+
+	/**
+	 * And the other way, for a network under the threshold that still does not
+	 * want the writes.
+	 *
+	 * @covers ::wp_presence_push_network_summary
+	 * @covers ::wp_presence_network_aggregation_enabled
+	 */
+	public function test_filter_can_stop_aggregating_below_the_threshold() {
+		$this->assertTrue( wp_presence_network_aggregation_enabled(), 'The test network is not large.' );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		$this->assertNull( $this->get_network_summary_row( $blog_id ) );
+	}
+
+	/**
 	 * The data column is read by people with a database client open, so it
 	 * names what it holds rather than storing a bare list of numbers.
 	 *


### PR DESCRIPTION
### Description

Closes #348

Adds `wp_presence_network_aggregation_enabled()`, defaulting to `! wp_is_large_network()` and filterable both ways. Checked on the push and on the read - a network that stopped aggregating but kept serving its existing rows would draw a snapshot frozen at the last push, with nothing to say the feed had stopped. The read gate sits in `wp_presence_compute_network_snapshot()`, the chokepoint every reader funnels through.

Left open deliberately: a gated network reads as empty, so the screens say nobody is online rather than saying aggregation is off. Happy to add a distinct state if you want one.

### Testing

Both gates are asserted as statement counts, not just absent rows: declining after a `SELECT` against the global cluster still costs what the gate exists to avoid.

Verified on a 3-site network with `wp_is_large_network` forced true. The widget shows its empty state, the Sites column shows `—`, and the Users view shows `Online (0)`.

### Screenshots

<img width="526" height="187" alt="dashboard-on" src="https://github.com/user-attachments/assets/e226617d-f2d2-42fd-9be8-6c672dfccdc5" />

<img width="526" height="103" alt="dashboard-off" src="https://github.com/user-attachments/assets/48e15e02-8f61-41b3-829d-a5dce993139f" />

<img width="1076" height="224" alt="sites-on" src="https://github.com/user-attachments/assets/27d23264-64b2-459a-9b49-e68a283f0727" />

<img width="1076" height="224" alt="sites-off" src="https://github.com/user-attachments/assets/55330f3c-daa9-413f-a937-7f21950ca787" />

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the implementation and tests

</details>