### PR TITLE
fix: bring the stale-screen banner back after a dismissal

### DIFF
--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -93,10 +93,10 @@
 		if ( bannerShown ) {
 			return;
 		}
-		showBanner( info );
+		showBanner( info, rev );
 	} );
 
-	function showBanner( info ) {
+	function showBanner( info, rev ) {
 		const target = document.querySelector( '.wrap' ) || document.getElementById( 'wpbody-content' );
 		if ( ! target ) {
 			return;
@@ -152,6 +152,11 @@
 		dismiss.appendChild( sr );
 		dismiss.addEventListener( 'click', function () {
 			notice.remove();
+			bannerShown = false;
+			// Dismissal acknowledges this revision, not the screen. The tick
+			// handler only compares against baselineRev, so clearing the flag
+			// without advancing it brings the same banner back one tick later.
+			baselineRev = rev;
 		} );
 		notice.appendChild( dismiss );
 

--- a/tests/e2e/presence-stale-screen-coalescing.test.js
+++ b/tests/e2e/presence-stale-screen-coalescing.test.js
@@ -6,6 +6,9 @@
  * sibling, and the leader's presence-screen-rev relays to siblings over
  * BroadcastChannel.
  *
+ * Also covers what dismissing the banner does to later edits, which shares
+ * this file's fixtures rather than duplicating them.
+ *
  * Uses two pages in one browser context, not two Playwright contexts —
  * Web Locks and BroadcastChannel are scoped per storage partition.
  *
@@ -191,5 +194,154 @@ test.describe( 'Presence Stale-Screen Tab Coalescing', () => {
 		] );
 
 		await sibling.close();
+	} );
+} );
+
+test.describe( 'Presence Stale-Screen Banner', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	/**
+	 * Edits a post and attributes it to a given user.
+	 *
+	 * `_edit_last` carries the actor and core only writes it from the admin
+	 * save path, so `wp_update_post()` alone leaves it empty and every edit
+	 * reads as authorless. Setting it here is what makes `actor_is_me` mean
+	 * anything.
+	 *
+	 * Post revisions are `strtotime( post_modified_gmt )`, so consecutive
+	 * edits inside one second are indistinguishable. Callers space them.
+	 *
+	 * @param {number} postId The post to touch.
+	 * @param {string} userId The editing user's ID.
+	 */
+	function editAsUser( postId, userId ) {
+		wpEval(
+			`wp_update_post( array( 'ID' => ${ postId }, 'post_content' => get_post_field( 'post_content', ${ postId } ) ) ); update_post_meta( ${ postId }, '_edit_last', ${ userId } );`
+		);
+	}
+
+	async function openPostAsLeader( page, postId ) {
+		await page.goto( `/wp-admin/post.php?post=${ postId }&action=edit` );
+		await waitForHeartbeat( page );
+		await waitForLeaderPing( page );
+	}
+
+	test( 'shows the banner again after a later edit once an earlier one was dismissed', async ( {
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Stale Screen Redisplay Post',
+			status: 'draft',
+		} );
+		const otherUserId = execOutput(
+			`npx wp-env run cli wp user get ${ testUsers[ 0 ].username } --field=ID`
+		);
+
+		await openPostAsLeader( page, post.id );
+
+		editAsUser( post.id, otherUserId );
+		await Promise.all( [
+			page.waitForSelector( '.wp-presence-stale-notice', {
+				timeout: 8000,
+			} ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+
+		await page.click( '.wp-presence-stale-notice .notice-dismiss' );
+		await expect(
+			page.locator( '.wp-presence-stale-notice' )
+		).toHaveCount( 0 );
+
+		// Past the one-second resolution of the revision.
+		await page.waitForTimeout( 1200 );
+		editAsUser( post.id, otherUserId );
+
+		await Promise.all( [
+			page.waitForSelector( '.wp-presence-stale-notice', {
+				timeout: 8000,
+			} ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+	} );
+
+	test( "stays silent for the viewer's own save and still reports the next foreign one", async ( {
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Stale Screen Self Save Post',
+			status: 'draft',
+		} );
+		const otherUserId = execOutput(
+			`npx wp-env run cli wp user get ${ testUsers[ 0 ].username } --field=ID`
+		);
+		const viewerId = execOutput(
+			`npx wp-env run cli wp user get admin --field=ID`
+		);
+
+		await openPostAsLeader( page, post.id );
+
+		editAsUser( post.id, viewerId );
+		for ( let tick = 0; tick < 3; tick++ ) {
+			await page.evaluate( () => wp.heartbeat.connectNow() );
+			await page.waitForTimeout( 500 );
+		}
+		await expect(
+			page.locator( '.wp-presence-stale-notice' )
+		).toHaveCount( 0 );
+
+		// A banner here proves the self-save advanced the baseline rather
+		// than the screen having gone inert.
+		await page.waitForTimeout( 1200 );
+		editAsUser( post.id, otherUserId );
+		await Promise.all( [
+			page.waitForSelector( '.wp-presence-stale-notice', {
+				timeout: 8000,
+			} ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+	} );
+
+	test( 'leaves the banner dismissed when no further edit has happened', async ( {
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'Stale Screen Dismissal Post',
+			status: 'draft',
+		} );
+		const otherUserId = execOutput(
+			`npx wp-env run cli wp user get ${ testUsers[ 0 ].username } --field=ID`
+		);
+
+		await openPostAsLeader( page, post.id );
+
+		editAsUser( post.id, otherUserId );
+		await Promise.all( [
+			page.waitForSelector( '.wp-presence-stale-notice', {
+				timeout: 8000,
+			} ),
+			page.evaluate( () => wp.heartbeat.connectNow() ),
+		] );
+
+		await page.click( '.wp-presence-stale-notice .notice-dismiss' );
+
+		// The revision that raised the banner is still ahead of the page's
+		// original baseline, so a fix that only clears the shown flag brings
+		// the same banner straight back.
+		for ( let tick = 0; tick < 3; tick++ ) {
+			await page.evaluate( () => wp.heartbeat.connectNow() );
+			await page.waitForTimeout( 500 );
+		}
+
+		await expect(
+			page.locator( '.wp-presence-stale-notice' )
+		).toHaveCount( 0 );
 	} );
 } );


### PR DESCRIPTION
Dismissing the banner removed the notice but left `bannerShown` set, so the guard in the tick handler suppressed every later banner for the life of the page. One dismissal and you stop hearing about other people's edits until you reload.

Clearing the flag alone is not enough. The tick handler compares against `baselineRev`, which the banner path deliberately does not advance, so a dismissal that only resets the flag brings the same banner straight back on the next tick. The dismiss handler now also advances `baselineRev` to the revision that raised the banner, which is what makes a dismissal mean "I have seen this edit" rather than "hide this screen".

One consequence worth knowing: if a newer edit lands while the banner is already up, the flag suppresses it and the baseline only advances to the older revision, so dismissing raises a fresh banner on the next tick. That is intended, there really is an edit you have not seen, but it does mean a dismissal can be followed immediately by another banner.

Three e2e guards in the existing stale-screen file, each mutation checked to fail on its own and only its own:

- the banner returns after a later edit, which fails without the flag reset
- a dismissal sticks when nothing else has happened, which fails without the baseline advance
- your own save stays silent and the next foreign edit still reports. That branch had no coverage at all: deleting it broke no test before this

Two things found while writing those, neither fixed here:

`wp_update_post()` never writes `_edit_last`, because core only does that from the admin save path. An edit driven from `wp eval` is therefore authorless and `actor_is_me` is always false. The relay test at `:160` sets a current user expecting that to attribute the edit, and it does not. My helper sets the meta explicitly. Happy to correct the older test here or leave it for you.

`presence-widgets.test.js` "Focus stays on the post link in Active Posts widget across a heartbeat re-render" is flaky on `main` independently of this branch: 5 of 6 runs failed on `005b6ca` untouched, 2 of 6 with this change. Worth its own issue if it is not already known.

Fixes #361

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Diagnosis, the fix, and the e2e guards. I reviewed the change, ran the mutation checks and the suites, and confirmed the flaky test against an untouched base branch.

</details>
