### PR TITLE
ci: offer a multisite variant of the Playground preview

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,6 +15,7 @@ artifacts
 build
 blueprint.json
 blueprint-40.json
+blueprint-multisite.json
 CHANGELOG.md
 README.md
 SECURITY.md

--- a/.github/workflows/playground-main-build.yml
+++ b/.github/workflows/playground-main-build.yml
@@ -1,0 +1,73 @@
+name: Playground Main Build
+
+# Builds `presence-api.zip` from `main` and force-pushes it to the
+# `preview-main` branch, which is what the repo's blueprints install.
+# Without this they would install the last wordpress.org release, so the
+# README badge would boot older code than the repo it sits in.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+      - 'tests/**'
+  workflow_dispatch:
+
+# Queued, not cancelled: the last push to finish is the one that wins.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.3'
+
+      - name: Build presence-api.zip
+        run: |
+          set -euo pipefail
+          mkdir -p build/presence-api
+          rsync -a --exclude-from='.distignore' --exclude='build' ./ build/presence-api/
+          (cd build && zip -qr presence-api.zip presence-api/)
+
+      # Same guard as the PR preview: a `.distignore` that drifts out of
+      # sync with the `require_once` graph installs fine and then fatals.
+      - name: Smoke-test the build
+        run: |
+          set -euo pipefail
+          test -f build/presence-api/presence-api.php
+          find build/presence-api -name '*.php' -print0 \
+            | xargs -0 -n1 -P 4 php -l > /dev/null
+
+      - name: Publish to the preview-main branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Force-pushed from a throwaway repo so no zip reaches the history
+          # everyone clones. The path is fixed because the blueprints commit
+          # to it; raw serves it with a five-minute cache.
+          mkdir -p preview
+          cp build/presence-api.zip preview/
+
+          cd preview
+          git init -q -b preview-main
+          git add -A
+          git -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -qm "Playground build of ${SHA}"
+          git push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" preview-main

--- a/.github/workflows/playground-preview-cleanup.yml
+++ b/.github/workflows/playground-preview-cleanup.yml
@@ -1,10 +1,10 @@
 name: Playground Preview Cleanup
 
-# Deletes the per-PR preview release + tag when a PR is closed.
+# Deletes the per-PR preview branch when a PR is closed.
 #
 # Uses `pull_request_target` so cleanup also fires for PRs from forks
 # (the token from `pull_request: closed` is read-only on forks). This
-# workflow never checks out PR code and only calls the release API
+# workflow never checks out PR code and only calls the git ref API
 # with values from the GitHub event payload, so `pull_request_target`
 # is safe here.
 
@@ -20,14 +20,15 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     steps:
-      - name: Delete preview release and tag
+      - name: Delete preview branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          TAG="preview-pr-${PR_NUMBER}"
-          # Tolerate "release not found" — the build may have failed or
-          # been skipped, leaving nothing to clean up.
-          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          NAME="preview-pr-${PR_NUMBER}"
+          # Tolerate "not found": the build may never have run. The release
+          # delete is for PRs opened before previews moved off Releases.
+          gh api --method DELETE "repos/${GH_REPO}/git/refs/heads/${NAME}" --silent 2>/dev/null || true
+          gh release delete "$NAME" --yes --cleanup-tag 2>/dev/null || true

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -159,12 +159,14 @@ jobs:
 
           BLUEPRINT=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint.json)
           BLUEPRINT_40=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint-40.json)
+          BLUEPRINT_MS=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint-multisite.json)
 
           encode() { printf '%s' "$1" | base64 -w0; }
 
           {
             echo "url=https://playground.wordpress.net/#$(encode "$BLUEPRINT")"
             echo "url_40=https://playground.wordpress.net/#$(encode "$BLUEPRINT_40")"
+            echo "url_multisite=https://playground.wordpress.net/#$(encode "$BLUEPRINT_MS")"
           } >> "$GITHUB_OUTPUT"
 
       - name: Post or update sticky comment
