### PR TITLE
fix: store collaboration state only while two editors are present

### DIFF
--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -346,9 +346,8 @@ function wp_presence_editor_heartbeat_received( $response, $data, $screen_id ) {
  * @return string The transient key.
  */
 function wp_presence_collaboration_state_key( $room ) {
-	// Rooms are `postType/post:123` and similar, so they carry characters an
-	// option name may not, and they are longer than the 172 a transient key
-	// can hold once the `_transient_timeout_` prefix is added.
+	// A room runs to `WP_PRESENCE_MAX_KEY_LENGTH`, past the 172 a transient key
+	// holds once `_transient_timeout_` is prefixed.
 	return 'wp_presence_collab_' . md5( $room );
 }
 
@@ -403,9 +402,12 @@ function wp_presence_check_collaboration_threshold( $room ) {
 		do_action( 'wp_presence_collaboration_ended', $room, $entries );
 	}
 
-	// Rewritten on every tick rather than only when the count moves, because
-	// the expiry has to be pushed forward too: a steady pair of editors that
-	// let this lapse would read back as a fresh start and announce itself
-	// again. One row per active room, expiring alongside the presence entries.
-	set_transient( $key, $editor_count, wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
+	// Rewritten every tick, not only when the count moves: a steady pair that
+	// let this lapse would read back as a fresh start and re-announce itself.
+	// Below two there is nothing to hold, since absent already reads as 1.
+	if ( $editor_count >= 2 ) {
+		set_transient( $key, $editor_count, wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) );
+	} elseif ( false !== $stored ) {
+		delete_transient( $key );
+	}
 }

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -685,6 +685,58 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 	/**
 	 * @covers ::wp_presence_check_collaboration_threshold
 	 */
+	public function test_collaboration_ended_does_not_refire_on_the_next_tick() {
+		$post_id = self::factory()->post->create();
+		$room    = wp_presence_post_room( $post_id );
+
+		// Two editors already recorded, one of whom has since gone.
+		set_transient( wp_presence_collaboration_state_key( $room ), 2, HOUR_IN_SECONDS );
+
+		$times_fired = 0;
+		add_action(
+			'wp_presence_collaboration_ended',
+			function () use ( &$times_fired ) {
+				++$times_fired;
+			}
+		);
+
+		wp_set_current_user( self::$editor_id );
+		for ( $tick = 0; $tick < 2; $tick++ ) {
+			wp_presence_editor_heartbeat_received(
+				array(),
+				array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+				'post'
+			);
+		}
+
+		$this->assertSame( 1, $times_fired, 'The 2 has to be cleared, or every later tick reads as another ending' );
+	}
+
+	/**
+	 * @covers ::wp_presence_check_collaboration_threshold
+	 */
+	public function test_a_lone_editor_stores_no_collaboration_state() {
+		$post_id = self::factory()->post->create();
+		$room    = wp_presence_post_room( $post_id );
+
+		wp_set_current_user( self::$editor_id );
+		wp_presence_editor_heartbeat_received(
+			array(),
+			array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+			'post'
+		);
+
+		// Absent already reads back as 1, so storing it is two option rows a tick
+		// that change no later decision.
+		$this->assertFalse(
+			get_transient( wp_presence_collaboration_state_key( $room ) ),
+			'A solo editing session should leave nothing behind'
+		);
+	}
+
+	/**
+	 * @covers ::wp_presence_check_collaboration_threshold
+	 */
 	public function test_collaboration_state_survives_the_request_that_wrote_it() {
 		$post_id  = self::factory()->post->create();
 		$editor_2 = self::factory()->user->create( array( 'role' => 'editor' ) );


### PR DESCRIPTION
Closes #385

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with implementation

</details>
