### PR TITLE
docs: correct @since tags to 0.2.0 on the network summary and admin room hooks

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -197,7 +197,7 @@ function wp_presence_admin_room_changed() {
 	 *
 	 * Fires when an admin-room write changes at least one row.
 	 *
-	 * @since 0.1.25
+	 * @since 0.2.0
 	 */
 	do_action( 'wp_presence_admin_room_changed' );
 }

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -179,7 +179,7 @@ function wp_presence_network_summary_refresh_interval() {
 	 *
 	 * Clamped to the read cutoff minus the idle heartbeat interval.
 	 *
-	 * @since 0.1.25
+	 * @since 0.2.0
 	 *
 	 * @param int $interval Seconds. Default is the clamp maximum.
 	 */
@@ -664,7 +664,7 @@ function wp_presence_flush_network_summary_cache() {
  * expensive half and is left to wp_presence_hydrate_network_snapshot(), which
  * runs against a handful of users rather than every user online.
  *
- * @since 0.1.25
+ * @since 0.2.0
  *
  * @param array $by_site Blog ID to array of user IDs.
  * @return array The same map with unknown users, and any site left empty by


### PR DESCRIPTION
`@since 0.1.25` documents a version that was never tagged, since the release goes 0.1.24 to 0.2.0.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with implementation

</details>
