### PR TITLE
refactor: share the avatar stack's CSS and JS across every surface

### DIFF
--- a/assets/css/avatar-stack.css
+++ b/assets/css/avatar-stack.css
@@ -1,0 +1,27 @@
+/**
+ * Overlapping avatar stack.
+ *
+ * Shared by the two "Who's Online" dashboard widgets and the "Online" column
+ * on Network Admin > Sites.
+ *
+ * @package Presence_API
+ */
+
+/* Inline so the stack sits on the baseline beside the Sites list count. */
+.presence-avatar-stack {
+	display: inline-flex;
+	align-items: center;
+}
+
+.presence-avatar-stack img {
+	position: relative;
+	width: 20px;
+	height: 20px;
+	margin-inline-start: -6px;
+	border-radius: 50%;
+	box-shadow: 0 0 0 2px #fff;
+}
+
+.presence-avatar-stack img:first-child {
+	margin-inline-start: 0;
+}

--- a/assets/js/avatar-stack.js
+++ b/assets/js/avatar-stack.js
@@ -1,0 +1,41 @@
+/**
+ * Overlapping avatar stack, client side.
+ *
+ * The counterpart to wp_presence_render_avatar_stack(). Both "Who's Online"
+ * widgets paint the stack server-side and then repaint it from a Heartbeat
+ * tick, so the two renderers have to emit the same markup.
+ *
+ * @package Presence_API
+ */
+( function () {
+	'use strict';
+
+	function esc( str ) {
+		var el = document.createElement( 'span' );
+		el.textContent = str;
+		return el.innerHTML;
+	}
+
+	/**
+	 * Builds an avatar stack.
+	 *
+	 * @param {Array}  users Users, each with an avatar_url and a display_name.
+	 * @param {number} max   Maximum number of avatars to show.
+	 * @return {string} HTML markup.
+	 */
+	window.wpPresenceBuildAvatarStack = function ( users, max ) {
+		// get_avatar_url() returns false with the Show Avatars setting off.
+		var shown = users.slice( 0, max ).filter( function ( user ) {
+			return !! user.avatar_url;
+		} );
+
+		var html = '<span class="presence-avatar-stack">';
+
+		// The avatars overlap, so the first one has to paint on top.
+		shown.forEach( function ( user, index ) {
+			html += '<img src="' + esc( user.avatar_url ) + '" width="20" height="20" style="z-index:' + ( shown.length - index ) + '" alt="' + esc( user.display_name ) + '" />';
+		} );
+
+		return html + '</span>';
+	};
+}() );

--- a/assets/js/avatar-stack.js
+++ b/assets/js/avatar-stack.js
@@ -19,6 +19,11 @@
 	/**
 	 * Builds an avatar stack.
 	 *
+	 * On `window` only because the two widgets' inline scripts are enqueued
+	 * separately and have no other way to share it. Nothing outside the plugin
+	 * is meant to call it.
+	 *
+	 * @private
 	 * @param {Array}  users Users, each with an avatar_url and a display_name.
 	 * @param {number} max   Maximum number of avatars to show.
 	 * @return {string} HTML markup.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -823,25 +823,41 @@ function wp_presence_hydrate_room_users( $rooms, $timeout = WP_PRESENCE_DEFAULT_
 }
 
 /**
+ * Enqueues the shared avatar-stack stylesheet.
+ *
+ * @access private
+ */
+function wp_presence_enqueue_avatar_stack_style() {
+	wp_enqueue_style(
+		'wp-presence-avatar-stack',
+		WP_PRESENCE_PLUGIN_URL . 'assets/css/avatar-stack.css',
+		array(),
+		WP_PRESENCE_VERSION
+	);
+}
+
+/**
  * Renders a small avatar stack for a list of users.
  *
  * Shared across every surface that shows an overlapping avatar stack (the
  * dashboard widget's overflow indicator, the network Sites list column, the
  * network dashboard widget) so they all render the stack identically.
  *
+ * assets/css/avatar-stack.css sizes the avatars; the attributes below only
+ * reserve the space until it loads.
+ *
  * @access private
  * @param array $users Users, each with 'avatar_url' and 'display_name'.
  * @param int   $max   Optional. Maximum avatars to show. Default 4.
- * @param int   $size  Optional. Avatar width and height in pixels. Default 20.
  * @return string HTML markup.
  */