@@ -174,22 +176,26 @@ jobs:
           HEAD_SHA: ${{ env.HEAD_SHA }}
           PLAYGROUND_URL: ${{ steps.playground.outputs.url }}
           PLAYGROUND_URL_40: ${{ steps.playground.outputs.url_40 }}
+          PLAYGROUND_URL_MULTISITE: ${{ steps.playground.outputs.url_multisite }}
         with:
           script: |
             const marker = '<!-- presence-api:playground-preview -->';
             const url = process.env.PLAYGROUND_URL;
             const url40 = process.env.PLAYGROUND_URL_40;
+            const urlMultisite = process.env.PLAYGROUND_URL_MULTISITE;
             const sha = process.env.HEAD_SHA;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const badge = 'https://img.shields.io/badge/Open%20in-WordPress%20Playground-3858E9?logo=wordpress&logoColor=white';
+            // Two-part shields badge: grey "Playground" label, blue variant.
+            const badge = (variant) =>
+              `https://img.shields.io/badge/Playground-${variant}-3858E9?logo=wordpress&logoColor=white`;
 
             const body = [
               marker,
               '## ▶ Preview in WordPress Playground',
               '',
-              `[![Open in WordPress Playground](${badge})](${url})`,
+              `[![Single site](${badge('Single%20site')})](${url}) [![Multisite network](${badge('Multisite%20network')})](${urlMultisite})`,
               '',
-              "Boots a fresh WordPress with this PR's presence-api build, seeds 5 demo users, and drops you on the dashboard.",
+              "Both boot a fresh WordPress with this PR's presence-api build and log you in. Single site seeds 5 demo users and lands on the dashboard. Multisite network adds three sub-sites alongside the main one, seeds 5 users on each, and lands on Network Admin.",
               '',
               `<sub>Stress-test variant: [40 demo users](${url40}) · Built from \`${sha}\`. Auto-updates when you push.</sub>`,
             ].join('\n');

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -2,18 +2,18 @@ name: Playground Preview Publish
 
 # Runs in the base-repo context (via `workflow_run`) so it has write
 # access even for PRs from forks. Downloads the build artifacts from
-# the triggering workflow, publishes them as a prerelease, and posts
-# (or updates) the sticky Playground comment on the PR.
+# the triggering workflow, pushes them to a per-PR `preview-pr-N`
+# branch that raw.githubusercontent.com can serve to the browser, and
+# posts (or updates) the sticky Playground comment on the PR.
 #
 # Security model: every PR-derived input is untrusted.
 #   - `pr-meta.json` is parsed with jq and regex-validated; we never
 #     `source` it as shell.
 #   - The blueprint templates we encode into Playground URLs come from
-#     the base ref (this checkout), not from the PR — only the plugin
-#     and seeder URLs are rewritten in, and both point exclusively at
-#     github.com/${{ github.repository }} under our control, so a fork
-#     PR cannot direct Playground at attacker-controlled URLs through
-#     this workflow.
+#     the base ref (this checkout), not from the PR. Only the asset URLs
+#     are rewritten in, and every one points at ${{ github.repository }},
+#     so a fork PR cannot redirect Playground.
+#   - Nothing reads `preview-pr-*`, so the branch is never executed.
 
 on:
   workflow_run: # zizmor: ignore[dangerous-triggers]
@@ -109,23 +109,30 @@ jobs:
             echo "HEAD_SHA=$TRUSTED_HEAD_SHA"
           } >> "$GITHUB_ENV"
 
