### PR TITLE
fix: register the network summary table name idempotently

### DIFF
--- a/presence-api.php
+++ b/presence-api.php
@@ -87,7 +87,10 @@ function wp_presence_register_network_summary_table() {
 	}
 	global $wpdb;
 	$wpdb->presence_network_summary = $wpdb->base_prefix . 'presence_network_summary';
-	$wpdb->ms_global_tables[]       = 'presence_network_summary';
+
+	if ( ! in_array( 'presence_network_summary', $wpdb->ms_global_tables, true ) ) {
+		$wpdb->ms_global_tables[] = 'presence_network_summary';
+	}
 }
 wp_presence_register_network_summary_table();
 

--- a/tests/test-table-creation.php
+++ b/tests/test-table-creation.php
@@ -584,8 +584,7 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 		$registered = $wpdb->presence_network_summary ?? null;
 		$is_global  = in_array( 'presence_network_summary', $wpdb->ms_global_tables, true );
 
-		// $wpdb outlives the test, and re-registering appended a second
-		// ms_global_tables entry, so put both back before asserting.
+		// $wpdb outlives the test, so put the array back before asserting.
 		$wpdb->ms_global_tables = $global_tables;
 
 		if ( ! is_multisite() ) {
@@ -595,5 +594,31 @@ class WP_Test_Presence_Table_Creation extends WP_Presence_UnitTestCase {
 
 		$this->assertSame( $wpdb->base_prefix . 'presence_network_summary', $registered );
 		$this->assertTrue( $is_global, 'Core only treats a table as network-wide if it is an ms_global_table.' );
+	}
+	/**
+	 * @covers ::wp_presence_register_network_summary_table
+	 */
+	public function test_registering_the_network_summary_table_is_idempotent() {
+		global $wpdb;
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$global_tables = $wpdb->ms_global_tables;
+
+		// Start from an array that has never seen the entry, since the real
+		// double registration at load time has already added it.
+		$wpdb->ms_global_tables = array_values( array_diff( $wpdb->ms_global_tables, array( 'presence_network_summary' ) ) );
+
+		wp_presence_register_network_summary_table();
+		wp_presence_register_network_summary_table();
+
+		$count = count( array_keys( $wpdb->ms_global_tables, 'presence_network_summary', true ) );
+
+		// $wpdb outlives the test.
+		$wpdb->ms_global_tables = $global_tables;
+
+		$this->assertSame( 1, $count, 'Registering twice should leave one entry in $wpdb->ms_global_tables.' );
 	}
 }


### PR DESCRIPTION
The second half of #330, now that the network stack has landed on `main` and this no longer means rebasing a stack.

`wp_presence_register_network_summary_table()` appends to `$wpdb->ms_global_tables` with no guard and runs twice, at require time and again on `init` priority 0, so `presence_network_summary` is in the array twice on every multisite request. Measured on a running network: 2 before, 1 after.

Same shape as #345, and the same reasoning for guarding the append rather than removing one of the two call sites: both date to the original registration with no recorded reason for the pair, so dropping one would be a load-order guess.

Core mostly hides it. `wpdb::tables()` rekeys by name when `$prefix` is true, so duplicates collapse, and `set_blog_id()` never reads `ms_global_tables` at all since it iterates the `blog` and `old` scopes. What sees the duplicate is `tables( 'ms_global', false )` and code reading `$wpdb->ms_global_tables` directly.

This also drops a line from `test_network_summary_table_is_registered_only_on_a_network()` that described the old behaviour, where re-registering "appended a second ms_global_tables entry". That stops being true here. The array restore itself stays, since `$wpdb` still outlives the test.

Fixes #330

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the guard and its test; I verified the behaviour on a running multisite network and reviewed the change.

</details>
