### PR TITLE
fix: outlast core's unfocused heartbeat interval in the presence TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ System-wide presence and awareness for WordPress.
 
 ## Problem
 
-WordPress has no way to know who is logged in, what screen they are on, or which posts are being edited — without writing to shared tables like `wp_postmeta` or `wp_options`. High-frequency writes to those tables invalidate caches site-wide ([#64696](https://core.trac.wordpress.org/ticket/64696)). This plugin uses a dedicated `wp_presence` table with a 60-second TTL to provide that awareness with zero cache side effects.
+WordPress has no way to know who is logged in, what screen they are on, or which posts are being edited — without writing to shared tables like `wp_postmeta` or `wp_options`. High-frequency writes to those tables invalidate caches site-wide ([#64696](https://core.trac.wordpress.org/ticket/64696)). This plugin uses a dedicated `wp_presence` table with a 150-second TTL to provide that awareness with zero cache side effects.
 
 > "This idea of presence I think is really cool and seeing where people are... you log into your WordPress, I see oh Matias is moderating some comments, Lynn is on the dashboard maybe reading some news... that idea of like you log in and you can kind of see the neighborhood of like who else is also there." — [Matt Mullenweg, WordPress 7.0 planning session](https://youtu.be/F-xMPY9WqG4?si=YK0rIUM2nuYy7x45&t=2435)
 
@@ -84,16 +84,18 @@ Without support, `wp_presence_post_room()` returns `false` for that post type an
 
 ### Filters
 #### `wp_presence_default_ttl`
-Filters the presence TTL (time-to-live) in seconds used for all queries and cleanup. Default: 60.
+Filters the presence TTL (time-to-live) in seconds used for all queries and cleanup. Default: 150.
+
+Values under 120 drop a tab that is still open and still pinging, since that is the Heartbeat interval core gives an unfocused or five-minute-idle tab.
 ```php
 add_filter( 'wp_presence_default_ttl', function( $timeout ) {
-    return 30; // Override TTL to 30 seconds.
+    return 300; // Override TTL to 5 minutes.
 } );
 ```
 
 Or define the constant before the plugin loads:
 ```php
-define( 'WP_PRESENCE_DEFAULT_TTL', 30 );
+define( 'WP_PRESENCE_DEFAULT_TTL', 300 );
 ```
 
 #### `wp_presence_current_screen_key`

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -11,7 +11,7 @@
 	const nonce = config.nonce || '';
 	const idleTicks = parseInt(config.idleTicks, 10) || 0;
 	const idleInterval = parseInt(config.idleInterval, 10) || 0;
-	const ttl = parseInt(config.ttl, 10) || 60;
+	const ttl = parseInt(config.ttl, 10) || 150;
 	const backoffEnabled = idleTicks > 0 && idleInterval > 0;
 	const TTL_SAFETY_MARGIN = 15;
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -296,7 +296,7 @@ function wp_presence_get_timeout( $timeout ) {
 	/**
 	 * Filters the presence TTL (time-to-live) used for queries and cleanup.
 	 *
-	 * @param int $timeout The timeout in seconds. Default WP_PRESENCE_DEFAULT_TTL (60).
+	 * @param int $timeout The timeout in seconds. Default WP_PRESENCE_DEFAULT_TTL (150).
 	 */
 	return (int) apply_filters( 'wp_presence_default_ttl', $timeout );
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -56,8 +56,11 @@ define( 'WP_PRESENCE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 // two distinct clients onto one UNIQUE KEY (room, client_id) row.
 define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );
 
+// Core pins an unfocused, or five-minute-idle, tab to a 120-second Heartbeat
+// interval that no client-side call can shorten, so a shorter TTL drops a tab
+// that is still open and still pinging. Core sizes post locks at 150 the same way.
 if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
-	define( 'WP_PRESENCE_DEFAULT_TTL', 60 );
+	define( 'WP_PRESENCE_DEFAULT_TTL', 150 );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ System-wide presence and awareness for WordPress.
 
 Presence API gives WordPress a system-wide awareness layer. It tracks which users are logged in, which admin screen they are on, and which posts they are editing.
 
-Data flows through the Heartbeat API and is stored in a dedicated `wp_presence` table with a 60-second TTL. No writes to `wp_postmeta` means no post-cache invalidation on every heartbeat.
+Data flows through the Heartbeat API and is stored in a dedicated `wp_presence` table with a 150-second TTL. No writes to `wp_postmeta` means no post-cache invalidation on every heartbeat.
 
 On a multisite network, Network Admin gets its own view of the same data: a Who's Online dashboard widget listing the busiest sites and who is on each, an Online column in the Sites list, and an Online view, filter, and column in the Users list. These require the `manage_network` capability.
 

--- a/tests/e2e/presence-heartbeat-backoff.test.js
+++ b/tests/e2e/presence-heartbeat-backoff.test.js
@@ -104,7 +104,9 @@ test.describe( 'Presence Heartbeat Idle Backoff', () => {
 		expect( widened ).toBe( true );
 		const widenedInterval = await page.evaluate( () => wp.heartbeat.interval() );
 		expect( widenedInterval ).toBeGreaterThan( normalInterval );
-		expect( widenedInterval ).toBeLessThan( 60 ); // Stays under the presence TTL.
+		// The idle interval is itself under the TTL.
+		const idleInterval = await page.evaluate( () => window.wpPresenceConfig.idleInterval );
+		expect( widenedInterval ).toBeLessThanOrEqual( idleInterval );
 
 		await page.evaluate( () => {
 			document.dispatchEvent( new KeyboardEvent( 'keydown', { bubbles: true } ) );

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -219,10 +219,10 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		wp_set_presence( 'test/room', 'old-client', array(), self::$editor_id );
 		wp_set_presence( 'test/room', 'new-client', array(), self::$editor_id );
 
-		// Backdate one entry.
+		// Backdate one entry past the cutoff the cleanup reads.
 		$wpdb->update(
 			$wpdb->presence,
-			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 120 ) ),
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - WP_PRESENCE_DEFAULT_TTL - MINUTE_IN_SECONDS ) ),
 			array( 'client_id' => 'old-client' ),
 			array( '%s' ),
 			array( '%s' )
@@ -252,7 +252,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		$wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->presence} SET date_gmt = %s",
-				gmdate( 'Y-m-d H:i:s', time() - 120 )
+				gmdate( 'Y-m-d H:i:s', time() - WP_PRESENCE_DEFAULT_TTL - MINUTE_IN_SECONDS )
 			)
 		);
 
@@ -585,27 +585,25 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 	 * @covers ::wp_presence_get_timeout
 	 */
 	public function test_ttl_filter() {
-		add_filter( 'wp_presence_default_ttl', function () {
-			return 120;
-		} );
+		add_filter( 'wp_presence_default_ttl', fn() => WP_PRESENCE_DEFAULT_TTL * 2 );
 
 		wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
 
-		// Backdate entry to 90 seconds ago — beyond default 60s but within filtered 120s.
+		// Beyond the default cutoff, within the filtered one.
 		global $wpdb;
 		$wpdb->update(
 			$wpdb->presence,
-			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 90 ) ),
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - WP_PRESENCE_DEFAULT_TTL - 30 ) ),
 			array( 'room' => 'test/room', 'client_id' => 'client-1' )
 		);
 
 		$entries = wp_get_presence( 'test/room' );
-		$this->assertCount( 1, $entries, 'Entry should be visible with filtered 120s TTL.' );
+		$this->assertCount( 1, $entries, 'Entry should be visible with the filtered TTL.' );
 
 		remove_all_filters( 'wp_presence_default_ttl' );
 
 		$entries = wp_get_presence( 'test/room' );
-		$this->assertCount( 0, $entries, 'Entry should be expired with default 60s TTL.' );
+		$this->assertCount( 0, $entries, 'Entry should be expired with the default TTL.' );
 	}
 
 	/**

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -44,6 +44,41 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * Core pins an unfocused tab to a 120-second interval no client-side call can
+	 * shorten, leaving the TTL as the only thing holding it in its room.
+	 *
+	 * @covers ::wp_presence_admin_heartbeat_received
+	 */
+	public function test_presence_outlives_the_unfocused_heartbeat_interval() {
+		global $wpdb;
+
+		// scheduleNextTick() in wp-includes/js/heartbeat.js.
+		$unfocused_interval = 120;
+
+		wp_set_current_user( self::$editor_id );
+
+		wp_presence_admin_heartbeat_received(
+			array(),
+			array( 'presence-ping' => array( 'screen' => 'dashboard' ) ),
+			'dashboard'
+		);
+
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - $unfocused_interval ) ),
+			array( 'client_id' => 'user-' . self::$editor_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$this->assertCount(
+			1,
+			wp_get_presence( wp_presence_admin_room() ),
+			'A tab pinging at the unfocused interval must not expire between ticks.'
+		);
+	}
+
+	/**
 	 * @covers ::wp_presence_admin_heartbeat_received
 	 */
 	public function test_admin_heartbeat_ignores_without_ping() {


### PR DESCRIPTION
## Description 

Fixes #354

Raises the default TTL to 150 - the number core sizes post locks against, for the same reason.

Verified in a browser: a visible-but-unfocused tab (`document.hasFocus()` stubbed false), sampled every 10s for 263s.

| elapsed | entry age | |
| --- | --- | --- |
| 61s | 2s | heartbeat tick |
| 122s | 63s | past the old 60s TTL |
| 172s | 114s | peak age, still well inside 150 |
| 182s | 4s | next tick, 120s after the previous one |

Present at all 27 samples. Under the old TTL the tab would have read offline for 60 seconds of every 120, since anything older than 60s fell outside the cutoff. `wp.heartbeat.interval()` reported 60 throughout while the measured gap was 120, which is why the TTL is the only lever. Reverting the constant to 60 makes the new test the only failure in the suite.

Two consequences needs weighing:

- `heartbeat-send` skips pinging while `visibilityState === 'hidden'` so backgrounded tabs age out via the TTL. They now linger up to 150s instead of 60s. Deleting on `visibilitychange` instead is worse: `client_id` is `user-<id>`, shared across tabs, so a hidden tab would clear presence for a user who still has a visible one open.
- `IDLE_THRESHOLD` is unchanged at 30s, so an unfocused tab renders as idle with a "2 mins ago" label between ticks rather than disappearing.

`wp_presence_network_summary_refresh_interval()` needed no change: its `TTL - idleInterval` clamp becomes 105s, and the 120s tick gap still lands inside the 150s cutoff - covered by the `WP_MULTISITE=1` run, which the single-site run skips. The idle backoff still resolves to `min(45, 135) = 45`.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigation, implementation, and tests; reviewed and verified by me.

</details>