### PR TITLE
docs: describe the network presence features in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,8 @@ Presence API gives WordPress a system-wide awareness layer. It tracks which user
 
 Data flows through the Heartbeat API and is stored in a dedicated `wp_presence` table with a 60-second TTL. No writes to `wp_postmeta` means no post-cache invalidation on every heartbeat.
 
+On a multisite network, Network Admin gets its own view of the same data: a Who's Online dashboard widget listing the busiest sites and who is on each, an Online column in the Sites list, and an Online view, filter, and column in the Users list. These require the `manage_network` capability.
+
 [Test in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json) without installing anything.
 
 = Features =
@@ -46,6 +48,16 @@ Or install manually:
 2. Activate through the **Plugins** menu.
 
 Or [try it in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/WordPress/presence-api/main/blueprint.json) without installing anything.
+
+== Frequently Asked Questions ==
+
+= Does it work on multisite? =
+
+Yes. Network-activate it and Network Admin gains a Who's Online dashboard widget listing the busiest sites and who is on each, an Online column in the Sites list, and an Online view, filter, and column in the Users list. Every site keeps its own widgets and lists, counting only the people on that site.
+
+= Who can see network-wide presence? =
+
+Anyone with the `manage_network` capability, which on a default network means super admins. The `wp_presence_network_capability` filter changes what is required.
 
 == Changelog ==
 


### PR DESCRIPTION
The description and FAQ are what a .org visitor reads before installing, and neither said the network features exist.

Fixes #353

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the readme.txt copy.

</details>
