### PR TITLE
ci: take a docblock, not a README entry, as the bar for a new public surface

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,9 +48,11 @@ Assigned issues left quiet for two weeks may be unassigned. Comment to pick one 
 
 ### Public surfaces
 
-A hook, REST route, WP-CLI command, guarded constant, or browser global that a site can reach is a promise: renaming it later breaks that site. `public-surface.yml` labels any pull request that adds one and comments with what is still missing from `README.md`.
+A hook, REST route, WP-CLI command, guarded constant, or browser global that a site can reach is a promise: renaming it later breaks that site. `public-surface.yml` labels any pull request that adds one and comments with the ones nothing has been written about yet.
 
-Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those `@private` in the docblock directly above, the same marker core uses to keep a symbol out of the code reference, and the check leaves them alone:
+Written about means a docblock directly above it with a sentence saying what it is for. That is where WordPress core's code reference reads from, and it keeps the write-up next to the code instead of in a hand-kept list that drifts the first time someone forgets it. `README.md` narrates the surfaces worth a worked example; it is not the inventory.
+
+Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those `@private` in that same docblock, the marker core uses to keep a symbol out of the code reference, and the check leaves them alone:
 
 ```js
 /**

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,6 +46,21 @@ Assigned issues left quiet for two weeks may be unassigned. Comment to pick one 
 3. All CI checks must pass before merge (PHPCS, PHPStan, PHPUnit across PHP 7.4 + 8.3 plus a multisite run, Playwright).
 4. Keep commits focused, one logical change per commit.
 
+### Public surfaces
+
+A hook, REST route, WP-CLI command, guarded constant, or browser global that a site can reach is a promise: renaming it later breaks that site. `public-surface.yml` labels any pull request that adds one and comments with what is still missing from `README.md`.
+
+Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those `@private` in the docblock directly above, the same marker core uses to keep a symbol out of the code reference, and the check leaves them alone:
+
+```js
+/**
+ * Builds an avatar stack.
+ *
+ * @private
+ */
+window.wpPresenceBuildAvatarStack = function ( users, max ) {};
+```
+
 ### Stacks
 
 A change too large to review in one pass goes in as a stack: each pull request based on the previous one, so each diff is only what that step added. Split where the reviewer's question changes, not every N lines. Nothing beyond git and `gh` is needed.

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -2,7 +2,7 @@
 
 // A hook, route, guarded constant, CLI command, or browser global is a promise:
 // once a site depends on one, renaming it breaks that site. This flags the pull
-// request that adds one and names the README section still missing it.
+// request that adds one and names the ones with nothing written above them.
 //
 // It compares the full set of surfaces at each end rather than diff lines, so
 // moving, reindenting, or renaming the function around a hook reads as no change.
@@ -39,17 +39,6 @@ const JS_RULES = [
 // The workflow greps for this literal to edit its own comment in place.
 const MARKER = '<!-- presence-api:public-surface -->';
 
-// README.md is the only canonical reference for extension points. src/README.md
-// covers the `usePresenceUsers` React hook alone; readme.txt lists no hooks.
-const DOC_FILE = 'README.md';
-const DEFAULT_SECTION = '## Extension Points';
-const DOC_SECTIONS = {
-  filter: '### Filters',
-  action: '### Actions',
-  rest: '## REST API',
-  cli: '## WP-CLI',
-};
-
 function isScanned(path) {
   return !IGNORED.some((re) => re.test(path)) && SCANNED.some((re) => re.test(path));
 }
@@ -59,104 +48,98 @@ function route(raw) {
   return raw.replace(/['"]/g, '').replace(/\s*\.\s*/g, '').replace(/\s+/g, ' ').trim();
 }
 
-// Not every reachable name is a promise. A browser global can exist only so two
-// enqueued scripts can share a renderer, and writing that up as an extension
-// point would freeze markup nobody meant to publish. `@private` is what core
-// uses to keep a symbol out of the code reference, so it is the marker here too.
-//
-// The docblock has to be the one directly above: only the opening of the
-// statement may sit between them, which covers `$ttl = apply_filters( ... )` and
-// `window.x = function () {}` while stopping a `@private` note from leaking onto
-// whatever the next statement happens to be.
-function isPrivate(source, index) {
+// The docblock directly above `index`, or an empty string when the nearest one
+// belongs to something else. Only the opening of the statement may sit between
+// them, which covers `$ttl = apply_filters( ... )` and `window.x = function () {}`
+// while stopping a docblock from leaking onto whatever statement follows the one
+// it describes.
+function docblockAbove(source, index) {
   const before = source.slice(0, index);
   const close = before.lastIndexOf('*/');
 
-  if (-1 === close) {
-    return false;
-  }
-
   // A statement terminator or a brace between the two means the docblock
   // belongs to something else.
-  if (/[;{}]/.test(before.slice(close + 2))) {
-    return false;
+  if (-1 === close || /[;{}]/.test(before.slice(close + 2))) {
+    return '';
   }
 
   const open = before.lastIndexOf('/**', close);
 
-  return -1 !== open && before.slice(open, close).includes('@private');
+  return -1 === open ? '' : before.slice(open, close);
+}
+
+// A docblock of nothing but tags is a signature, not a write-up: the bar is a
+// sentence saying what the surface is for, which is what core's code reference
+// renders. Documenting the hook where it fires beats a hand-kept list, which
+// drifts the first time nobody updates it.
+function describes(block) {
+  return block
+    .replace(/^\/\*\*/, '')
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*+\s*/, '').trim())
+    .some((line) => '' !== line && !line.startsWith('@'));
 }
 
 // Identifiers are `kind:name` and carry no path, so the same hook found at a new
-// location is the same surface.
+// location is the same surface. Each one also reports whether the docblock above
+// it describes it; `@private` in that docblock withdraws the surface entirely.
 function findSurfaces(source, path) {
   const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
 
   return rules.flatMap(([regex, build]) =>
     [...source.matchAll(regex)]
-      .filter((m) => !isPrivate(source, m.index))
-      .map(build)
-      .filter((s) => !s.endsWith(':'))
+      .map((m) => ({ id: build(m), block: docblockAbove(source, m.index) }))
+      .filter(({ id, block }) => !id.endsWith(':') && !block.includes('@private'))
+      .map(({ id, block }) => ({ id, documented: describes(block) }))
   );
 }
 
+// Additions only. A hook fired from two places is documented once and
+// cross-referenced from the other, the way core does it, so one write-up
+// anywhere at the head covers the surface.
 function newSurfaces(base, head) {
-  const before = new Set(base);
-  return [...new Set(head)].filter((s) => !before.has(s)).sort();
+  const before = new Set(base.map((s) => s.id));
+  const fresh = new Map();
+
+  for (const { id, documented } of head) {
+    if (!before.has(id)) {
+      fresh.set(id, documented || Boolean(fresh.get(id)));
+    }
+  }
+
+  return [...fresh]
+    .map(([id, documented]) => ({ id, documented }))
+    .sort((a, b) => a.id.localeCompare(b.id));
 }
 
-// A name appearing anywhere in README.md counts, which is deliberately loose:
-// the bar is writing a hook down at all, not writing it up well.
-function auditSurfaces(surfaces, doc) {
-  return surfaces.map((surface) => {
-    const at = surface.indexOf(':');
-    const kind = surface.slice(0, at);
-    const name = surface.slice(at + 1);
+// The instruction is the same for every entry, so it is given once in the lead
+// sentence and each entry here is just the name and what kind of thing it is.
+function formatAudit(surfaces) {
+  return surfaces
+    .map(({ id, documented }) => {
+      const at = id.indexOf(':');
+      const entry = `- \`${id.slice(at + 1)}\` (${id.slice(0, at)})`;
 
