### PR TITLE
ci: flag pull requests that add a public extension point

### DIFF
--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -1,0 +1,179 @@
+'use strict';
+
+// A hook, route, guarded constant, CLI command, or browser global is a promise:
+// once a site depends on one, renaming it breaks that site. This flags the pull
+// request that adds one and names the README section still missing it.
+//
+// It compares the full set of surfaces at each end rather than diff lines, so
+// moving, reindenting, or renaming the function around a hook reads as no change.
+
+// The plugin ships what is in these paths. `tests/` calls `apply_filters` and
+// `do_action` constantly without publishing anything, and built assets under
+// `assets/js/build/` duplicate the surfaces already counted in `src/`.
+const SCANNED = [/^includes\//, /^assets\/js\//, /^src\//, /^(presence-api|uninstall)\.php$/];
+const IGNORED = [/^assets\/js\/build\//, /\/test\//, /\.test\.js$/];
+
+const PHP_RULES = [
+  [
+    /\b(apply_filters|do_action)(?:_ref_array|_deprecated)?\s*\(\s*(['"])(.*?)\2/g,
+    (m) => `${'apply_filters' === m[1] ? 'filter' : 'action'}:${m[3]}`,
+  ],
+  // Only the guarded form, and only the plugin's own prefix: a bare `define()`
+  // is an internal a site cannot override, and every file opens with `ABSPATH`.
+  [/if\s*\(\s*!\s*defined\s*\(\s*(['"])(WP_PRESENCE_[A-Z0-9_]*)\1\s*\)\s*\)/g, (m) => `constant:${m[2]}`],
+  // Routes are usually concatenated (`'/' . $this->rest_base . '/rooms'`), so
+  // take the whole second argument rather than the first literal inside it.
+  [/register_rest_route\s*\(\s*[^,]+,\s*([^,]+?)\s*,/g, (m) => `rest:${route(m[1])}`],
+  [/WP_CLI::add_command\s*\(\s*(['"])(.*?)\1/g, (m) => `cli:${m[2]}`],
+];
+
+const JS_RULES = [
+  [/\bwindow\.(wpPresence[\w$]*)\s*=(?!=)/g, (m) => `js-global:window.${m[1]}`],
+  [/\bwindow\.wp\.presence\.([\w$]+)\s*=(?!=)/g, (m) => `js-global:wp.presence.${m[1]}`],
+  [
+    /\b(?:wp\.hooks\.)?(applyFilters|doAction)\s*\(\s*(['"`])(.*?)\2/g,
+    (m) => `${'applyFilters' === m[1] ? 'js-filter' : 'js-action'}:${m[3]}`,
+  ],
+];
+
+// The workflow greps for this literal to edit its own comment in place.
+const MARKER = '<!-- presence-api:public-surface -->';
+
+// README.md is the only canonical reference for extension points. src/README.md
+// covers the `usePresenceUsers` React hook alone; readme.txt lists no hooks.
+const DOC_FILE = 'README.md';
+const DEFAULT_SECTION = '## Extension Points';
+const DOC_SECTIONS = {
+  filter: '### Filters',
+  action: '### Actions',
+  rest: '## REST API',
+  cli: '## WP-CLI',
+};
+
+function isScanned(path) {
+  return !IGNORED.some((re) => re.test(path)) && SCANNED.some((re) => re.test(path));
+}
+
+// `'/' . $this->rest_base . '/rooms'` reads back as `/$this->rest_base/rooms`.
+function route(raw) {
+  return raw.replace(/['"]/g, '').replace(/\s*\.\s*/g, '').replace(/\s+/g, ' ').trim();
+}
+
+// Identifiers are `kind:name` and carry no path, so the same hook found at a new
+// location is the same surface.
+function findSurfaces(source, path) {
+  const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
+
+  return rules.flatMap(([regex, build]) =>
+    [...source.matchAll(regex)].map(build).filter((s) => !s.endsWith(':'))
+  );
+}
+
+function newSurfaces(base, head) {
+  const before = new Set(base);
+  return [...new Set(head)].filter((s) => !before.has(s)).sort();
+}
+
+// A name appearing anywhere in README.md counts, which is deliberately loose:
+// the bar is writing a hook down at all, not writing it up well.
+function auditSurfaces(surfaces, doc) {
+  return surfaces.map((surface) => {
+    const at = surface.indexOf(':');
+    const kind = surface.slice(0, at);
+    const name = surface.slice(at + 1);
+
+    return {
+      kind,
+      name,
+      section: DOC_SECTIONS[kind] || DEFAULT_SECTION,
+      // Globals are written `window.x` here but `x` in prose.
+      documented: doc.includes(name.split('.').pop()),
+    };
+  });
+}
+
+function formatAudit(audit) {
+  return audit
+    .map(({ kind, name, section, documented }) =>
+      documented
+        ? `- ${kind} \`${name}\`: documented`
+        : `- ${kind} \`${name}\`: **missing from \`${DOC_FILE}\`**, add it under \`${section}\``
+    )
+    .join('\n');
+}
+
+function formatComment(audit) {
+  const one = 1 === audit.length;
+  const headline = audit.every((s) => s.documented)
+    ? `${one ? 'It is' : 'They are'} already in \`${DOC_FILE}\`.`
+    : `Update \`${DOC_FILE}\` before this merges.`;
+
+  return [
+    MARKER,
+    '## New public surface',
+    '',
+    `This branch adds ${audit.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
+    '',
+    formatAudit(audit),
+    '',
+    'Also update `readme.txt` under `= For Developers =` if the change is user-facing.',
+    '',
+  ].join('\n');
+}
+
+module.exports = findSurfaces;
+module.exports.findSurfaces = findSurfaces;
+module.exports.newSurfaces = newSurfaces;
+module.exports.auditSurfaces = auditSurfaces;
+module.exports.formatAudit = formatAudit;
+module.exports.formatComment = formatComment;
+module.exports.isScanned = isScanned;
+module.exports.DOC_FILE = DOC_FILE;
+module.exports.MARKER = MARKER;
+
+// CLI: `node detect-public-surface.js <base-ref> <head-ref>`. Reads both trees
+// through git, never the working directory, so the head is never checked out.
+// Writes `count` to $GITHUB_OUTPUT and the comment body to comment.md.
+if (require.main === module) {
+  const { execFileSync } = require('node:child_process');
+  const fs = require('node:fs');
+
+  const [baseRef, headRef] = process.argv.slice(2);
+
+  if (!baseRef || !headRef) {
+    console.error('Usage: node detect-public-surface.js <base-ref> <head-ref>');
+    process.exit(1);
+  }
+
+  const git = (args) => execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+  const read = (ref, path) => {
+    try {
+      return git(['show', `${ref}:${path}`]);
+    } catch {
+      return '';
+    }
+  };
+
+  const scan = (ref) =>
+    git(['ls-tree', '-r', '--name-only', ref])
+      .split('\n')
+      .filter(isScanned)
+      .flatMap((path) => findSurfaces(read(ref, path), path));
+
+  // README.md is read at the head, so a branch adding a hook and its write-up
+  // together reports the surface as already covered.
+  const audit = auditSurfaces(newSurfaces(scan(baseRef), scan(headRef)), read(headRef, DOC_FILE));
+
+  if (audit.length) {
+    console.log(`Found ${audit.length} new public ${1 === audit.length ? 'surface' : 'surfaces'}:`);
+    console.log(formatAudit(audit));
+    fs.writeFileSync('comment.md', formatComment(audit));
+  } else {
+    console.log('No new public surfaces.');
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `count=${audit.length}\n`);
+  }
+}

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const findSurfaces = require('./detect-public-surface.js');
+const { newSurfaces, auditSurfaces, formatAudit, formatComment, isScanned, MARKER } = findSurfaces;
+
+const php = (source) => findSurfaces(source, 'includes/functions.php');
+const js = (source) => findSurfaces(source, 'assets/js/presence-ping.js');
+
+// ---------------------------------------------------------------------------
+// PHP hooks
+// ---------------------------------------------------------------------------
+
+test('reads filters and actions apart', () => {
+  assert.deepEqual(php("apply_filters( 'wp_presence_default_ttl', 30 );"), [
+    'filter:wp_presence_default_ttl',
+  ]);
+  assert.deepEqual(php("do_action( 'wp_presence_admin_room_changed' );"), [
+    'action:wp_presence_admin_room_changed',
+  ]);
+});
+
+test('reads the _ref_array and _deprecated variants', () => {
+  assert.deepEqual(
+    php("apply_filters_ref_array( 'a', $x ); do_action_deprecated( 'b', $y, '1.0' );"),
+    ['filter:a', 'action:b']
+  );
+});
+
+test('keeps an interpolated hook name whole', () => {
+  assert.deepEqual(php('do_action( "wp_presence_{$room}_joined" );'), [
+    'action:wp_presence_{$room}_joined',
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// Constants, REST, CLI
+// ---------------------------------------------------------------------------
+
+test('counts a guarded constant, ignores a bare define and core guards', () => {
+  const source = `
+    if ( ! defined( 'ABSPATH' ) ) {
+      exit;
+    }
+    if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
+      define( 'WP_PRESENCE_DEFAULT_TTL', 30 );
+    }
+    define( 'WP_PRESENCE_INTERNAL', 5 );
+  `;
+  assert.deepEqual(php(source), ['constant:WP_PRESENCE_DEFAULT_TTL']);
+});
+
+test('reads a route through a variable namespace', () => {
+  assert.deepEqual(
+    php("register_rest_route( $this->namespace, '/presence', array() );"),
+    ['rest:/presence']
+  );
+});
+
+test('reads a concatenated route whole, not just its first literal', () => {
+  const source = `register_rest_route(
+    $this->namespace,
+    '/' . $this->rest_base . '/rooms',
+    array()
+  );`;
+  assert.deepEqual(php(source), ['rest:/$this->rest_base/rooms']);
+});
+
+test('reads a CLI command', () => {
+  assert.deepEqual(php("WP_CLI::add_command( 'presence', $class );"), ['cli:presence']);
+});
+
+// ---------------------------------------------------------------------------
+// JavaScript
+// ---------------------------------------------------------------------------
+
+test('reads browser globals and the wp.presence namespace', () => {
+  assert.deepEqual(js('window.wpPresenceCreateTabCoordinator = function () {};'), [
+    'js-global:window.wpPresenceCreateTabCoordinator',
+  ]);
+  assert.deepEqual(js('window.wp.presence.markScreenStale = function () {};'), [
+    'js-global:wp.presence.markScreenStale',
+  ]);
+});
+
+test('a comparison against a global is not a declaration', () => {
+  assert.deepEqual(js('if ( window.wpPresenceThing === undefined ) {}'), []);
+});
+
+test('reads wp.hooks calls', () => {
+  assert.deepEqual(js("wp.hooks.applyFilters( 'presence.entry', x );"), [
+    'js-filter:presence.entry',
+  ]);
+});
+
+test('php rules do not run against a js file, or the reverse', () => {
+  assert.deepEqual(js("apply_filters( 'not_php', 1 );"), []);
+  assert.deepEqual(php('window.wpPresenceThing = 1;'), []);
+});
+
+// ---------------------------------------------------------------------------
+// newSurfaces
+// ---------------------------------------------------------------------------
+
+test('a hook moved to another file is not new', () => {
+  // The identifier carries no path, so both sides collapse to the same entry.
+  const base = findSurfaces("apply_filters( 'a', 1 );", 'includes/one.php');
+  const head = findSurfaces("apply_filters( 'a', 1 );", 'includes/two.php');
+  assert.deepEqual(newSurfaces(base, head), []);
+});
+
+test('reports additions, ignores removals, and sorts', () => {
+  assert.deepEqual(newSurfaces(['filter:a', 'action:gone'], ['filter:a', 'filter:c', 'action:b']), [
+    'action:b',
+    'filter:c',
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// isScanned
+// ---------------------------------------------------------------------------
+
+test('scans shipped code only', () => {
+  for (const path of ['includes/functions.php', 'presence-api.php', 'assets/js/ping.js']) {
+    assert.equal(isScanned(path), true, path);
+  }
+  // `tests/` is the loudest false-positive source: it calls hooks constantly
+  // without publishing any. Built assets duplicate `src/`.
+  for (const path of [
+    'tests/test-functions.php',
+    'assets/js/build/index.js',
+    'src/utils/test/coordinator.test.js',
+    '.github/scripts/detect-public-surface.js',
+  ]) {
+    assert.equal(isScanned(path), false, path);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// auditSurfaces
+// ---------------------------------------------------------------------------
+
+test('sends each kind to the section that documents it', () => {
+  const audit = auditSurfaces(['filter:a', 'action:b', 'rest:/c', 'cli:d'], '');
+  assert.deepEqual(
+    audit.map((s) => s.section),
+    ['### Filters', '### Actions', '## REST API', '## WP-CLI']
+  );
+});
+
+test('a name already in the README counts as documented', () => {
+  const doc = '### Filters\n#### `wp_presence_default_ttl`\nFilters the TTL.';
+  const [documented, missing] = auditSurfaces(
+    ['filter:wp_presence_default_ttl', 'filter:wp_presence_new_hook'],
+    doc
+  );
+  assert.equal(documented.documented, true);
+  assert.equal(missing.documented, false);
+});
+
+test('a global is matched on its last segment, since prose drops the window prefix', () => {
+  const [surface] = auditSurfaces(
+    ['js-global:wp.presence.markScreenStale'],
+    'Bump the revision from JS via `wp.presence.markScreenStale()`.'
+  );
+  assert.equal(surface.documented, true);
+});
+
+test('splits on the first colon so a namespaced hook name survives', () => {
+  const [surface] = auditSurfaces(['js-filter:presence.entry'], '');
+  assert.equal(surface.name, 'presence.entry');
+});
+
+// ---------------------------------------------------------------------------
+// formatAudit
+// ---------------------------------------------------------------------------
+
+test('names the file and section for anything undocumented', () => {
+  const report = formatAudit(auditSurfaces(['filter:wp_presence_new_hook'], ''));
+  assert.equal(
+    report,
+    '- filter `wp_presence_new_hook`: **missing from `README.md`**, add it under `### Filters`'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// formatComment
+// ---------------------------------------------------------------------------
+
+test('leads with the marker so the workflow can find its own comment', () => {
+  assert.ok(formatComment(auditSurfaces(['filter:a'], '')).startsWith(MARKER));
+});
+
+test('asks for a README update only while something is missing', () => {
+  const missing = formatComment(auditSurfaces(['filter:a'], ''));
+  const covered = formatComment(auditSurfaces(['filter:a'], 'a'));
+  assert.match(missing, /adds 1 extension point that sites can depend on\. Update `README\.md`/);
+  assert.match(covered, /adds 1 extension point that sites can depend on\. It is already in/);
+});
+
+test('agrees in number', () => {
+  const two = formatComment(auditSurfaces(['filter:a', 'action:b'], 'a b'));
+  assert.match(two, /adds 2 extension points that sites can depend on\. They are already in/);
+});

--- a/.github/workflows/public-surface.yml
+++ b/.github/workflows/public-surface.yml
@@ -1,0 +1,72 @@
+name: Public Surface
+
+on:
+  # Labelling needs a write token, which `pull_request` does not get from a
+  # fork, and most contributions here are forks. The head is only ever read as
+  # text through `git show`: never checked out, never installed, never run.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect new public surfaces
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      LABEL: Public API
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Against the merge base, so a surface someone else merged while this
+      # branch was open is not attributed to it.
+      - name: Compare surfaces
+        id: surfaces
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --quiet origin "+refs/pull/${PR}/head:refs/pr/head"
+          node .github/scripts/detect-public-surface.js \
+            "$(git merge-base "$BASE_SHA" refs/pr/head)" refs/pr/head
+
+      # One comment, edited in place on every push, so a branch that adds a hook
+      # and then documents it ends up with an accurate comment.
+      - name: Label and comment
+        env:
+          COUNT: ${{ steps.surfaces.outputs.count }}
+        run: |
+          # MARKER in detect-public-surface.js.
+          ID=$( gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+            --jq 'map(select(.body | startswith("<!-- presence-api:public-surface -->"))) | first | .id // empty' )
+
+          if [ "$COUNT" -eq 0 ]; then
+            # Removing an absent label is a no-op.
+            gh issue edit "$PR" --remove-label "$LABEL"
+            if [ -n "$ID" ]; then
+              gh api --method DELETE "repos/$GH_REPO/issues/comments/$ID" --silent
+            fi
+            exit 0
+          fi
+
+          gh issue edit "$PR" --add-label "$LABEL"
+
+          if [ -n "$ID" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$ID" -F body=@comment.md --silent
+          else
+            gh pr comment "$PR" --body-file comment.md
+          fi


### PR DESCRIPTION
Adding a hook or a route is a promise to every site that uses it, and there is currently nothing that separates that from an ordinary change.

---

**AI usage:** Assisting with detector implementation and tests.