### PR TITLE
fix: exclude Codecov config and Jest test from release zip

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -18,6 +18,7 @@ blueprint-40.json
 CHANGELOG.md
 README.md
 SECURITY.md
+codecov.yml
 composer.json
 package.json
 package-lock.json
@@ -27,5 +28,6 @@ phpunit.xml.dist
 release-please-config.json
 scripts/
 src/hooks/test/
+src/utils/test/
 includes/db-viewer.php
 includes/debugger-widget.php


### PR DESCRIPTION
Excludes `codecov.yml` and `src/utils/test/` from the distributed plugin ZIP.

Fixes #370

## testing

- Built the distribution using the release workflows `rsync` process.
- Confirmed `codecov.yml` is absent.
- Confirmed `src/utils/test/` is absent.
- Confirmed production files under `src/utils/` and `src/hooks/` remain included.