-    return {
-      kind,
-      name,
-      section: DOC_SECTIONS[kind] || DEFAULT_SECTION,
-      // Globals are written `window.x` here but `x` in prose.
-      documented: doc.includes(name.split('.').pop()),
-    };
-  });
-}
-
-// The file is named once in the lead sentence, so an entry only has to say where
-// in it the surface belongs. With nothing missing there is no instruction left to
-// give and each entry is just the name.
-function formatAudit(audit) {
-  const covered = audit.every((s) => s.documented);
-
-  return audit
-    .map(({ kind, name, section, documented }) => {
-      const entry = `- \`${name}\` (${kind})`;
-
-      if (covered) {
-        return entry;
-      }
-
-      return documented ? `${entry}: documented` : `${entry}: add it under \`${section}\``;
+      return documented ? entry : `${entry}: undocumented`;
     })
     .join('\n');
 }
 
 // A heading would open with a rule across the thread for what is usually a
 // one-line note, so the title runs inline and the aside is set small.
-function formatComment(audit) {
-  const one = 1 === audit.length;
-  const headline = audit.every((s) => s.documented)
-    ? `${one ? 'It is' : 'They are'} already in \`${DOC_FILE}\`.`
-    : `Update \`${DOC_FILE}\` before this merges.`;
+function formatComment(surfaces) {
+  const one = 1 === surfaces.length;
+  const headline = surfaces.every((s) => s.documented)
+    ? `${one ? 'It is' : 'They are'} already documented.`
+    : 'Add a docblock above each one saying what it is for.';
 
   return [
     MARKER,
-    `**New public surface.** This branch adds ${audit.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
+    `**New public surface.** This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
     '',
-    formatAudit(audit),
+    formatAudit(surfaces),
     '',
-    '<sub>If the change is user-facing, add it to `readme.txt` under `= For Developers =` too.</sub>',
+    '<sub>Worth a line in `README.md` too, and in `readme.txt` under `= For Developers =` if it is user-facing.</sub>',
     '',
   ].join('\n');
 }
@@ -164,11 +147,9 @@ function formatComment(audit) {
 module.exports = findSurfaces;
 module.exports.findSurfaces = findSurfaces;
 module.exports.newSurfaces = newSurfaces;
-module.exports.auditSurfaces = auditSurfaces;
 module.exports.formatAudit = formatAudit;
 module.exports.formatComment = formatComment;
 module.exports.isScanned = isScanned;
-module.exports.DOC_FILE = DOC_FILE;
 module.exports.MARKER = MARKER;
 
 // CLI: `node detect-public-surface.js <base-ref> <head-ref>`. Reads both trees
@@ -201,19 +182,17 @@ if (require.main === module) {
       .filter(isScanned)
       .flatMap((path) => findSurfaces(read(ref, path), path));
 
-  // README.md is read at the head, so a branch adding a hook and its write-up
-  // together reports the surface as already covered.
-  const audit = auditSurfaces(newSurfaces(scan(baseRef), scan(headRef)), read(headRef, DOC_FILE));
+  const surfaces = newSurfaces(scan(baseRef), scan(headRef));
 
-  if (audit.length) {
-    console.log(`Found ${audit.length} new public ${1 === audit.length ? 'surface' : 'surfaces'}:`);
-    console.log(formatAudit(audit));
-    fs.writeFileSync('comment.md', formatComment(audit));
+  if (surfaces.length) {
+    console.log(`Found ${surfaces.length} new public ${1 === surfaces.length ? 'surface' : 'surfaces'}:`);
+    console.log(formatAudit(surfaces));
+    fs.writeFileSync('comment.md', formatComment(surfaces));
   } else {
     console.log('No new public surfaces.');
   }
 
   if (process.env.GITHUB_OUTPUT) {
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `count=${audit.length}\n`);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `count=${surfaces.length}\n`);
   }
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -59,13 +59,44 @@ function route(raw) {
   return raw.replace(/['"]/g, '').replace(/\s*\.\s*/g, '').replace(/\s+/g, ' ').trim();
 }
 
+// Not every reachable name is a promise. A browser global can exist only so two
+// enqueued scripts can share a renderer, and writing that up as an extension
+// point would freeze markup nobody meant to publish. `@private` is what core
+// uses to keep a symbol out of the code reference, so it is the marker here too.
+//
+// The docblock has to be the one directly above: only the opening of the
+// statement may sit between them, which covers `$ttl = apply_filters( ... )` and
+// `window.x = function () {}` while stopping a `@private` note from leaking onto
+// whatever the next statement happens to be.
+function isPrivate(source, index) {
+  const before = source.slice(0, index);
+  const close = before.lastIndexOf('*/');
+
+  if (-1 === close) {
+    return false;
+  }
+
+  // A statement terminator or a brace between the two means the docblock
+  // belongs to something else.
+  if (/[;{}]/.test(before.slice(close + 2))) {
+    return false;
+  }
+
+  const open = before.lastIndexOf('/**', close);
+
+  return -1 !== open && before.slice(open, close).includes('@private');
+}
+
 // Identifiers are `kind:name` and carry no path, so the same hook found at a new
 // location is the same surface.
 function findSurfaces(source, path) {
   const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
 
   return rules.flatMap(([regex, build]) =>
-    [...source.matchAll(regex)].map(build).filter((s) => !s.endsWith(':'))
+    [...source.matchAll(regex)]
+      .filter((m) => !isPrivate(source, m.index))
+      .map(build)
+      .filter((s) => !s.endsWith(':'))
   );
 }
 

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -92,16 +92,27 @@ function auditSurfaces(surfaces, doc) {
   });
 }
 
+// The file is named once in the lead sentence, so an entry only has to say where
+// in it the surface belongs. With nothing missing there is no instruction left to
+// give and each entry is just the name.
 function formatAudit(audit) {
+  const covered = audit.every((s) => s.documented);
+
   return audit
-    .map(({ kind, name, section, documented }) =>
-      documented
-        ? `- ${kind} \`${name}\`: documented`
-        : `- ${kind} \`${name}\`: **missing from \`${DOC_FILE}\`**, add it under \`${section}\``
-    )
+    .map(({ kind, name, section, documented }) => {
+      const entry = `- \`${name}\` (${kind})`;
+
+      if (covered) {
+        return entry;
+      }
+
+      return documented ? `${entry}: documented` : `${entry}: add it under \`${section}\``;
+    })
     .join('\n');
 }
 
+// A heading would open with a rule across the thread for what is usually a
+// one-line note, so the title runs inline and the aside is set small.
 function formatComment(audit) {
   const one = 1 === audit.length;
   const headline = audit.every((s) => s.documented)
@@ -110,13 +121,11 @@ function formatComment(audit) {
 
   return [
     MARKER,
-    '## New public surface',
-    '',
-    `This branch adds ${audit.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
+    `**New public surface.** This branch adds ${audit.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
     '',
     formatAudit(audit),
     '',
-    'Also update `readme.txt` under `= For Developers =` if the change is user-facing.',
+    '<sub>If the change is user-facing, add it to `readme.txt` under `= For Developers =` too.</sub>',
     '',
   ].join('\n');
 }

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -95,6 +95,42 @@ test('reads wp.hooks calls', () => {
   ]);
 });
 
+// ---------------------------------------------------------------------------
+// @private
+// ---------------------------------------------------------------------------
+
+test('a @private docblock keeps an internal seam out', () => {
+  const source = `/**
+ * Builds an avatar stack.
+ *
+ * @private
+ */
+window.wpPresenceBuildAvatarStack = function ( users, max ) {};`;
+  assert.deepEqual(js(source), []);
+  assert.deepEqual(js(source.replace(' * @private\n', '')), [
+    'js-global:window.wpPresenceBuildAvatarStack',
+  ]);
+});
+
+test('@private applies to the statement it documents, not the next one', () => {
+  const source = `/**
+ * @private
+ */
+window.wpPresenceInternal = function () {};
+window.wpPresencePublic = function () {};`;
+  assert.deepEqual(js(source), ['js-global:window.wpPresencePublic']);
+});
+
+test('@private reads the same above a php hook', () => {
+  const source = `/**
+ * Fires internally.
+ *
+ * @private
+ */
+do_action( 'wp_presence_internal' );`;
+  assert.deepEqual(php(source), []);
+});
+
 test('php rules do not run against a js file, or the reverse', () => {
   assert.deepEqual(js("apply_filters( 'not_php', 1 );"), []);
   assert.deepEqual(php('window.wpPresenceThing = 1;'), []);

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -4,10 +4,12 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const findSurfaces = require('./detect-public-surface.js');
-const { newSurfaces, auditSurfaces, formatAudit, formatComment, isScanned, MARKER } = findSurfaces;
+const { newSurfaces, formatAudit, formatComment, isScanned, MARKER } = findSurfaces;
 
-const php = (source) => findSurfaces(source, 'includes/functions.php');
-const js = (source) => findSurfaces(source, 'assets/js/presence-ping.js');
+const ids = (surfaces) => surfaces.map((s) => s.id);
+const php = (source) => ids(findSurfaces(source, 'includes/functions.php'));
+const js = (source) => ids(findSurfaces(source, 'assets/js/presence-ping.js'));
+const surface = (id, documented = false) => ({ id, documented });
 
 // ---------------------------------------------------------------------------
 // PHP hooks
@@ -95,6 +97,11 @@ test('reads wp.hooks calls', () => {
   ]);
 });
 
+test('php rules do not run against a js file, or the reverse', () => {
+  assert.deepEqual(js("apply_filters( 'not_php', 1 );"), []);
+  assert.deepEqual(php('window.wpPresenceThing = 1;'), []);
+});
+
 // ---------------------------------------------------------------------------
 // @private
 // ---------------------------------------------------------------------------
@@ -131,9 +138,37 @@ do_action( 'wp_presence_internal' );`;
   assert.deepEqual(php(source), []);
 });
 
-test('php rules do not run against a js file, or the reverse', () => {
-  assert.deepEqual(js("apply_filters( 'not_php', 1 );"), []);
-  assert.deepEqual(php('window.wpPresenceThing = 1;'), []);
+// ---------------------------------------------------------------------------
+// The documented bar
+// ---------------------------------------------------------------------------
+
+test('a docblock saying what the hook is for documents it, through the assignment', () => {
+  const [long] = findSurfaces(
+    `/**
+ * Filters the default TTL.
+ *
+ * @since 0.1.0
+ * @param int $ttl Seconds.
+ */
+$ttl = apply_filters( 'wp_presence_default_ttl', 30 );`,
+    'includes/functions.php'
+  );
+  const [short] = findSurfaces(
+    "/** Filters the TTL. */\napply_filters( 'a', 1 );",
+    'includes/functions.php'
+  );
+  assert.equal(long.documented, true);
+  assert.equal(short.documented, true);
+});
+
+test('tags with no sentence are a signature, not a write-up', () => {
+  const [tagged] = findSurfaces(
+    "/**\n * @since 0.1.0\n */\napply_filters( 'a', 1 );",
+    'includes/functions.php'
+  );
+  const [bare] = findSurfaces("apply_filters( 'a', 1 );", 'includes/functions.php');
+  assert.equal(tagged.documented, false);
+  assert.equal(bare.documented, false);
 });
 
 // ---------------------------------------------------------------------------
@@ -148,10 +183,16 @@ test('a hook moved to another file is not new', () => {
 });
 
 test('reports additions, ignores removals, and sorts', () => {
-  assert.deepEqual(newSurfaces(['filter:a', 'action:gone'], ['filter:a', 'filter:c', 'action:b']), [
-    'action:b',
-    'filter:c',
-  ]);
+  const fresh = newSurfaces(
+    [surface('filter:a'), surface('action:gone')],
+    [surface('filter:a'), surface('filter:c'), surface('action:b')]
+  );
+  assert.deepEqual(ids(fresh), ['action:b', 'filter:c']);
+});
+
+test('one write-up covers a hook fired from two places', () => {
+  const [only] = newSurfaces([], [surface('filter:a'), surface('filter:a', true)]);
+  assert.equal(only.documented, true);
 });
 
 // ---------------------------------------------------------------------------
@@ -175,52 +216,16 @@ test('scans shipped code only', () => {
 });
 
 // ---------------------------------------------------------------------------
-// auditSurfaces
-// ---------------------------------------------------------------------------
-
-test('sends each kind to the section that documents it', () => {
-  const audit = auditSurfaces(['filter:a', 'action:b', 'rest:/c', 'cli:d'], '');
-  assert.deepEqual(
-    audit.map((s) => s.section),
-    ['### Filters', '### Actions', '## REST API', '## WP-CLI']
-  );
-});
-
-test('a name already in the README counts as documented', () => {
-  const doc = '### Filters\n#### `wp_presence_default_ttl`\nFilters the TTL.';
-  const [documented, missing] = auditSurfaces(
-    ['filter:wp_presence_default_ttl', 'filter:wp_presence_new_hook'],
-    doc
-  );
-  assert.equal(documented.documented, true);
-  assert.equal(missing.documented, false);
-});
-
-test('a global is matched on its last segment, since prose drops the window prefix', () => {
-  const [surface] = auditSurfaces(
-    ['js-global:wp.presence.markScreenStale'],
-    'Bump the revision from JS via `wp.presence.markScreenStale()`.'
-  );
-  assert.equal(surface.documented, true);
-});
-
-test('splits on the first colon so a namespaced hook name survives', () => {
-  const [surface] = auditSurfaces(['js-filter:presence.entry'], '');
-  assert.equal(surface.name, 'presence.entry');
-});
-
-// ---------------------------------------------------------------------------
 // formatAudit
 // ---------------------------------------------------------------------------
 
-test('names the section for anything undocumented', () => {
-  const report = formatAudit(auditSurfaces(['filter:wp_presence_new_hook'], ''));
-  assert.equal(report, '- `wp_presence_new_hook` (filter): add it under `### Filters`');
+test('marks what is undocumented and leaves the rest bare', () => {
+  const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
+  assert.equal(report, '- `wp_presence_new_hook` (filter): undocumented\n- `b` (action)');
 });
 
-test('drops the per-entry status once everything is documented', () => {
-  const report = formatAudit(auditSurfaces(['filter:a', 'action:b'], 'a b'));
-  assert.equal(report, '- `a` (filter)\n- `b` (action)');
+test('splits on the first colon so a namespaced hook name survives', () => {
+  assert.match(formatAudit([surface('js-filter:presence.entry', true)]), /`presence\.entry` \(js-filter\)/);
 });
 
 // ---------------------------------------------------------------------------
@@ -228,19 +233,19 @@ test('drops the per-entry status once everything is documented', () => {
 // ---------------------------------------------------------------------------
 
 test('leads with the marker so the workflow can find its own comment', () => {
-  assert.ok(formatComment(auditSurfaces(['filter:a'], '')).startsWith(MARKER));
+  assert.ok(formatComment([surface('filter:a')]).startsWith(MARKER));
 });
 
-test('asks for a README update only while something is missing', () => {
-  const missing = formatComment(auditSurfaces(['filter:a'], ''));
-  const covered = formatComment(auditSurfaces(['filter:a'], 'a'));
-  assert.match(missing, /adds 1 extension point that sites can depend on\. Update `README\.md`/);
-  assert.match(covered, /adds 1 extension point that sites can depend on\. It is already in/);
+test('asks for a docblock only while something is undocumented', () => {
+  const missing = formatComment([surface('filter:a')]);
+  const covered = formatComment([surface('filter:a', true)]);
+  assert.match(missing, /adds 1 extension point that sites can depend on\. Add a docblock/);
+  assert.match(covered, /adds 1 extension point that sites can depend on\. It is already documented\./);
   // A heading would rule off the thread; the title carries inline instead.
   assert.doesNotMatch(missing, /^#/m);
 });
 
 test('agrees in number', () => {
-  const two = formatComment(auditSurfaces(['filter:a', 'action:b'], 'a b'));
-  assert.match(two, /adds 2 extension points that sites can depend on\. They are already in/);
+  const two = formatComment([surface('filter:a', true), surface('action:b', true)]);
+  assert.match(two, /adds 2 extension points that sites can depend on\. They are already documented\./);
 });

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -177,12 +177,14 @@ test('splits on the first colon so a namespaced hook name survives', () => {
 // formatAudit
 // ---------------------------------------------------------------------------
 
-test('names the file and section for anything undocumented', () => {
+test('names the section for anything undocumented', () => {
   const report = formatAudit(auditSurfaces(['filter:wp_presence_new_hook'], ''));
-  assert.equal(
-    report,
-    '- filter `wp_presence_new_hook`: **missing from `README.md`**, add it under `### Filters`'
-  );
+  assert.equal(report, '- `wp_presence_new_hook` (filter): add it under `### Filters`');
+});
+
+test('drops the per-entry status once everything is documented', () => {
+  const report = formatAudit(auditSurfaces(['filter:a', 'action:b'], 'a b'));
+  assert.equal(report, '- `a` (filter)\n- `b` (action)');
 });
 
 // ---------------------------------------------------------------------------
@@ -198,6 +200,8 @@ test('asks for a README update only while something is missing', () => {
   const covered = formatComment(auditSurfaces(['filter:a'], 'a'));
   assert.match(missing, /adds 1 extension point that sites can depend on\. Update `README\.md`/);
   assert.match(covered, /adds 1 extension point that sites can depend on\. It is already in/);
+  // A heading would rule off the thread; the title carries inline instead.
+  assert.doesNotMatch(missing, /^#/m);
 });
 
 test('agrees in number', () => {


### PR DESCRIPTION
#373 showed the bar was wrong: it asked for a README entry on a global that only exists so two of the plugin's own inline scripts can share a renderer.

Related: #373

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the check's rewrite and its tests.

</details>