### PR TITLE
feat: expose network presence via REST and WP-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ All endpoints require `edit_posts`. Responses include `Cache-Control: no-store`.
 | `DELETE` | `/wp-presence/v1/presence` | Remove a presence entry |
 | `GET` | `/wp-presence/v1/presence/rooms` | List active rooms |
 
+### Network
+
+Multisite only, and gated on `manage_network` rather than `edit_posts`.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/wp-presence/v1/presence/network` | List sites with users online, busiest first |
+| `GET` | `/wp-presence/v1/presence/network/<blog_id>` | One site's users online |
+
+The collection accepts `page` and `per_page` (default 50, max 100), counting sites in `X-WP-Total` and `X-WP-TotalPages` and the network headcount in `X-WP-Presence-Users-Online`. Both routes accept `users_per_site` to cap the users named per site (default 0, every user); each site's `user_count` stays its real total. A site nobody is on answers with an empty user list, so only an unknown `blog_id` is a 404.
+
 ## WP-CLI
 
 ```
@@ -136,6 +147,7 @@ wp presence list      # List all active presence entries
 wp presence summary   # Summary grouped by room
 wp presence set       # Manually upsert an entry
 wp presence cleanup   # Delete expired entries immediately
+wp presence network   # Network-wide summary (multisite only)
 ```
 
 ## Post-lock bridge

--- a/includes/class-wp-rest-presence-network-controller.php
+++ b/includes/class-wp-rest-presence-network-controller.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * REST API: WP_REST_Presence_Network_Controller class
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Core class used to read network-wide presence via the REST API.
+ *
+ * A site is the item here, not a presence entry: the summary table this reads
+ * holds one row per site, and resolving names and avatars is what costs, so
+ * the collection paginates over sites and each item carries only the users it
+ * was asked to resolve.
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Presence_Network_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wp-presence/v1';
+		$this->rest_base = 'presence/network';
+	}
+
+	/**
+	 * Registers the routes for network presence.
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'per_page'       => array(
+							'type'              => 'integer',
+							'default'           => 50,
+							'minimum'           => 1,
+							'maximum'           => 100,
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'absint',
+						),
+						'page'           => array(
+							'type'              => 'integer',
+							'default'           => 1,
+							'minimum'           => 1,
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'absint',
+						),
+						'users_per_site' => self::users_per_site_arg(),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<blog_id>[\d]+)',
+			array(
+				'args'   => array(
+					'blog_id' => array(
+						'description' => __( 'Unique identifier for the site.', 'presence-api' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'users_per_site' => self::users_per_site_arg(),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Returns the shared definition of the per-site resolve cap.
+	 *
+	 * @return array Argument definition.
+	 */
+	private static function users_per_site_arg() {
+		return array(
+			'type'              => 'integer',
+			'default'           => 0,
+			'minimum'           => 0,
+			'maximum'           => 100,
+			'validate_callback' => 'rest_validate_request_arg',
+			'sanitize_callback' => 'absint',
+		);
+	}
+
+	/**
+	 * Checks if the current user has permission to read network presence.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( wp_presence_network_capability() ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view network presence.', 'presence-api' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if the current user has permission to read one site's presence.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Retrieves the sites with users online, busiest first.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$per_page = $request->get_param( 'per_page' );
+		$page     = $request->get_param( 'page' );
+
+		$summary = wp_presence_get_network_summary(
+			array(
+				'sites'          => $per_page,
+				'offset'         => ( $page - 1 ) * $per_page,
+				'users_per_site' => $request->get_param( 'users_per_site' ),
+			)
+		);
+
+		$data = array();
+
+		foreach ( $summary['sites'] as $site ) {
+			$data[] = $this->prepare_item_for_response( $site, $request )->get_data();
+		}
+
+		$response = rest_ensure_response( $data );
+
+		// Sites, since a site is what is being paginated. The user total has no
+		// standard header to go in, and a caller after the headcount alone would
+		// otherwise have to walk every page for it.
+		$response->header( 'X-WP-Total', $summary['total_sites_online'] );
+		$response->header( 'X-WP-TotalPages', (int) ceil( $summary['total_sites_online'] / $per_page ) );
+		$response->header( 'X-WP-Presence-Users-Online', $summary['total_users_online'] );
+		$response->header( 'Cache-Control', 'no-store' );
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves one site's presence.
+	 *
+	 * A site nobody is on answers with an empty user list; a 404 means no such
+	 * site, so a poll on one site reads the same shape either way.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error otherwise.
+	 */
+	public function get_item( $request ) {
+		$blog_id = (int) $request->get_param( 'blog_id' );
+		$site    = get_site( $blog_id );
+
+		if ( ! $site ) {
+			return new WP_Error(
+				'rest_site_invalid_id',
+				__( 'Invalid site ID.', 'presence-api' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$summary = wp_presence_get_network_summary(
+			array(
+				'blog_id'        => $blog_id,
+				'users_per_site' => $request->get_param( 'users_per_site' ),
+			)
+		);
+
+		$item = $summary['sites'] ? $summary['sites'][0] : self::empty_site( $site );
+
+		$response = rest_ensure_response( $this->prepare_item_for_response( $item, $request )->get_data() );
+
+		$response->header( 'Cache-Control', 'no-store' );
+
+		return $response;
+	}
+
+	/**
+	 * Builds the item for a site nobody is online on.
+	 *
+	 * A site with users online has its URL derived from the summary row it
+	 * pushed. There is no row here, so this reads the site's own siteurl, which
+	 * costs a switch_to_blog() -- affordable for the one site this route serves,
+	 * and unlike the derived form it reflects a mapped domain.
+	 *
+	 * @param WP_Site $site The site.
+	 * @return array Item in the shape wp_presence_get_network_summary() returns.
+	 */
+	private static function empty_site( $site ) {
+		return array(
+			'blog_id'    => (int) $site->blog_id,
+			'domain'     => $site->domain,
+			'path'       => $site->path,
+			'url'        => trailingslashit( get_site_url( (int) $site->blog_id ) ),
+			'users'      => array(),
+			'user_count' => 0,
+		);
+	}
+
+	/**
+	 * Prepares a site for the REST response.
+	 *
+	 * @param array           $item    Site entry from wp_presence_get_network_summary().
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+
+		$data = array();
+
+		if ( rest_is_field_included( 'blog_id', $fields ) ) {
+			$data['blog_id'] = (int) $item['blog_id'];
+		}
+
+		if ( rest_is_field_included( 'domain', $fields ) ) {
+			$data['domain'] = $item['domain'];
+		}
+
+		if ( rest_is_field_included( 'path', $fields ) ) {
+			$data['path'] = $item['path'];
+		}
+
+		if ( rest_is_field_included( 'url', $fields ) ) {
+			$data['url'] = $item['url'];
+		}
+
+		if ( rest_is_field_included( 'user_count', $fields ) ) {
+			$data['user_count'] = (int) $item['user_count'];
+		}
+
+		if ( rest_is_field_included( 'users', $fields ) ) {
+			$data['users'] = $item['users'];
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the network presence site schema, conforming to JSON Schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'presence-network-site',
+			'type'       => 'object',
+			'properties' => array(
+				'blog_id'    => array(
+					'description' => __( 'The site ID.', 'presence-api' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'domain'     => array(
+					'description' => __( 'The domain of the site.', 'presence-api' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'path'       => array(
+					'description' => __( 'The path of the site.', 'presence-api' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'url'        => array(
+					'description' => __( 'The URL of the site.', 'presence-api' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'user_count' => array(
+					'description' => __( 'How many users are online on the site, which the users list is capped below.', 'presence-api' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'users'      => array(
+					'description' => __( 'The users online on the site.', 'presence-api' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'user_id'      => array(
+								'description' => __( 'The WordPress user ID.', 'presence-api' ),
+								'type'        => 'integer',
+							),
+							'display_name' => array(
+								'description' => __( 'The display name of the user.', 'presence-api' ),
+								'type'        => 'string',
+							),
+							'avatar_url'   => array(
+								'description' => __( 'The avatar URL of the user.', 'presence-api' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/includes/class-wp-rest-presence-network-controller.php
+++ b/includes/class-wp-rest-presence-network-controller.php
@@ -12,10 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Core class used to read network-wide presence via the REST API.
  *
- * A site is the item here, not a presence entry: the summary table this reads
- * holds one row per site, and resolving names and avatars is what costs, so
- * the collection paginates over sites and each item carries only the users it
- * was asked to resolve.
+ * A site is the item here, not a presence entry: the summary table holds one
+ * row per site, and resolving names and avatars is what costs.
  *
  * @see WP_REST_Controller
  */
@@ -159,9 +157,8 @@ class WP_REST_Presence_Network_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $data );
 
-		// Sites, since a site is what is being paginated. The user total has no
-		// standard header to go in, and a caller after the headcount alone would
-		// otherwise have to walk every page for it.
+		// The user total has no standard header, and a caller after the headcount
+		// alone would otherwise have to walk every page for it.
 		$response->header( 'X-WP-Total', $summary['total_sites_online'] );
 		$response->header( 'X-WP-TotalPages', (int) ceil( $summary['total_sites_online'] / $per_page ) );
 		$response->header( 'X-WP-Presence-Users-Online', $summary['total_users_online'] );
@@ -173,8 +170,8 @@ class WP_REST_Presence_Network_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves one site's presence.
 	 *
-	 * A site nobody is on answers with an empty user list; a 404 means no such
-	 * site, so a poll on one site reads the same shape either way.
+	 * A site nobody is on answers with an empty user list, so only an unknown
+	 * site is a 404 and a poll reads the same shape either way.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error otherwise.
@@ -210,10 +207,8 @@ class WP_REST_Presence_Network_Controller extends WP_REST_Controller {
 	/**
 	 * Builds the item for a site nobody is online on.
 	 *
-	 * A site with users online has its URL derived from the summary row it
-	 * pushed. There is no row here, so this reads the site's own siteurl, which
-	 * costs a switch_to_blog() -- affordable for the one site this route serves,
-	 * and unlike the derived form it reflects a mapped domain.
+	 * With no summary row to derive the URL from, this reads the site's own
+	 * siteurl: one switch_to_blog(), and it reflects a mapped domain.
 	 *
 	 * @param WP_Site $site The site.
 	 * @return array Item in the shape wp_presence_get_network_summary() returns.

--- a/includes/cli/class-wp-presence-cli-command.php
+++ b/includes/cli/class-wp-presence-cli-command.php
@@ -184,6 +184,98 @@ class WP_Presence_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Shows a network-wide presence summary.
+	 *
+	 * Multisite only.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--site=<blog_id>]
+	 * : Report this site only. The totals stay network-wide.
+	 *
+	 * [--sites=<number>]
+	 * : Maximum sites to report, busiest first. Defaults to every site.
+	 *
+	 * [--users-per-site=<number>]
+	 * : Maximum users to name per site. Defaults to every user.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp presence network
+	 *     wp presence network --sites=5 --users-per-site=4
+	 *     wp presence network --site=3
+	 *     wp presence network --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function network( $args, $assoc_args ) {
+		if ( ! is_multisite() ) {
+			WP_CLI::error( __( 'This is not a multisite installation.', 'presence-api' ) );
+		}
+
+		// Only once --user names someone: shell access already outranks the
+		// capability, but running as a user must not show more than they could see.
+		if ( get_current_user_id() && ! current_user_can( wp_presence_network_capability() ) ) {
+			WP_CLI::error( __( 'Sorry, you are not allowed to view network presence.', 'presence-api' ) );
+		}
+
+		$blog_id = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'site', 0 );
+
+		if ( $blog_id && ! get_site( $blog_id ) ) {
+			WP_CLI::error( __( 'Invalid site ID.', 'presence-api' ) );
+		}
+
+		$summary = wp_presence_get_network_summary(
+			array(
+				'blog_id'        => $blog_id,
+				'sites'          => (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'sites', 0 ),
+				'users_per_site' => (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'users-per-site', 0 ),
+			)
+		);
+
+		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $summary ) );
+			return;
+		}
+
+		/* translators: %d: Number of sites with someone online. */
+		WP_CLI::log( sprintf( __( 'Sites online: %d', 'presence-api' ), $summary['total_sites_online'] ) );
+		/* translators: %d: Number of users online, summed per site. */
+		WP_CLI::log( sprintf( __( 'Users online: %d', 'presence-api' ), $summary['total_users_online'] ) );
+
+		if ( empty( $summary['sites'] ) ) {
+			WP_CLI::log( __( 'No presence data.', 'presence-api' ) );
+			return;
+		}
+
+		$items = array();
+		foreach ( $summary['sites'] as $site ) {
+			$items[] = array(
+				'blog_id'    => $site['blog_id'],
+				'url'        => $site['url'],
+				'user_count' => $site['user_count'],
+				'users'      => implode( ', ', wp_list_pluck( $site['users'], 'display_name' ) ),
+			);
+		}
+
+		WP_CLI::log( '' );
+		WP_CLI\Utils\format_items( $format, $items, array( 'blog_id', 'url', 'user_count', 'users' ) );
+	}
+
+	/**
 	 * Deletes all presence entries from the table.
 	 *
 	 * ## OPTIONS

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -492,6 +492,7 @@ function wp_presence_get_network_snapshot( array $args = array() ) {
  *     @type int $sites          Maximum sites to resolve, busiest first. Default 0, every site.
  *     @type int $users_per_site Maximum users to resolve per site. Default 0, every user.
  *     @type int $blog_id        Resolve this site only. Default 0, no restriction.
+ *     @type int $offset         Sites to skip before resolving. Default 0.
  * }
  * @return array {
  *     @type array $sites               blog_id, domain, path, url, users
@@ -512,16 +513,18 @@ function wp_presence_get_network_summary( array $args = array() ) {
 			'sites'          => 0,
 			'users_per_site' => 0,
 			'blog_id'        => 0,
+			'offset'         => 0,
 		)
 	);
 
 	$timeout = wp_presence_get_timeout( $args['timeout'] );
 	$key     = sprintf(
-		'summary:%d:%d:%d:%d',
+		'summary:%d:%d:%d:%d:%d',
 		$timeout,
 		(int) $args['sites'],
 		(int) $args['users_per_site'],
-		(int) $args['blog_id']
+		(int) $args['blog_id'],
+		(int) $args['offset']
 	);
 
 	return wp_presence_network_cached(
@@ -531,7 +534,8 @@ function wp_presence_get_network_summary( array $args = array() ) {
 				wp_presence_get_network_snapshot( array( 'timeout' => $timeout ) ),
 				(int) $args['sites'],
 				(int) $args['users_per_site'],
-				(int) $args['blog_id']
+				(int) $args['blog_id'],
+				(int) $args['offset']
 			);
 		}
 	);
@@ -764,17 +768,18 @@ function wp_presence_compute_network_snapshot( $timeout ) {
  * @param int   $max_sites      Maximum sites to resolve. 0 for every site.
  * @param int   $users_per_site Maximum users to resolve per site. 0 for every user.
  * @param int   $blog_id        Resolve this site only. 0 for no restriction.
+ * @param int   $offset         Sites to skip before resolving. Default 0.
  * @return array See wp_presence_get_network_summary().
  */
-function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $users_per_site, $blog_id ) {
+function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $users_per_site, $blog_id, $offset = 0 ) {
 	$by_site = $snapshot['sites'];
 
 	if ( $blog_id ) {
 		$by_site = isset( $by_site[ $blog_id ] ) ? array( $blog_id => $by_site[ $blog_id ] ) : array();
 	}
 
-	if ( $max_sites > 0 ) {
-		$by_site = array_slice( $by_site, 0, $max_sites, true );
+	if ( $offset > 0 || $max_sites > 0 ) {
+		$by_site = array_slice( $by_site, $offset, $max_sites > 0 ? $max_sites : null, true );
 	}
 
 	if ( ! $by_site ) {

--- a/presence-api.php
+++ b/presence-api.php
@@ -106,6 +106,7 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-widget
 
 if ( is_multisite() ) {
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-functions.php';
+	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/class-wp-rest-presence-network-controller.php';
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-sites-list.php';
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/network-user-list.php';
 	require_once WP_PRESENCE_PLUGIN_DIR . 'includes/widgets/class-wp-presence-network-widget-whos-online.php';
@@ -145,6 +146,11 @@ function wp_presence_register_post_type_support() {
 function wp_presence_register_rest_routes() {
 	$controller = new WP_REST_Presence_Controller();
 	$controller->register_routes();
+
+	if ( is_multisite() ) {
+		$network_controller = new WP_REST_Presence_Network_Controller();
+		$network_controller->register_routes();
+	}
 }
 
 /**

--- a/tests/test-cli-command.php
+++ b/tests/test-cli-command.php
@@ -362,4 +362,23 @@ class WP_Test_Presence_CLI_Command extends WP_Presence_UnitTestCase {
 
 		$this->assertSame( array( '0 entries deleted.' ), WP_CLI::messages( 'success' ) );
 	}
+
+	/**
+	 * The summary table behind it only exists on a network, and the functions it
+	 * reads are not loaded here at all.
+	 *
+	 * @covers WP_Presence_CLI_Command::network
+	 */
+	public function test_network_refuses_to_run_on_a_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Requires single site.' );
+		}
+
+		$this->assert_halts_with(
+			function () {
+				$this->command->network( array(), array() );
+			},
+			'This is not a multisite installation.'
+		);
+	}
 }

--- a/tests/test-cli-network-command.php
+++ b/tests/test-cli-network-command.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Tests for the network subcommand of the WP-CLI command.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group cli
+ * @group ms-required
+ *
+ * @covers WP_Presence_CLI_Command::network
+ */
+
+require_once __DIR__ . '/stubs/wp-cli.php';
+require_once dirname( __DIR__ ) . '/includes/cli/class-wp-presence-cli-command.php';
+
+class WP_Test_Presence_CLI_Network_Command extends WP_Presence_Network_UnitTestCase {
+
+	private $command;
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		WP_CLI::reset();
+		$this->command = new WP_Presence_CLI_Command();
+	}
+
+	private function assert_errors_with( callable $run, $expected ) {
+		try {
+			$run();
+		} catch ( WP_Presence_CLI_Halt $e ) {
+			$this->assertSame( $expected, $e->getMessage() );
+			return;
+		}
+
+		$this->fail( 'Expected WP_CLI::error() to halt the command.' );
+	}
+
+	private function last_table() {
+		return end( WP_CLI::$formatted );
+	}
+
+	public function test_it_reports_every_site_with_someone_online() {
+		$busy  = $this->create_blog();
+		$quiet = $this->create_blog();
+
+		$this->set_network_summary_row( $busy, self::factory()->user->create_many( 2 ) );
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+
+		$this->command->network( array(), array() );
+
+		$this->assertContains( 'Sites online: 2', WP_CLI::messages( 'log' ) );
+		$this->assertContains( 'Users online: 3', WP_CLI::messages( 'log' ) );
+
+		$table = $this->last_table();
+
+		$this->assertSame( array( 'blog_id', 'url', 'user_count', 'users' ), $table['fields'] );
+		$this->assertSame( array( $busy, $quiet ), wp_list_pluck( $table['items'], 'blog_id' ), 'Busiest site first.' );
+		$this->assertSame( 2, $table['items'][0]['user_count'] );
+	}
+
+	public function test_it_names_the_users_online_on_each_site() {
+		$blog_id = $this->create_blog();
+
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		$this->command->network( array(), array() );
+
+		$this->assertSame(
+			get_userdata( self::$editor_id )->display_name,
+			$this->last_table()['items'][0]['users']
+		);
+	}
+
+	public function test_a_quiet_network_reports_zero_rather_than_a_table() {
+		$this->command->network( array(), array() );
+
+		$this->assertSame(
+			array( 'Sites online: 0', 'Users online: 0', 'No presence data.' ),
+			WP_CLI::messages( 'log' )
+		);
+		$this->assertSame( array(), WP_CLI::$formatted );
+	}
+
+	public function test_json_emits_the_whole_summary() {
+		$blog_id = $this->create_blog();
+
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		$this->command->network( array(), array( 'format' => 'json' ) );
+
+		$decoded = json_decode( WP_CLI::messages( 'log' )[0], true );
+
+		$this->assertSame( 1, $decoded['total_sites_online'] );
+		$this->assertSame( 1, $decoded['total_users_online'] );
+		$this->assertSame( $blog_id, $decoded['sites'][0]['blog_id'] );
+		$this->assertSame( self::$editor_id, $decoded['sites'][0]['users'][0]['user_id'] );
+	}
+
+	public function test_site_narrows_to_one_site_while_the_totals_stay_network_wide() {
+		$wanted = $this->create_blog();
+		$other  = $this->create_blog();
+
+		$this->set_network_summary_row( $wanted, array( self::$editor_id ) );
+		$this->set_network_summary_row( $other, self::factory()->user->create_many( 2 ) );
+
+		$this->command->network( array(), array( 'site' => $wanted ) );
+
+		$this->assertSame( array( $wanted ), wp_list_pluck( $this->last_table()['items'], 'blog_id' ) );
+		$this->assertContains( 'Sites online: 2', WP_CLI::messages( 'log' ) );
+	}
+
+	// Without this a typo'd ID reads as a quiet site rather than a bad flag.
+	public function test_site_rejects_an_id_no_site_answers_to() {
+		$this->assert_errors_with(
+			fn() => $this->command->network( array(), array( 'site' => 999999 ) ),
+			'Invalid site ID.'
+		);
+	}
+
+	public function test_the_caps_bound_what_is_reported() {
+		$busy  = $this->create_blog();
+		$quiet = $this->create_blog();
+
+		$this->set_network_summary_row( $busy, self::factory()->user->create_many( 3 ) );
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+
+		$this->command->network(
+			array(),
+			array(
+				'sites'          => 1,
+				'users-per-site' => 1,
+			)
+		);
+
+		$items = $this->last_table()['items'];
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( 3, $items[0]['user_count'], 'A capped list reported its own length as the headcount.' );
+		$this->assertSame( 1, substr_count( $items[0]['users'], ',' ) + 1 );
+	}
+
+	public function test_running_as_a_user_without_the_capability_is_refused() {
+		wp_set_current_user( self::$editor_id );
+
+		$this->assert_errors_with(
+			fn() => $this->command->network( array(), array() ),
+			'Sorry, you are not allowed to view network presence.'
+		);
+	}
+
+	public function test_running_as_a_network_admin_is_allowed() {
+		$this->become_network_admin();
+
+		$this->command->network( array(), array() );
+
+		$this->assertSame( array(), WP_CLI::messages( 'error' ) );
+	}
+
+	public function test_running_without_a_user_is_allowed() {
+		$this->assertSame( 0, get_current_user_id() );
+
+		$this->command->network( array(), array() );
+
+		$this->assertSame( array(), WP_CLI::messages( 'error' ) );
+	}
+}

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -345,6 +345,43 @@ class WP_Test_Network_Presence extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * A paginated caller wants a page of the same busiest-first order, so the
+	 * skip happens where the cap does: before anything is resolved.
+	 *
+	 * @covers ::wp_presence_get_network_summary
+	 * @covers ::wp_presence_hydrate_network_snapshot
+	 */
+	public function test_summary_can_skip_sites_before_resolving_them() {
+		$busiest = $this->create_blog();
+		$busy    = $this->create_blog();
+		$quiet   = $this->create_blog();
+
+		$this->set_network_summary_row( $busiest, self::factory()->user->create_many( 3 ) );
+		$this->set_network_summary_row( $busy, self::factory()->user->create_many( 2 ) );
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+
+		$page_two = wp_presence_get_network_summary(
+			array(
+				'sites'  => 1,
+				'offset' => 1,
+			)
+		);
+
+		$this->assertSame( array( $busy ), wp_list_pluck( $page_two['sites'], 'blog_id' ) );
+		$this->assertSame( 3, $page_two['total_sites_online'] );
+
+		// An offset with no cap behind it runs to the end of the network.
+		$rest = wp_presence_get_network_summary( array( 'offset' => 1 ) );
+
+		$this->assertSame( array( $busy, $quiet ), wp_list_pluck( $rest['sites'], 'blog_id' ) );
+
+		$past_end = wp_presence_get_network_summary( array( 'offset' => 3 ) );
+
+		$this->assertSame( array(), $past_end['sites'] );
+		$this->assertSame( 3, $past_end['total_sites_online'] );
+	}
+
+	/**
 	 * Network presence data spans every site on the install, so the bar to see
 	 * it is a network capability, and a network that delegates differently can
 	 * move it.

--- a/tests/test-network-rest-controller.php
+++ b/tests/test-network-rest-controller.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests for the network presence REST controller.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ *
+ * @covers WP_REST_Presence_Network_Controller
+ */
+class WP_Test_Network_Presence_REST_Controller extends WP_Presence_Network_UnitTestCase {
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	private function get( $route, array $params = array() ) {
+		$request = new WP_REST_Request( 'GET', $route );
+
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	public function test_the_collection_reports_every_site_with_someone_online() {
+		$this->become_network_admin();
+
+		$busy  = $this->create_blog();
+		$quiet = $this->create_blog();
+
+		$this->set_network_summary_row( $busy, self::factory()->user->create_many( 2 ) );
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+
+		$response = $this->get( '/wp-presence/v1/presence/network' );
+		$data     = $response->get_data();
+		$headers  = $response->get_headers();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( $busy, $quiet ), wp_list_pluck( $data, 'blog_id' ), 'Busiest site first.' );
+		$this->assertSame( 2, $data[0]['user_count'] );
+		$this->assertCount( 2, $data[0]['users'] );
+		$this->assertArrayHasKey( 'avatar_url', $data[0]['users'][0] );
+		$this->assertSame( 2, $headers['X-WP-Total'] );
+		$this->assertSame( 3, $headers['X-WP-Presence-Users-Online'] );
+		$this->assertSame( 'no-store', $headers['Cache-Control'] );
+	}
+
+	public function test_the_collection_paginates_over_sites() {
+		$this->become_network_admin();
+
+		$busy  = $this->create_blog();
+		$quiet = $this->create_blog();
+
+		$this->set_network_summary_row( $busy, self::factory()->user->create_many( 2 ) );
+		$this->set_network_summary_row( $quiet, array( self::$editor_id ) );
+
+		$response = $this->get(
+			'/wp-presence/v1/presence/network',
+			array(
+				'per_page' => 1,
+				'page'     => 2,
+			)
+		);
+
+		$headers = $response->get_headers();
+
+		$this->assertSame( array( $quiet ), wp_list_pluck( $response->get_data(), 'blog_id' ) );
+
+		// Network-wide, so a caller can tell the page is a page.
+		$this->assertSame( 2, $headers['X-WP-Total'] );
+		$this->assertSame( 2, $headers['X-WP-TotalPages'] );
+	}
+
+	public function test_users_per_site_caps_what_is_resolved_without_capping_the_count() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, self::factory()->user->create_many( 3 ) );
+
+		$response = $this->get( '/wp-presence/v1/presence/network', array( 'users_per_site' => 1 ) );
+		$data     = $response->get_data();
+
+		$this->assertCount( 1, $data[0]['users'] );
+		$this->assertSame( 3, $data[0]['user_count'] );
+	}
+
+	public function test_the_collection_is_closed_to_users_without_the_network_capability() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->get( '/wp-presence/v1/presence/network' );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * The route has to read the filter rather than hard-code the default.
+	 */
+	public function test_the_route_honours_the_filtered_network_capability() {
+		wp_set_current_user( self::$editor_id );
+
+		add_filter( 'wp_presence_network_capability', fn() => 'edit_posts' );
+
+		$this->assertSame( 200, $this->get( '/wp-presence/v1/presence/network' )->get_status() );
+	}
+
+	public function test_a_single_site_reports_who_is_on_it() {
+		$this->become_network_admin();
+
+		$wanted = $this->create_blog();
+		$other  = $this->create_blog();
+
+		$this->set_network_summary_row( $wanted, array( self::$editor_id ) );
+		$this->set_network_summary_row( $other, self::factory()->user->create_many( 2 ) );
+
+		$response = $this->get( '/wp-presence/v1/presence/network/' . $wanted );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $wanted, $data['blog_id'] );
+		$this->assertSame( 1, $data['user_count'] );
+		$this->assertSame( self::$editor_id, $data['users'][0]['user_id'] );
+	}
+
+	/**
+	 * An empty site is a 200; a 404 is reserved for a site that does not exist.
+	 */
+	public function test_a_site_nobody_is_on_answers_with_an_empty_user_list() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+
+		$response = $this->get( '/wp-presence/v1/presence/network/' . $blog_id );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $blog_id, $data['blog_id'] );
+		$this->assertSame( array(), $data['users'] );
+		$this->assertSame( 0, $data['user_count'] );
+		$this->assertSame( trailingslashit( get_site_url( $blog_id ) ), $data['url'] );
+	}
+
+	public function test_a_site_that_does_not_exist_is_a_404() {
+		$this->become_network_admin();
+
+		$response = $this->get( '/wp-presence/v1/presence/network/999999' );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'rest_site_invalid_id', $response->get_data()['code'] );
+	}
+
+	public function test_a_single_site_is_closed_to_users_without_the_network_capability() {
+		$blog_id = $this->create_blog();
+
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->get( '/wp-presence/v1/presence/network/' . $blog_id );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+}

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -739,4 +739,19 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 			$this->assertNotContains( $unused_user_id, $returned_user_ids, 'Users from rooms outside page 1 should not be queried' );
 		}
 	}
+
+	/**
+	 * The summary table behind them only exists on a network.
+	 *
+	 * @covers ::wp_presence_register_rest_routes
+	 */
+	public function test_the_network_routes_are_not_registered_on_a_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Requires single site.' );
+		}
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp-presence/v1/presence/network' ) );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
 }


### PR DESCRIPTION
### Description

Closes #350

Adds a `wp presence network` subcommand and two network-scoped REST routes, both gated on `wp_presence_network_capability()`. Both read the summary table directly, so answering for the whole network costs no `switch_to_blog()` per site.

Sites are the paginated unit, since a site is what the table holds a row for. `X-WP-Total` counts sites, and the user headcount rides in `X-WP-Presence-Users-Online` — a caller after the total alone would otherwise have to walk every page for it. Paginating meant giving `wp_presence_get_network_summary()` an `offset`, which is the only change here to existing code.

Two decisions worth a look:

- The CLI checks the capability only once `--user` names someone. Shell access already outranks `manage_network`, so the check keeps `--user` honest rather than keeping anyone out — but the guard reads oddly without that context.
- A site nobody is on answers `200` with an empty user list, so only an unknown `blog_id` is a `404`. A poll against one site reads the same shape either way.

### Testing

Both halves cover the single-site case, where the summary table does not exist: the routes are not registered, and the subcommand refuses. That path is invisible to the multisite suite, and without the guard the subcommand fatals on an undefined function rather than erroring cleanly.

### Screenshots

#### WP CLI

<img width="1306" height="197" alt="image" src="https://github.com/user-attachments/assets/9bb1ebea-925a-415c-aad3-d87ab4414c8f" />

<img width="1334" height="196" alt="image" src="https://github.com/user-attachments/assets/3a0dc57f-126d-4315-bbf0-cc155313b2e7" />

<img width="1335" height="184" alt="image" src="https://github.com/user-attachments/assets/329e475a-84d8-41d8-b1e2-4439055dfdda" />

<img width="1344" height="214" alt="image" src="https://github.com/user-attachments/assets/c8a7e0ae-85df-4455-8af2-824bab604bcc" />

<img width="1331" height="144" alt="image" src="https://github.com/user-attachments/assets/fb9f037d-902f-4bb6-ba03-0c34069ab0cd" />

#### REST API

<img width="1065" height="814" alt="image" src="https://github.com/user-attachments/assets/3c70887a-60e1-49df-b8ee-bfe5dc8a6e3a" />

<img width="1061" height="811" alt="image" src="https://github.com/user-attachments/assets/5ca53438-9f71-4cac-a220-07645cbb8215" />

<img width="1063" height="789" alt="image" src="https://github.com/user-attachments/assets/5a058b90-ab86-43c7-9ffd-20d7af84d56c" />

<img width="1075" height="655" alt="image" src="https://github.com/user-attachments/assets/dbdf7e6b-770d-4f0a-a100-ea86c8ba64c6" />

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the implementation and tests

</details>