### PR TITLE
chore: housekeeping for the public-surface check, release previews, and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Assigned issues left quiet for two weeks may be unassigned. Comment to pick one 
 
 ## Pull requests
 
-1. Branch off `main`, or off the parent branch if this is one of a stack.
+1. Branch off `main`.
 2. Title the pull request as a [Conventional Commit](https://www.conventionalcommits.org/). Pull requests are merged with a merge commit whose subject is the pull request title, so the title is what release-please reads. `lint-pr.yml` enforces this.
 3. All CI checks must pass before merge (PHPCS, PHPStan, PHPUnit across PHP 7.4 + 8.3 plus a multisite run, Playwright).
 4. Keep commits focused, one logical change per commit.
@@ -74,29 +74,6 @@ JavaScript has no `@since` line to sit under, so `@private` on its own is enough
  */
 window.wpPresenceBuildAvatarStack = function ( users, max ) {};
 ```
-
-### Stacks
-
-A change too large to review in one pass goes in as a stack: each pull request based on the previous one, so each diff is only what that step added. Split where the reviewer's question changes, not every N lines. Nothing beyond git and `gh` is needed.
-
-```bash
-git checkout -b feature/thing-schema main
-# commit
-git checkout -b feature/thing-write
-```
-
-Open each one against its parent, or its diff carries the parent's work too:
-
-```bash
-gh pr create --base main --head feature/thing-schema
-gh pr create --base feature/thing-schema --head feature/thing-write
-```
-
-Put the same numbered list of the whole stack at the top of every body, marking the current one, so a reviewer landing in the middle knows what it sits on.
-
-When a lower pull request changes, rebase each branch above it in order and push with `--force-with-lease`, never plain `--force`.
-
-Merge bottom-up, one at a time, each on its own green CI. GitHub retargets a child to `main` when its base is merged and deleted, so nothing needs re-pointing by hand.
 
 ## Getting credited
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,19 @@ A hook, REST route, WP-CLI command, guarded constant, or browser global that a s
 
 Written about means a docblock directly above it with a sentence saying what it is for. That is where WordPress core's code reference reads from, and it keeps the write-up next to the code instead of in a hand-kept list that drifts the first time someone forgets it. `README.md` narrates the surfaces worth a worked example; it is not the inventory.
 
-Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those `@private` in that same docblock, the marker core uses to keep a symbol out of the code reference, and the check leaves them alone:
+Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those private in that same docblock and the check leaves them alone. In PHP use `@access private`, the marker [core's documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) name, directly below `@since`:
+
+```php
+/**
+ * Returns the transient key a room's collaboration state is stored under.
+ *
+ * @since 0.1.0
+ * @access private
+ */
+function wp_presence_collaboration_state_key( $room ) {}
+```
+
+JavaScript has no `@since` line to sit under, so `@private` on its own is enough there:
 
 ```js
 /**

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -36,6 +36,9 @@ const JS_RULES = [
   ],
 ];
 
+// `@access private` in PHP per core's standards, `@private` in JS.
+const PRIVATE = /@(?:private\b|access\s+private\b)/;
+
 // The workflow greps for this literal to edit its own comment in place.
 const MARKER = '<!-- presence-api:public-surface -->';
 
@@ -82,14 +85,14 @@ function describes(block) {
 
 // Identifiers are `kind:name` and carry no path, so the same hook found at a new
 // location is the same surface. Each one also reports whether the docblock above
-// it describes it; `@private` in that docblock withdraws the surface entirely.
+// it describes it; a private marker in that docblock withdraws it entirely.
 function findSurfaces(source, path) {
   const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
 
   return rules.flatMap(([regex, build]) =>
     [...source.matchAll(regex)]
       .map((m) => ({ id: build(m), block: docblockAbove(source, m.index) }))
-      .filter(({ id, block }) => !id.endsWith(':') && !block.includes('@private'))
+      .filter(({ id, block }) => !id.endsWith(':') && !PRIVATE.test(block))
       .map(({ id, block }) => ({ id, documented: describes(block) }))
   );
 }

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -128,6 +128,18 @@ window.wpPresencePublic = function () {};`;
   assert.deepEqual(js(source), ['js-global:window.wpPresencePublic']);
 });
 
+test('@access private withdraws a surface the same way', () => {
+  const source = `/**
+ * Fires internally.
+ *
+ * @since 0.1.0
+ * @access private
+ */
+do_action( 'wp_presence_internal' );`;
+  assert.deepEqual(php(source), []);
+  assert.deepEqual(php(source.replace(' * @access private\n', '')), ['action:wp_presence_internal']);
+});
+
 test('@private reads the same above a php hook', () => {
   const source = `/**
  * Fires internally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-  # Unfiltered on purpose. A pull request in a stack is based on its parent
-  # branch rather than main, and `branches: [ main ]` skips it entirely, so
-  # every pull request below the top of a stack would merge unverified.
+  # Unfiltered: `branches: [ main ]` would skip PRs against another base.
   pull_request:
 
 permissions:

--- a/.github/workflows/playground-preview-cleanup.yml
+++ b/.github/workflows/playground-preview-cleanup.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-24.04
-    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     steps:
       - name: Delete preview branch
         env:

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -34,7 +34,6 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'pull_request'
-      && !startsWith(github.event.workflow_run.head_branch, 'release-please--')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -5,6 +5,8 @@ name: Playground Preview
 # sibling `Playground Preview Publish` workflow picks the artifacts up
 # on `workflow_run` and hosts them, so a preview always shows the PR's
 # own build at its latest commit.
+#
+# Release-please PRs included: nothing else verifies the staged version.
 
 on:
   pull_request:
@@ -31,7 +33,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Three unrelated bits of housekeeping, one commit each.

- The public-surface check only recognized `@private`, which nothing in this repo uses.
- Release-please pull requests were excluded from the Playground preview, so there was no way to boot a staged release before tagging it.
- CONTRIBUTING still documented stacked pull requests.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with implementation

</details>