-      - name: Publish prerelease (replaces any prior preview for this PR)
+      # Playground fetches these from the browser. Release assets send no
+      # `Access-Control-Allow-Origin`; raw.githubusercontent.com does.
+      - name: Publish preview assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          TAG="preview-pr-${PR_NUMBER}"
-          # Drop any prior release+tag for this PR so we always serve the
-          # latest preview from a stable URL. Tolerate first-time absence.
-          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
-          gh release create "$TAG" \
-            artifacts/release-assets/presence-api.zip \
-            artifacts/release-assets/demo-seeder.php \
-            artifacts/release-assets/screen-stale-demo-helper.php \
-            --prerelease \
-            --target "$HEAD_SHA" \
-            --title "PR #${PR_NUMBER} preview" \
-            --notes "Auto-built from \`${HEAD_SHA}\` for PR #${PR_NUMBER}. Deleted on PR close."
+          BRANCH="preview-pr-${PR_NUMBER}"
+
+          # Force-pushed from a throwaway repo, so no preview blob reaches the
+          # history everyone clones. The SHA is a path component because raw
+          # caches by path.
+          mkdir -p "preview/${HEAD_SHA}"
+          cp artifacts/release-assets/* "preview/${HEAD_SHA}/"
+
+          cd preview
+          git init -q -b "$BRANCH"
+          git add -A
+          git -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -qm "Playground preview for PR #${PR_NUMBER} at ${HEAD_SHA}"
+          git push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" "$BRANCH"
 
       - name: Assemble Playground URLs from base-ref blueprints
         id: playground
@@ -133,12 +140,21 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          TAG="preview-pr-${PR_NUMBER}"
-          # Both URLs resolve to github.com/${REPO} — never to the PR's
-          # head repository — so a fork PR cannot redirect Playground.
-          PLUGIN_URL="https://github.com/${REPO}/releases/download/${TAG}/presence-api.zip"
-          SEEDER_URL="https://github.com/${REPO}/releases/download/${TAG}/demo-seeder.php"
-          HELPER_URL="https://github.com/${REPO}/releases/download/${TAG}/screen-stale-demo-helper.php"
+          # Always the base repository, never the PR's head repository.
+          RAW="https://raw.githubusercontent.com/${REPO}/preview-pr-${PR_NUMBER}/${HEAD_SHA}"
+          PLUGIN_URL="${RAW}/presence-api.zip"
+          SEEDER_URL="${RAW}/demo-seeder.php"
+          HELPER_URL="${RAW}/screen-stale-demo-helper.php"
+
+          # raw's CDN can lag the push by a few seconds.
+          for _ in $(seq 30); do
+            if curl -sf -o /dev/null "$PLUGIN_URL"; then
+              break
+            fi
+            sleep 2
+          done
+          curl -sf -o /dev/null "$PLUGIN_URL" \
+            || { echo "Preview assets never appeared at $PLUGIN_URL"; exit 1; }
 
           # writeFile steps are matched by trailing path component so the
           # seeder and helper get distinct URLs without depending on the
@@ -185,7 +201,6 @@ jobs:
             const urlMultisite = process.env.PLAYGROUND_URL_MULTISITE;
             const sha = process.env.HEAD_SHA;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            // Two-part shields badge: grey "Playground" label, blue variant.
             const badge = (variant) =>
               `https://img.shields.io/badge/Playground-${variant}-3858E9?logo=wordpress&logoColor=white`;
 

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -3,8 +3,8 @@ name: Playground Preview
 # Builds `presence-api.zip` from the PR commit and uploads it (plus the
 # demo seeder and a small metadata file) as workflow artifacts. The
 # sibling `Playground Preview Publish` workflow picks the artifacts up
-# on `workflow_run` and hands them to GitHub Releases for hosting — we
-# don't depend on any third-party artifact proxy.
+# on `workflow_run` and hosts them, so a preview always shows the PR's
+# own build at its latest commit.
 
 on:
   pull_request:

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -77,7 +77,7 @@ jobs:
           for f in blueprint.json blueprint-40.json blueprint-multisite.json; do
             jq -e '
               (.steps | length > 0)
-              and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP", "enableMultisite")))
+              and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP", "enableMultisite", "wp-cli")))
               and (.steps | map(select(.step == "installPlugin" and (.pluginData.resource // "") == "url")) | length == 1)
               and (.steps | map(select(.step == "writeFile" and (.data.resource // "") == "url")) | length == 2)
             ' "$f" > /dev/null

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -74,10 +74,10 @@ jobs:
       - name: Schema-validate blueprints
         run: |
           set -euo pipefail
-          for f in blueprint.json blueprint-40.json; do
+          for f in blueprint.json blueprint-40.json blueprint-multisite.json; do
             jq -e '
               (.steps | length > 0)
-              and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP")))
+              and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP", "enableMultisite")))
               and (.steps | map(select(.step == "installPlugin" and (.pluginData.resource // "") == "url")) | length == 1)
               and (.steps | map(select(.step == "writeFile" and (.data.resource // "") == "url")) | length == 2)
             ' "$f" > /dev/null

--- a/blueprint-40.json
+++ b/blueprint-40.json
@@ -10,7 +10,7 @@
 			"step": "installPlugin",
 			"pluginData": {
 				"resource": "url",
-				"url": "https://downloads.wordpress.org/plugin/presence-api.latest-stable.zip"
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/preview-main/presence-api.zip"
 			}
 		},
 		{

--- a/blueprint-40.json
+++ b/blueprint-40.json
@@ -10,7 +10,7 @@
 			"step": "installPlugin",
 			"pluginData": {
 				"resource": "url",
-				"url": "https://github.com/WordPress/presence-api/releases/latest/download/presence-api.zip"
+				"url": "https://downloads.wordpress.org/plugin/presence-api.latest-stable.zip"
 			}
 		},
 		{

--- a/blueprint-multisite.json
+++ b/blueprint-multisite.json
@@ -3,9 +3,12 @@
 		"php": "8.3",
 		"wp": "latest"
 	},
-	"landingPage": "/wp-admin/",
+	"landingPage": "/wp-admin/network/",
 	"login": true,
 	"steps": [
+		{
+			"step": "enableMultisite"
+		},
 		{
 			"step": "installPlugin",
 			"pluginData": {
@@ -31,7 +34,7 @@
 		},
 		{
 			"step": "runPHP",
-			"code": "<?php require '/wordpress/wp-load.php'; require '/wordpress/wp-content/plugins/presence-api/demo-seeder.php'; wp_presence_demo_seed( 40 ); update_user_meta( 1, 'show_welcome_panel', 0 ); update_user_meta( 1, 'meta-box-order_dashboard', array( 'normal' => 'presence_whos_online,presence_active_posts,dashboard_right_now,dashboard_activity', 'side' => 'dashboard_quick_press,dashboard_primary' ) ); ?>"
+			"code": "<?php require '/wordpress/wp-load.php'; require_once ABSPATH . 'wp-admin/includes/plugin.php'; activate_plugin( 'presence-api/presence-api.php', '', true ); $domain = parse_url( get_option( 'siteurl' ), PHP_URL_HOST ); wpmu_create_blog( $domain, '/engineering/', 'Engineering', 1 ); wpmu_create_blog( $domain, '/marketing/', 'Marketing', 1 ); wpmu_create_blog( $domain, '/design/', 'Design', 1 ); require '/wordpress/wp-content/plugins/presence-api/demo-seeder.php'; foreach ( get_sites( array( 'number' => 100 ) ) as $site ) { switch_to_blog( $site->blog_id ); wp_presence_demo_seed( 5 ); restore_current_blog(); } update_user_meta( 1, 'show_welcome_panel', 0 ); ?>"
 		}
 	]
 }

--- a/blueprint-multisite.json
+++ b/blueprint-multisite.json
@@ -13,7 +13,7 @@
 			"step": "installPlugin",
 			"pluginData": {
 				"resource": "url",
-				"url": "https://downloads.wordpress.org/plugin/presence-api.latest-stable.zip"
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/preview-main/presence-api.zip"
 			},
 			"options": {
 				"activate": false

--- a/blueprint-multisite.json
+++ b/blueprint-multisite.json
@@ -13,7 +13,10 @@
 			"step": "installPlugin",
 			"pluginData": {
 				"resource": "url",
-				"url": "https://github.com/WordPress/presence-api/releases/latest/download/presence-api.zip"
+				"url": "https://downloads.wordpress.org/plugin/presence-api.latest-stable.zip"
+			},
+			"options": {
+				"activate": false
 			}
 		},
 		{
@@ -33,8 +36,24 @@
 			}
 		},
 		{
-			"step": "runPHP",
-			"code": "<?php require '/wordpress/wp-load.php'; require_once ABSPATH . 'wp-admin/includes/plugin.php'; activate_plugin( 'presence-api/presence-api.php', '', true ); $domain = parse_url( get_option( 'siteurl' ), PHP_URL_HOST ); wpmu_create_blog( $domain, '/engineering/', 'Engineering', 1 ); wpmu_create_blog( $domain, '/marketing/', 'Marketing', 1 ); wpmu_create_blog( $domain, '/design/', 'Design', 1 ); require '/wordpress/wp-content/plugins/presence-api/demo-seeder.php'; foreach ( get_sites( array( 'number' => 100 ) ) as $site ) { switch_to_blog( $site->blog_id ); wp_presence_demo_seed( 5 ); restore_current_blog(); } update_user_meta( 1, 'show_welcome_panel', 0 ); ?>"
+			"step": "wp-cli",
+			"command": "wp plugin activate presence-api --network"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp site create --slug=engineering --title=Engineering"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp site create --slug=marketing --title=Marketing"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp site create --slug=design --title=Design"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp eval 'require \"/wordpress/wp-content/plugins/presence-api/demo-seeder.php\"; foreach ( get_sites( array( \"number\" => 100 ) ) as $site ) { $blog_id = (int) $site->blog_id; switch_to_blog( $blog_id ); foreach ( wp_presence_demo_seed( 5 ) as $user_id ) { add_user_to_blog( $blog_id, $user_id, \"editor\" ); } restore_current_blog(); } update_user_meta( 1, \"show_welcome_panel\", 0 );'"
 		}
 	]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -10,7 +10,7 @@
 			"step": "installPlugin",
 			"pluginData": {
 				"resource": "url",
-				"url": "https://downloads.wordpress.org/plugin/presence-api.latest-stable.zip"
+				"url": "https://raw.githubusercontent.com/WordPress/presence-api/preview-main/presence-api.zip"
 			}
 		},
 		{

--- a/blueprint.json
+++ b/blueprint.json
@@ -10,7 +10,7 @@
 			"step": "installPlugin",
 			"pluginData": {
 				"resource": "url",
-				"url": "https://github.com/WordPress/presence-api/releases/latest/download/presence-api.zip"
+				"url": "https://downloads.wordpress.org/plugin/presence-api.latest-stable.zip"
 			}
 		},
 		{

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,5 +1,6 @@
 {
 	"preferredVersions": {
+		"php": "8.3",
 		"wp": "latest"
 	},
 	"landingPage": "/wp-admin/",

--- a/readme.txt
+++ b/readme.txt
@@ -17,8 +17,6 @@ Presence API gives WordPress a system-wide awareness layer. It tracks which user
 
 Data flows through the Heartbeat API and is stored in a dedicated `wp_presence` table with a 60-second TTL. No writes to `wp_postmeta` means no post-cache invalidation on every heartbeat.
 
-[Test in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json) without installing anything.
-
 = Features =
 
 * Who's Online dashboard widget with idle detection
@@ -44,8 +42,6 @@ Or install manually:
 
 1. Download the zip and upload the `presence-api` folder to `/wp-content/plugins/`.
 2. Activate through the **Plugins** menu.
-
-Or [try it in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json) without installing anything.
 
 == Changelog ==
 


### PR DESCRIPTION
Every Playground preview link this repo has posted was dead: GitHub release assets send no `access-control-allow-origin`, so the browser refused the fetch.

Related: #286

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the blueprints and the preview workflows.

</details>
