### PR TITLE
fix: detect the collaboration edge across requests

### DIFF
--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -337,6 +337,22 @@ function wp_presence_editor_heartbeat_received( $response, $data, $screen_id ) {
 }
 
 /**
+ * Builds the transient key holding a room's last observed editor count.
+ *
+ * @since 0.2.0
+ *
+ * @access private
+ * @param string $room The presence room identifier.
+ * @return string The transient key.
+ */
+function wp_presence_collaboration_state_key( $room ) {
+	// Rooms are `postType/post:123` and similar, so they carry characters an
+	// option name may not, and they are longer than the 172 a transient key
+	// can hold once the `_transient_timeout_` prefix is added.
+	return 'wp_presence_collab_' . md5( $room );
+}
+
+/**
  * Checks if the collaboration threshold has been crossed and fires appropriate actions.
  *
  * Fires 'wp_presence_collaboration_started' when editor count goes from 1 to 2+.
@@ -358,8 +374,12 @@ function wp_presence_check_collaboration_threshold( $room ) {
 		)
 	);
 
-	static $previous = array();
-	$prev_count      = $previous[ $room ] ?? 1;
+	// Every tick is its own request, so this cannot be held in memory. The
+	// transient expires on the presence TTL: once the entries it describes
+	// have aged out there is no earlier count left to be the edge from.
+	$key        = wp_presence_collaboration_state_key( $room );
+	$stored     = get_transient( $key );
+	$prev_count = false === $stored ? 1 : (int) $stored;
 
 	if ( 1 === $prev_count && $editor_count >= 2 ) {
 		/**
@@ -383,5 +403,9 @@ function wp_presence_check_collaboration_threshold( $room ) {
 		do_action( 'wp_presence_collaboration_ended', $room, $entries );
 	}
 
-	$previous[ $room ] = $editor_count;
+	// Rewritten on every tick rather than only when the count moves, because
+	// the expiry has to be pushed forward too: a steady pair of editors that
+	// let this lapse would read back as a fresh start and announce itself
+	// again. One row per active room, expiring alongside the presence entries.
+	set_transient( $key, $editor_count, wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
 }

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -584,6 +584,126 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * A tick is its own request, so the previous editor count has to be read
+	 * back from storage rather than from anything held in memory. Seeding that
+	 * storage is what stands in for "an earlier request already ran".
+	 *
+	 * @covers ::wp_presence_check_collaboration_threshold
+	 */
+	public function test_collaboration_ended_fires_on_state_left_by_an_earlier_request() {
+		$post_id = self::factory()->post->create();
+		$room    = wp_presence_post_room( $post_id );
+
+		set_transient( wp_presence_collaboration_state_key( $room ), 2, HOUR_IN_SECONDS );
+
+		$action_ran = false;
+		add_action(
+			'wp_presence_collaboration_ended',
+			function () use ( &$action_ran ) {
+				$action_ran = true;
+			}
+		);
+
+		// One editor present, where an earlier request saw two.
+		wp_set_current_user( self::$editor_id );
+		wp_presence_editor_heartbeat_received(
+			array(),
+			array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+			'post'
+		);
+
+		$this->assertTrue( $action_ran, 'Going 2 to 1 across requests should fire the end action' );
+	}
+
+	/**
+	 * @covers ::wp_presence_check_collaboration_threshold
+	 */
+	public function test_collaboration_started_does_not_refire_while_two_editors_stay() {
+		$post_id  = self::factory()->post->create();
+		$editor_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$room     = wp_presence_post_room( $post_id );
+
+		wp_set_presence( $room, 'editor-' . $editor_2, array( 'screen' => 'post' ), $editor_2 );
+		set_transient( wp_presence_collaboration_state_key( $room ), 2, HOUR_IN_SECONDS );
+
+		$times_fired = 0;
+		add_action(
+			'wp_presence_collaboration_started',
+			function () use ( &$times_fired ) {
+				++$times_fired;
+			}
+		);
+
+		// Three more ticks with both editors still here.
+		for ( $i = 0; $i < 3; $i++ ) {
+			wp_set_current_user( self::$editor_id );
+			wp_presence_editor_heartbeat_received(
+				array(),
+				array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+				'post'
+			);
+		}
+
+		$this->assertSame( 0, $times_fired, 'Collaboration already started should not re-announce' );
+	}
+
+	/**
+	 * @covers ::wp_presence_check_collaboration_threshold
+	 */
+	public function test_collaboration_state_survives_the_request_that_wrote_it() {
+		$post_id  = self::factory()->post->create();
+		$editor_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$room     = wp_presence_post_room( $post_id );
+
+		wp_set_presence( $room, 'editor-' . $editor_2, array( 'screen' => 'post' ), $editor_2 );
+
+		wp_set_current_user( self::$editor_id );
+		wp_presence_editor_heartbeat_received(
+			array(),
+			array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+			'post'
+		);
+
+		$this->assertSame(
+			2,
+			get_transient( wp_presence_collaboration_state_key( $room ) ),
+			'The count a request observed has to outlive it'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_check_collaboration_threshold
+	 */
+	public function test_collaboration_state_expiry_is_pushed_forward_on_every_tick() {
+		$post_id  = self::factory()->post->create();
+		$editor_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$room     = wp_presence_post_room( $post_id );
+		$key      = wp_presence_collaboration_state_key( $room );
+
+		wp_set_presence( $room, 'editor-' . $editor_2, array( 'screen' => 'post' ), $editor_2 );
+
+		// Two editors already recorded, but about to lapse.
+		set_transient( $key, 2, 5 );
+
+		wp_set_current_user( self::$editor_id );
+		wp_presence_editor_heartbeat_received(
+			array(),
+			array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+			'post'
+		);
+
+		// Writing only when the count moves would leave the old 5s expiry in
+		// place, and the pair would re-announce itself once it ran out. Derived
+		// from the TTL rather than a literal so a change to it cannot quietly
+		// make this assertion meaningless.
+		$this->assertGreaterThan(
+			time() + (int) floor( wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) / 2 ),
+			(int) get_option( '_transient_timeout_' . $key ),
+			'An unchanged count still has to push the expiry forward'
+		);
+	}
+
+	/**
 	 * Decodes the wpPresenceConfig object handed to presence-ping.js.
 	 *
 	 * @return array The decoded config.


### PR DESCRIPTION
`wp_presence_check_collaboration_threshold()` held the previous editor count in a function `static`. A tick is its own request, so `$prev_count` was always its `?? 1` default: `wp_presence_collaboration_started` fired on every tick with two or more editors, and `wp_presence_collaboration_ended` could not fire at all.

Measured with two logged-in sessions on the same post, both hooks logged. On `2acf1fe`, six ticks from the second editor produced `started=7` (the sixth plus one automatic tick from the other session) and `ended=0`. The same run on this branch gives `started=1, ended=1`.

**Why the suite was green on both hooks.** `test_collaboration_started_action` and `test_collaboration_ended_action` call the handler several times inside one PHPUnit process, which is the one condition where a `static` does work. They cover the sequence without the request boundary that breaks it, and they still pass if you revert this change. The four new tests seed the stored count the way an earlier request would have left it, which is what makes them fail on the old code.

**The decision you did not specify: a per-room transient, not an option.** An option grows a row per post anyone edits and never reclaims it. An expiring transient is not autoloaded, and tying its TTL to `wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL )` means the memory of a room dies exactly when the entries it describes do. That expression also means #379 raising the TTL to 150 carries this along with no edit here.

**It rewrites on every tick rather than only when the count moves,** which is one row per active room per tick. Writing only on change was my first version and it is wrong: the expiry never moves, so a steady pair lapses mid-session and announces itself again. `test_collaboration_state_expiry_is_pushed_forward_on_every_tick` is the guard for exactly that. If that write volume is the wrong trade, say so, because the alternative is a longer fixed TTL and I would rather you picked it.

**Known limitation.** Read-then-write is not atomic, so two editors ticking in the same instant can both see the old count and both fire `started`. Rarer than the current behaviour of firing every tick, but not zero.

Note #379 also edits `tests/test-heartbeat.php`, so whichever of us lands second gets a trivial rebase.

Fixes #362

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Diagnosis, the fix, and the tests. I reproduced the every-tick firing on a running site with two logged-in sessions before any code was written, verified the fix against the base branch the same way, and ran the mutation checks and suites myself.

</details>
