### PR TITLE
fix: refresh the network summary timestamp unconditionally

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -230,25 +230,20 @@ function wp_presence_push_network_summary() {
 
 	$blog_id = get_current_blog_id();
 	$now     = gmdate( 'Y-m-d H:i:s' );
-	$refresh = gmdate( 'Y-m-d H:i:s', time() - wp_presence_network_summary_refresh_interval() );
 
-	// updated_gmt is assigned before data because MySQL applies the assignments
-	// in order, so reading `data` after `data = VALUES(data)` would compare the
-	// new value against itself and never detect a change. The gate above already
-	// rules out most unchanged writes; this keeps updated_gmt honest for the
-	// refresh push, which rewrites the same data on purpose.
+	// Unconditional: the gate above already ruled out unchanged writes, and the
+	// IF() this replaced was silently dropped by SQLite, freezing updated_gmt.
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$result = $wpdb->query(
 		$wpdb->prepare(
 			"INSERT INTO {$wpdb->presence_network_summary} (blog_id, data, updated_gmt)
 			VALUES (%d, %s, %s)
 			ON DUPLICATE KEY UPDATE
-				updated_gmt = IF( data <> VALUES(data) OR updated_gmt < %s, VALUES(updated_gmt), updated_gmt ),
+				updated_gmt = VALUES(updated_gmt),
 				data = VALUES(data)",
 			$blog_id,
 			wp_presence_encode_network_summary_row( $blog_id, $user_ids ),
-			$now,
-			$refresh
+			$now
 		)
 	);
 


### PR DESCRIPTION
Closes #369

Reproduced on `wp-sqlite-database-integration` through the Playground CLI, both shapes against the same table in one request:

```
db driver: sqlite
wanted updated_gmt: 2026-08-27 21:55:54
seeded:                2026-08-27 21:50:54  data={"a":1}  err=
after IF() upsert:     2026-08-27 21:50:54  data={"a":2}  err=
after plain upsert:    2026-08-27 21:55:54  data={"a":2}  err=
```

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with implementation

</details>
