### PR TITLE
fix: require manage_options to reach the debugger widget

### DIFF
--- a/includes/debugger-widget.php
+++ b/includes/debugger-widget.php
@@ -11,8 +11,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Registers the Heartbeat dashboard widget.
+ *
+ * Hiding it by default is not a permission: Screen Options undoes that.
  */
 function wp_presence_heartbeat_widget_register() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
 	wp_add_dashboard_widget(
 		'presence_heartbeat',
 		__( 'Presence API Debugger', 'presence-api' ),
@@ -90,13 +96,15 @@ function wp_presence_heartbeat_widget_render() {
  * Returns the site-wide presence summary so the widget can update
  * its user and room counts on each tick.
  *
+ * Checked again here because Heartbeat does not run through the registration.
+ *
  * @param array  $response  The Heartbeat response.
  * @param array  $data      The $_POST data sent.
  * @param string $screen_id The screen ID.
  * @return array The Heartbeat response.
  */
 function wp_presence_heartbeat_widget_received( $response, $data, $screen_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by filter signature.
-	if ( empty( $data['presence-ping'] ) ) {
+	if ( empty( $data['presence-ping'] ) || ! current_user_can( 'manage_options' ) ) {
 		return $response;
 	}
 

--- a/tests/test-debugger-widget.php
+++ b/tests/test-debugger-widget.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Tests for the Presence API Debugger dashboard widget's capability bar.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ */
+
+// The plugin loads this only under WP_DEBUG, which the suite does not set.
+require_once WP_PRESENCE_PLUGIN_DIR . 'includes/debugger-widget.php';
+
+class WP_Test_Presence_Debugger_Widget extends WP_Presence_UnitTestCase {
+
+	/**
+	 * @covers ::wp_presence_heartbeat_widget_received
+	 */
+	public function test_heartbeat_says_nothing_to_a_subscriber() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = wp_presence_heartbeat_widget_received( array(), array( 'presence-ping' => 1 ), 'dashboard' );
+
+		$this->assertSame( array(), $response, 'A subscriber sending the ping key should learn nothing about the site.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_heartbeat_widget_received
+	 */
+	public function test_heartbeat_answers_an_administrator() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$response = wp_presence_heartbeat_widget_received( array(), array( 'presence-ping' => 1 ), 'dashboard' );
+
+		$this->assertArrayHasKey( 'presence-heartbeat-users', $response );
+	}
+
+	/**
+	 * @covers ::wp_presence_heartbeat_widget_register
+	 */
+	public function test_the_widget_is_registered_for_administrators_only() {
+		global $wp_meta_boxes;
+
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		set_current_screen( 'dashboard' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		$wp_meta_boxes = array();
+		wp_presence_heartbeat_widget_register();
+
+		$this->assertSame( array(), $wp_meta_boxes, 'A subscriber should get no widget.' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$wp_meta_boxes = array();
+		wp_presence_heartbeat_widget_register();
+
+		// Across the whole screen: core is free to normalise context and priority.
+		$registered = array();
+		foreach ( $wp_meta_boxes['dashboard'] as $context ) {
+			foreach ( $context as $priority ) {
+				$registered = array_merge( $registered, array_keys( $priority ) );
+			}
+		}
+
+		$this->assertContains( 'presence_heartbeat', $registered );
+	}
+}


### PR DESCRIPTION
The sibling developer tool at `includes/db-viewer.php:22` already checks `manage_options`, so the debugger widget was the odd one out among its own peers.

Fixes #363

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the capability checks and their tests.

</details>