-function wp_presence_render_avatar_stack( $users, $max = 4, $size = 20 ) {
+function wp_presence_render_avatar_stack( $users, $max = 4 ) {
 	$stack_max = min( count( $users ), $max );
 	$html      = '<span class="presence-avatar-stack">';
 
 	foreach ( array_slice( $users, 0, $stack_max ) as $index => $user ) {
 		$z     = $stack_max - $index;
-		$html .= '<img src="' . esc_url( $user['avatar_url'] ) . '" width="' . (int) $size . '" height="' . (int) $size . '" style="z-index:' . (int) $z . '" alt="' . esc_attr( $user['display_name'] ) . '" />';
+		$html .= '<img src="' . esc_url( $user['avatar_url'] ) . '" width="20" height="20" style="z-index:' . (int) $z . '" alt="' . esc_attr( $user['display_name'] ) . '" />';
 	}
 
 	$html .= '</span>';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -837,11 +837,31 @@ function wp_presence_enqueue_avatar_stack_style() {
 }
 
 /**
+ * Enqueues the shared avatar-stack script.
+ *
+ * Only the two widgets that repaint over Heartbeat need it; a stack rendered
+ * once per page load is served by the PHP renderer alone.
+ *
+ * @access private
+ */
+function wp_presence_enqueue_avatar_stack_script() {
+	wp_enqueue_script(
+		'wp-presence-avatar-stack',
+		WP_PRESENCE_PLUGIN_URL . 'assets/js/avatar-stack.js',
+		array(),
+		WP_PRESENCE_VERSION,
+		true
+	);
+}
+
+/**
  * Renders a small avatar stack for a list of users.
  *
  * Shared across every surface that shows an overlapping avatar stack (the
  * dashboard widget's overflow indicator, the network Sites list column, the
- * network dashboard widget) so they all render the stack identically.
+ * network dashboard widget) so they all render the stack identically, and
+ * mirrored by wpPresenceBuildAvatarStack() in assets/js/avatar-stack.js for
+ * the widgets that repaint over Heartbeat.
  *
  * assets/css/avatar-stack.css sizes the avatars; the attributes below only
  * reserve the space until it loads.
@@ -852,11 +872,19 @@ function wp_presence_enqueue_avatar_stack_style() {
  * @return string HTML markup.
  */
 function wp_presence_render_avatar_stack( $users, $max = 4 ) {
-	$stack_max = min( count( $users ), $max );
-	$html      = '<span class="presence-avatar-stack">';
+	$shown = array();
 
-	foreach ( array_slice( $users, 0, $stack_max ) as $index => $user ) {
-		$z     = $stack_max - $index;
+	// get_avatar_url() returns false with the Show Avatars setting off.
+	foreach ( array_slice( $users, 0, $max ) as $user ) {
+		if ( ! empty( $user['avatar_url'] ) ) {
+			$shown[] = $user;
+		}
+	}
+
+	$html = '<span class="presence-avatar-stack">';
+
+	foreach ( $shown as $index => $user ) {
+		$z     = count( $shown ) - $index;
 		$html .= '<img src="' . esc_url( $user['avatar_url'] ) . '" width="20" height="20" style="z-index:' . (int) $z . '" alt="' . esc_attr( $user['display_name'] ) . '" />';
 	}
 

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -26,6 +26,25 @@ function wp_presence_register_network_sites_column( $columns ) {
 }
 
 /**
+ * Enqueues the avatar-stack stylesheet on the Sites list.
+ *
+ * No other presence asset loads on this screen, so nothing else pulls it in.
+ *
+ * @param string $hook_suffix The current admin page.
+ */
+function wp_presence_enqueue_network_sites_assets( $hook_suffix ) {
+	if ( 'sites.php' !== $hook_suffix ) {
+		return;
+	}
+
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return;
+	}
+
+	wp_presence_enqueue_avatar_stack_style();
+}
+
+/**
  * Renders the "Online" column for a single row of the Sites list table.
  *
  * Rendered once per page load, the same as every other column on this table

--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -56,6 +56,8 @@ class WP_Presence_Network_Widget_Whos_Online {
 		wp_enqueue_script( 'heartbeat' );
 		wp_add_inline_script( 'heartbeat', self::get_inline_script() );
 
+		wp_presence_enqueue_avatar_stack_style();
+
 		wp_register_style( 'presence-network-widget', false, array(), WP_PRESENCE_VERSION );
 		wp_enqueue_style( 'presence-network-widget' );
 		wp_add_inline_style( 'presence-network-widget', self::get_inline_css() );
@@ -74,10 +76,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 			#presence-network-widget-list .presence-site-info { flex: 1; min-width: 0; }
 			#presence-network-widget-list .presence-site-count { color: #646970; font-size: 12px; }
 			#presence-network-widget-list .presence-more-link { display: block; padding: 6px 12px; color: var(--wp-admin-theme-color, #2271b1); font-size: 13px; text-decoration: none; }
-			#presence-network-widget-list .presence-more-link:hover { text-decoration: underline; }
-			#presence-network-widget-list .presence-avatar-stack { display: inline-flex; align-items: center; }
-			#presence-network-widget-list .presence-avatar-stack img { border-radius: 50%; width: 20px; height: 20px; margin-inline-start: -6px; box-shadow: 0 0 0 2px #fff; position: relative; }
-			#presence-network-widget-list .presence-avatar-stack img:first-child { margin-inline-start: 0; }';
+			#presence-network-widget-list .presence-more-link:hover { text-decoration: underline; }';
 	}
 
 	/**

--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -54,7 +54,12 @@ class WP_Presence_Network_Widget_Whos_Online {
 		}
 
 		wp_enqueue_script( 'heartbeat' );
-		wp_add_inline_script( 'heartbeat', self::get_inline_script() );
+		wp_presence_enqueue_avatar_stack_script();
+
+		// A handle of its own so the inline script can declare what it needs.
+		wp_register_script( 'presence-network-widget', false, array( 'jquery', 'heartbeat', 'wp-presence-avatar-stack' ), WP_PRESENCE_VERSION, true );
+		wp_enqueue_script( 'presence-network-widget' );
+		wp_add_inline_script( 'presence-network-widget', self::get_inline_script() );
 
 		wp_presence_enqueue_avatar_stack_style();
 
@@ -249,18 +254,6 @@ class WP_Presence_Network_Widget_Whos_Online {
 		return el.innerHTML;
 	}
 
-	function buildAvatarStack(users) {
-		var stackMax = Math.min(users.length, avatarMax);
-		var html = '<span class="presence-avatar-stack">';
-		users.slice(0, stackMax).forEach(function(user, idx) {
-			if (user.avatar_url) {
-				html += '<img src="' + esc(user.avatar_url) + '" width="20" height="20" style="z-index:' + (stackMax - idx) + '" alt="' + esc(user.display_name) + '" />';
-			}
-		});
-		html += '</span>';
-		return html;
-	}
-
 	// Already cut to the sites and avatars this widget shows, so nothing is
 	// sliced here; overflow is a count the server sends, not what is left over.
 	function buildListHtml(sites, overflow) {
@@ -270,7 +263,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 
 		var html = '<ul class="presence-user-list">';
 		sites.forEach(function(site) {
-			html += '<li class="presence-site-item">' + buildAvatarStack(site.users);
+			html += '<li class="presence-site-item">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
 			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
 			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
 		});

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -40,6 +40,13 @@ class WP_Presence_Widget_Whos_Online {
 	const IDLE_THRESHOLD = 30;
 
 	/**
+	 * Maximum avatars in the overflow stack.
+	 *
+	 * @var int
+	 */
+	const AVATAR_STACK_MAX = 4;
+
+	/**
 	 * Returns the overflow threshold, filtered for customization.
 	 *
 	 * When the number of overflow users exceeds this value, the widget
@@ -123,10 +130,12 @@ class WP_Presence_Widget_Whos_Online {
 			return;
 		}
 
-		wp_add_inline_script(
-			'heartbeat',
-			self::get_inline_script()
-		);
+		wp_presence_enqueue_avatar_stack_script();
+
+		// A handle of its own so the inline script can declare what it needs.
+		wp_register_script( 'presence-dashboard-widget', false, array( 'jquery', 'heartbeat', 'wp-presence-avatar-stack' ), WP_PRESENCE_VERSION, true );
+		wp_enqueue_script( 'presence-dashboard-widget' );
+		wp_add_inline_script( 'presence-dashboard-widget', self::get_inline_script() );
 
 		wp_presence_enqueue_avatar_stack_style();
 
@@ -302,6 +311,7 @@ class WP_Presence_Widget_Whos_Online {
 	var idleThreshold = %d;
 	var overflowThreshold = %d;
 	var usersUrl = %s;
+	var avatarMax = %d;
 
 	function esc(str) {
 		var el = document.createElement('span');
@@ -397,18 +407,6 @@ class WP_Presence_Widget_Whos_Online {
 		return html;
 	}
 
-	function buildAvatarStack(overflow) {
-		var stackMax = Math.min(overflow.length, 4);
-		var html = '<span class="presence-avatar-stack">';
-		overflow.slice(0, stackMax).forEach(function(entry, idx) {
-			if (entry.avatar_url) {
-				html += '<img src="' + esc(entry.avatar_url) + '" width="24" height="24" style="z-index:' + (stackMax - idx) + '" alt="' + esc(entry.display_name) + '" />';
-			}
-		});
-		html += '</span>';
-		return html;
-	}
-
 	function buildFullHtml(visible, overflow) {
 		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.usersOnline) + '">';
 		visible.forEach(function(entry) {
@@ -419,14 +417,14 @@ class WP_Presence_Widget_Whos_Online {
 			if (overflow.length > overflowThreshold) {
 				// Summary mode: avatar stack + count linking to Users page.
 				html += '<a href="' + esc(usersUrl) + '" class="presence-overflow-toggle">';
-				html += buildAvatarStack(overflow);
+				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
 				html += '<span class="presence-overflow-text">' + esc(i18n.moreCountLink.replace('%%d', overflow.length)) + '</span></a>';
 			} else {
 				// Expandable list mode.
 				html += '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="presence-overflow-list"';
 				if (isExpanded) html += ' style="display:none"';
 				html += '>';
-				html += buildAvatarStack(overflow);
+				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
 				html += '<span class="presence-overflow-text">' + esc(i18n.moreCount.replace('%%d', overflow.length)) + '</span></button>';
 				html += '<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' + esc(i18n.additionalUsers) + '"';
 				if (!isExpanded) html += ' style="display:none"';
@@ -559,6 +557,7 @@ JS,
 			self::IDLE_THRESHOLD,
 			self::get_overflow_threshold(),
 			wp_json_encode( admin_url( 'users.php?presence_status=online' ) ),
+			self::AVATAR_STACK_MAX,
 			self::VISIBLE_ROWS
 		);
 	}
@@ -659,7 +658,7 @@ JS,
 			echo '</ul>';
 
 			if ( ! empty( $overflow ) ) {
-				$stack_max   = min( count( $overflow ), 4 );
+				$stack_max   = min( count( $overflow ), self::AVATAR_STACK_MAX );
 				$stack_users = array();
 
 				foreach ( array_slice( $overflow, 0, $stack_max ) as $oentry ) {
@@ -678,7 +677,7 @@ JS,
 				if ( count( $overflow ) > self::get_overflow_threshold() ) {
 					// Summary mode: avatar stack + count linking to Users page.
 					echo '<a href="' . esc_url( admin_url( 'users.php?presence_status=online' ) ) . '" class="presence-overflow-toggle">';
-					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4 ) );
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, self::AVATAR_STACK_MAX ) );
 					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more — view all users', 'presence-api' ), count( $overflow ) ) );
@@ -686,7 +685,7 @@ JS,
 				} else {
 					// Expandable list mode.
 					echo '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="false" aria-controls="presence-overflow-list">';
-					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4 ) );
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, self::AVATAR_STACK_MAX ) );
 					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more', 'presence-api' ), count( $overflow ) ) );

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -128,6 +128,8 @@ class WP_Presence_Widget_Whos_Online {
 			self::get_inline_script()
 		);
 
+		wp_presence_enqueue_avatar_stack_style();
+
 		wp_register_style( 'presence-dashboard-widget', false, array(), WP_PRESENCE_VERSION );
 		wp_enqueue_style( 'presence-dashboard-widget' );
 		wp_add_inline_style( 'presence-dashboard-widget', self::get_inline_css() );
@@ -154,9 +156,6 @@ class WP_Presence_Widget_Whos_Online {
 			#presence-whos-online-list .presence-overflow-toggle { background: none; border: none; padding: 6px 12px; color: var(--wp-admin-theme-color, #2271b1); font-size: 13px; cursor: pointer; width: 100%; text-align: left; display: flex; align-items: center; gap: 4px; }
 			#presence-whos-online-list .presence-overflow-toggle:hover .presence-overflow-text { text-decoration: underline; }
 			#presence-whos-online-list .presence-overflow-toggle:focus { outline: 2px solid var(--wp-admin-theme-color, #2271b1); outline-offset: -2px; }
-			#presence-whos-online-list .presence-avatar-stack { display: flex; align-items: center; }
-			#presence-whos-online-list .presence-avatar-stack img { border-radius: 50%; width: 20px; height: 20px; margin-inline-start: -6px; box-shadow: 0 0 0 2px #fff; position: relative; }
-			#presence-whos-online-list .presence-avatar-stack img:first-child { margin-inline-start: 0; }
 			#presence-whos-online-list .presence-overflow-expanded { margin: 0; }
 			#presence-whos-online-list .presence-overflow-expanded .presence-user-item:first-child { border-top: 1px solid #f0f0f1; }
 			#presence-whos-online-list .screen-reader-text { border: 0; clip: rect(1px, 1px, 1px, 1px); clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; word-wrap: normal !important; }';
@@ -679,7 +678,7 @@ JS,
 				if ( count( $overflow ) > self::get_overflow_threshold() ) {
 					// Summary mode: avatar stack + count linking to Users page.
 					echo '<a href="' . esc_url( admin_url( 'users.php?presence_status=online' ) ) . '" class="presence-overflow-toggle">';
-					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4, 24 ) );
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4 ) );
 					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more — view all users', 'presence-api' ), count( $overflow ) ) );
@@ -687,7 +686,7 @@ JS,
 				} else {
 					// Expandable list mode.
 					echo '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="false" aria-controls="presence-overflow-list">';
-					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4, 24 ) );
+					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, 4 ) );
 					echo '<span class="presence-overflow-text">';
 					/* translators: %d: Number of additional online users. */
 					echo esc_html( sprintf( __( '+%d more', 'presence-api' ), count( $overflow ) ) );

--- a/presence-api.php
+++ b/presence-api.php
@@ -363,6 +363,7 @@ add_filter( 'heartbeat_received', array( 'WP_Presence_Widget_Active_Posts', 'hea
 if ( is_multisite() ) {
 	add_filter( 'wpmu_blogs_columns', 'wp_presence_register_network_sites_column' );
 	add_action( 'manage_sites_custom_column', 'wp_presence_render_network_sites_column', 10, 2 );
+	add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_network_sites_assets' );
 
 	add_filter( 'views_users-network', 'wp_presence_network_users_views' );
 	add_filter( 'users_list_table_query_args', 'wp_presence_filter_network_online_users' );

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -795,4 +795,34 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		$this->assertSame( 4, substr_count( wp_presence_render_avatar_stack( $users ), '<img ' ) );
 		$this->assertSame( 2, substr_count( wp_presence_render_avatar_stack( $users, 2 ), '<img ' ) );
 	}
+
+	/**
+	 * get_avatar_url() returns false with the Show Avatars setting off, and the
+	 * Heartbeat render skips those users. A src-less <img> here would paint a
+	 * broken avatar until the first tick swept it away.
+	 *
+	 * @covers ::wp_presence_render_avatar_stack
+	 */
+	public function test_avatar_stack_skips_a_user_with_no_avatar() {
+		$html = wp_presence_render_avatar_stack(
+			array(
+				array(
+					'avatar_url'   => '',
+					'display_name' => 'Ana',
+				),
+				array(
+					'avatar_url'   => 'https://example.com/bo.png',
+					'display_name' => 'Bo',
+				),
+				array(
+					'avatar_url'   => false,
+					'display_name' => 'Cyd',
+				),
+			)
+		);
+
+		$this->assertSame( 1, substr_count( $html, '<img ' ) );
+		$this->assertStringNotContainsString( 'Ana', $html );
+		$this->assertStringContainsString( 'z-index:1', $html, 'The z-index counts the avatars drawn, not the users passed in.' );
+	}
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -793,10 +793,6 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		);
 
 		$this->assertSame( 4, substr_count( wp_presence_render_avatar_stack( $users ), '<img ' ) );
-
-		$sized = wp_presence_render_avatar_stack( $users, 2, 24 );
-
-		$this->assertSame( 2, substr_count( $sized, '<img ' ) );
-		$this->assertStringContainsString( 'width="24" height="24"', $sized );
+		$this->assertSame( 2, substr_count( wp_presence_render_avatar_stack( $users, 2 ), '<img ' ) );
 	}
 }

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -57,6 +57,7 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 	 * made it, so the negatives have to come before the positive.
 	 *
 	 * @covers ::wp_presence_enqueue_network_sites_assets
+	 * @covers ::wp_presence_enqueue_avatar_stack_style
 	 */
 	public function test_sites_list_enqueues_the_avatar_stack_style() {
 		wp_presence_enqueue_network_sites_assets( 'sites.php' );

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -50,6 +50,28 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * Without this the avatars paint square, ringless and unoverlapped: no
+	 * other presence asset loads on this screen.
+	 *
+	 * The three cases share one test because an enqueue outlives the test that
+	 * made it, so the negatives have to come before the positive.
+	 *
+	 * @covers ::wp_presence_enqueue_network_sites_assets
+	 */
+	public function test_sites_list_enqueues_the_avatar_stack_style() {
+		wp_presence_enqueue_network_sites_assets( 'sites.php' );
+		$this->assertFalse( wp_style_is( 'wp-presence-avatar-stack', 'enqueued' ), 'A visitor with no capability sees no column to style.' );
+
+		$this->become_network_admin();
+
+		wp_presence_enqueue_network_sites_assets( 'index.php' );
+		$this->assertFalse( wp_style_is( 'wp-presence-avatar-stack', 'enqueued' ), 'Only the Sites list needs it.' );
+
+		wp_presence_enqueue_network_sites_assets( 'sites.php' );
+		$this->assertTrue( wp_style_is( 'wp-presence-avatar-stack', 'enqueued' ) );
+	}
+
+	/**
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
 	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online() {

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -64,6 +64,9 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 	/**
 	 * The widget only exists on the dashboard, so every other admin screen has
 	 * to load without its script or style.
+	 *
+	 * @covers ::wp_presence_enqueue_avatar_stack_style
+	 * @covers ::wp_presence_enqueue_avatar_stack_script
 	 */
 	public function test_scripts_are_only_enqueued_on_the_dashboard() {
 		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'sites.php' );

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -74,6 +74,10 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 
 		$this->assertTrue( wp_script_is( 'heartbeat', 'enqueued' ) );
 		$this->assertTrue( wp_style_is( 'presence-network-widget', 'enqueued' ) );
+
+		// The inline script calls into the shared file, so it has to load first.
+		$this->assertTrue( wp_script_is( 'wp-presence-avatar-stack', 'enqueued' ) );
+		$this->assertContains( 'wp-presence-avatar-stack', wp_scripts()->registered['presence-network-widget']->deps );
 	}
 
 	public function test_heartbeat_ignores_without_ping() {

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -341,6 +341,8 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 	/**
 	 * @covers WP_Presence_Widget_Whos_Online::enqueue_scripts
+	 * @covers ::wp_presence_enqueue_avatar_stack_style
+	 * @covers ::wp_presence_enqueue_avatar_stack_script
 	 */
 	public function test_the_dashboard_gets_the_widget_style_and_heartbeat_script() {
 		WP_Presence_Widget_Whos_Online::enqueue_scripts( 'index.php' );

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -350,8 +350,13 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 		$css = wp_styles()->get_data( 'presence-dashboard-widget', 'after' );
 		$this->assertStringContainsString( '#presence-whos-online-list', implode( '', (array) $css ) );
 
-		$script = implode( '', (array) wp_scripts()->get_data( 'heartbeat', 'after' ) );
+		$script = implode( '', (array) wp_scripts()->get_data( 'presence-dashboard-widget', 'after' ) );
 		$this->assertStringContainsString( 'presence-whos-online-list', $script );
+
+		// The inline script calls into the shared file, so it has to load first.
+		$this->assertTrue( wp_script_is( 'wp-presence-avatar-stack', 'enqueued' ) );
+		$this->assertContains( 'wp-presence-avatar-stack', wp_scripts()->registered['presence-dashboard-widget']->deps );
+		$this->assertContains( 'heartbeat', wp_scripts()->registered['presence-dashboard-widget']->deps );
 	}
 
 	/**


### PR DESCRIPTION
Shared `assets/css/avatar-stack.css` and `assets/js/avatar-stack.js` replace the four inline copies. Each widget's inline script moves off the `heartbeat` handle onto one of its own, so it can declare the shared file as a dependency. `$size` is gone; both callers passed a value the CSS overrode.

The shared renderer is where the server and Heartbeat renders have to agree, which is #331: `wp_presence_render_avatar_stack()` now skips a user with no `avatar_url` instead of emitting `<img src="">`, matching what the widget JS already did.

Separately, nothing enqueued a stylesheet on Network Admin > Sites, so the column added in #335 has been drawing square, ringless avatars. It gets the shared stylesheet now.

| Before | After |
| --- | --- |
| <img width="1078" height="299" alt="sites-column-before" src="https://github.com/user-attachments/assets/d4728489-7c16-4c40-8b80-b6dcc19a699e" /> | <img width="1078" height="299" alt="sites-column-after" src="https://github.com/user-attachments/assets/291c3d84-ca4e-40ef-a1c0-3d70da598569" /> |

Fixes #312
Fixes #331

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Implementation and tests, reviewed and edited by me.

</details>