### PR TITLE
ci: let the blueprint gate pass on branches that predate a blueprint

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -75,6 +75,11 @@ jobs:
         run: |
           set -euo pipefail
           for f in blueprint.json blueprint-40.json blueprint-multisite.json; do
+            # This step is the base's, the checkout is the PR's head.
+            if [ ! -f "$f" ]; then
+              echo "::notice::$f is not on this branch, so nothing to validate."
+              continue
+            fi
             jq -e '
               (.steps | length > 0)
               and (.steps | all(.step | IN("installPlugin", "writeFile", "runPHP", "enableMultisite", "wp-cli")))


### PR DESCRIPTION
#380 has been failing since #377 landed, and any branch opened before a future blueprint would fail the same way.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with the diagnosis and the workflow change.

</details>
