### PR TITLE
fix: preserve focus across heartbeat re-renders in the network Who's Online widget

### DIFF
--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -135,7 +135,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 		echo '<ul class="presence-user-list" aria-label="' . esc_attr__( 'Sites with online users', 'presence-api' ) . '">';
 
 		foreach ( $summary['sites'] as $site ) {
-			echo '<li class="presence-site-item">';
+			echo '<li class="presence-site-item" data-blog-id="' . (int) $site['blog_id'] . '">';
 			echo wp_kses_post( wp_presence_render_avatar_stack( $site['users'], WP_PRESENCE_NETWORK_AVATARS ) );
 			echo '<span class="presence-site-info"><a href="' . esc_url( $site['url'] ) . '">' . esc_html( $site['domain'] . $site['path'] ) . '</a></span>';
 			echo '<span class="presence-site-count">' . (int) $site['user_count'] . '</span>';
@@ -254,6 +254,40 @@ class WP_Presence_Network_Widget_Whos_Online {
 		return el.innerHTML;
 	}
 
+	// The swap below replaces every node, so a keyboard user standing on a site
+	// link lands on the body unless the spot is recorded and handed back.
+	function captureFocus(container) {
+		var active = document.activeElement;
+		if (!active || !$.contains(container[0], active)) {
+			return null;
+		}
+		var item = $(active).closest('[data-blog-id]');
+		if (item.length) {
+			return { type: 'site', id: item.data('blog-id') };
+		}
+		if ($(active).hasClass('presence-more-link')) {
+			return { type: 'more' };
+		}
+		return { type: 'none' };
+	}
+
+	function restoreFocus(container, info) {
+		if (!info) {
+			return;
+		}
+		var target = null;
+		if (info.type === 'site') {
+			target = container.find('[data-blog-id="' + info.id + '"] a').first();
+		} else if (info.type === 'more') {
+			target = container.find('.presence-more-link');
+		}
+		if (target && target.length) {
+			target.trigger('focus');
+		} else {
+			container.trigger('focus');
+		}
+	}
+
 	// Already cut to the sites and avatars this widget shows, so nothing is
 	// sliced here; overflow is a count the server sends, not what is left over.
 	function buildListHtml(sites, overflow) {
@@ -263,7 +297,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 
 		var html = '<ul class="presence-user-list">';
 		sites.forEach(function(site) {
-			html += '<li class="presence-site-item">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
+			html += '<li class="presence-site-item" data-blog-id="' + parseInt(site.blog_id, 10) + '">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
 			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
 			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
 		});
@@ -308,7 +342,9 @@ class WP_Presence_Network_Widget_Whos_Online {
 		var sig = JSON.stringify([sites, overflow]);
 
 		if (sig !== lastSignature) {
+			var focusInfo = captureFocus(container);
 			container.html(buildListHtml(sites, overflow));
+			restoreFocus(container, focusInfo);
 			lastSignature = sig;
 		}
 	});

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -146,6 +146,23 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 		$this->assertStringContainsString( 'localhost', $output );
 	}
 
+	public function test_each_rendered_site_carries_its_blog_id() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		// Heartbeat re-renders restore focus by matching this attribute, so a row
+		// without one drops a keyboard user to the body on every presence change.
+		$this->assertStringContainsString(
+			'data-blog-id="' . $blog_id . '"',
+			$output,
+			'Focus restore has nothing to key on without the blog ID on the row'
+		);
+	}
+
 	/**
 	 * The widget draws five sites and links out for the rest, so it asks the
 	 * read path for five rather than pulling the whole network across and


### PR DESCRIPTION
Closes #389

Third time for this one: `45e4f13` fixed it for Who's Online and `07846f7` for Active Posts, both on 2026-08-12, and the network widget shipped afterwards without picking it up.

Verified in Chromium against a three-site wp-env network, focusing a site link and forcing a real re-render:

```
server-rendered data-blog-id: ["1","2","3"]

-- focused site link 1: "localhost:8888/" (blog 1)
   dropped row 11, blog 3 now has 4
   heartbeat: tick
   after: "localhost:8888/" (blog 1, in widget: true)
   PASS focus returned to the same site

-- focused site link 2: "localhost:8888/marketing/" (blog 2)
   dropped row 6, blog 3 now has 3
   heartbeat: tick
   after: "localhost:8888/marketing/" (blog 2, in widget: true)
   PASS focus returned to the same site
```

Before the patch the same run reported `"localhost:8888/" -> "<body>"`.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with implementation

</details>
