### PR TITLE
fix: Filter out archived, spam, and deleted sites from network presence

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -425,13 +425,18 @@ function wp_presence_get_network_sites_for_user( $user_id ) {
 	// Resolved here rather than in the index above, so a network where nobody
 	// is looked up pays for no sites at all. get_sites() primes the site cache,
 	// so rows sharing a site resolve it once.
-	return get_sites(
+	$sites = get_sites(
 		array(
 			'site__in' => $blog_ids,
 			'number'   => 0,
 			'orderby'  => 'site__in',
+			'archived' => 0,
+			'spam'     => 0,
+			'deleted'  => 0,
 		)
 	);
+
+	return is_array( $sites ) ? $sites : array();
 }
 
 /**
@@ -716,8 +721,15 @@ function wp_presence_compute_network_snapshot( $timeout ) {
 			'site__in' => array_keys( $by_site ),
 			'fields'   => 'ids',
 			'number'   => 0,
+			'archived' => 0,
+			'spam'     => 0,
+			'deleted'  => 0,
 		)
 	);
+
+	if ( ! is_array( $live ) ) {
+		$live = array();
+	}
 
 	$by_site = array_intersect_key( $by_site, array_flip( array_map( 'intval', $live ) ) );
 
@@ -809,8 +821,15 @@ function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $use
 		array(
 			'site__in' => array_keys( $by_site ),
 			'number'   => 0,
+			'archived' => 0,
+			'spam'     => 0,
+			'deleted'  => 0,
 		)
 	);
+
+	if ( ! is_array( $found ) ) {
+		$found = array();
+	}
 
 	foreach ( $found as $found_site ) {
 		$found_sites[ (int) $found_site->blog_id ] = $found_site;

--- a/presence-api.php
+++ b/presence-api.php
@@ -217,13 +217,15 @@ function wp_presence_on_initialize_site( $site ) {
  * @return int[] Site IDs.
  */
 function wp_presence_get_network_site_ids() {
-	return get_sites(
+	$sites = get_sites(
 		array(
 			'fields'                 => 'ids',
 			'number'                 => 0,
 			'update_site_meta_cache' => false,
 		)
 	);
+
+	return is_array( $sites ) ? $sites : array();
 }
 
 /**

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -11,69 +11,95 @@
  * @group presence
  * @group ms-required
  */
-class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
+class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase
+{
 
 	private static $editor_id;
 
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	public static function wpSetUpBeforeClass(WP_UnitTest_Factory $factory)
+	{
+		self::$editor_id = $factory->user->create(array('role' => 'editor'));
 	}
 
 	/**
 	 * @covers ::wp_presence_register_network_sites_column
 	 */
-	public function test_sites_column_requires_capability() {
-		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
+	public function test_sites_column_requires_capability()
+	{
+		$columns = wp_presence_register_network_sites_column(array('blogname' => 'Site'));
 
-		$this->assertArrayNotHasKey( 'presence_online', $columns, 'A visitor with no capability should not see the column.' );
+		$this->assertArrayNotHasKey('presence_online', $columns, 'A visitor with no capability should not see the column.');
 	}
 
 	/**
 	 * @covers ::wp_presence_register_network_sites_column
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_renders_avatar_stack_and_count() {
+	public function test_sites_column_renders_avatar_stack_and_count()
+	{
 		$this->become_network_admin();
 
 		$blog_id = $this->create_blog();
-		$this->set_presence_on_site( $blog_id, self::$editor_id );
+		$this->set_presence_on_site($blog_id, self::$editor_id);
 
-		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
-		$this->assertArrayHasKey( 'presence_online', $columns );
+		$columns = wp_presence_register_network_sites_column(array('blogname' => 'Site'));
+		$this->assertArrayHasKey('presence_online', $columns);
 
 		ob_start();
-		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		wp_presence_render_network_sites_column('presence_online', $blog_id);
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'presence-avatar-stack', $output );
-		$this->assertStringContainsString( '1', $output );
+		$this->assertStringContainsString('presence-avatar-stack', $output);
+		$this->assertStringContainsString('1', $output);
 	}
 
 	/**
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online() {
+	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online()
+	{
 		$this->become_network_admin();
 
 		$blog_id = $this->create_blog();
 
 		ob_start();
-		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		wp_presence_render_network_sites_column('presence_online', $blog_id);
 		$output = ob_get_clean();
 
-		$this->assertSame( '&#8212;', $output );
+		$this->assertSame('&#8212;', $output);
 	}
 
 	/**
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_ignores_other_columns() {
+	public function test_sites_column_ignores_other_columns()
+	{
 		$this->become_network_admin();
 
 		ob_start();
-		wp_presence_render_network_sites_column( 'blogname', 1 );
+		wp_presence_render_network_sites_column('blogname', 1);
 		$output = ob_get_clean();
 
-		$this->assertSame( '', $output );
+		$this->assertSame('', $output);
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_shows_dash_for_archived_site()
+	{
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site($blog_id, self::$editor_id);
+
+		update_blog_status($blog_id, 'archived', 1);
+		wp_presence_flush_network_summary_cache();
+
+		ob_start();
+		wp_presence_render_network_sites_column('presence_online', $blog_id);
+		$output = ob_get_clean();
+
+		$this->assertSame('&#8212;', $output, 'An archived site must show a dash in the Online column.');
 	}
 }

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -11,95 +11,88 @@
  * @group presence
  * @group ms-required
  */
-class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase
-{
+class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 
 	private static $editor_id;
 
-	public static function wpSetUpBeforeClass(WP_UnitTest_Factory $factory)
-	{
-		self::$editor_id = $factory->user->create(array('role' => 'editor'));
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	/**
 	 * @covers ::wp_presence_register_network_sites_column
 	 */
-	public function test_sites_column_requires_capability()
-	{
-		$columns = wp_presence_register_network_sites_column(array('blogname' => 'Site'));
+	public function test_sites_column_requires_capability() {
+		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
 
-		$this->assertArrayNotHasKey('presence_online', $columns, 'A visitor with no capability should not see the column.');
+		$this->assertArrayNotHasKey( 'presence_online', $columns, 'A visitor with no capability should not see the column.' );
 	}
 
 	/**
 	 * @covers ::wp_presence_register_network_sites_column
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_renders_avatar_stack_and_count()
-	{
+	public function test_sites_column_renders_avatar_stack_and_count() {
 		$this->become_network_admin();
 
 		$blog_id = $this->create_blog();
-		$this->set_presence_on_site($blog_id, self::$editor_id);
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
 
-		$columns = wp_presence_register_network_sites_column(array('blogname' => 'Site'));
-		$this->assertArrayHasKey('presence_online', $columns);
+		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
+		$this->assertArrayHasKey( 'presence_online', $columns );
 
 		ob_start();
-		wp_presence_render_network_sites_column('presence_online', $blog_id);
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString('presence-avatar-stack', $output);
-		$this->assertStringContainsString('1', $output);
+		$this->assertStringContainsString( 'presence-avatar-stack', $output );
+		$this->assertStringContainsString( '1', $output );
 	}
 
 	/**
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online()
-	{
+	public function test_sites_column_shows_a_dash_for_a_site_with_nobody_online() {
 		$this->become_network_admin();
 
 		$blog_id = $this->create_blog();
 
 		ob_start();
-		wp_presence_render_network_sites_column('presence_online', $blog_id);
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
 		$output = ob_get_clean();
 
-		$this->assertSame('&#8212;', $output);
+		$this->assertSame( '&#8212;', $output );
 	}
 
 	/**
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_ignores_other_columns()
-	{
+	public function test_sites_column_ignores_other_columns() {
 		$this->become_network_admin();
 
 		ob_start();
-		wp_presence_render_network_sites_column('blogname', 1);
+		wp_presence_render_network_sites_column( 'blogname', 1 );
 		$output = ob_get_clean();
 
-		$this->assertSame('', $output);
+		$this->assertSame( '', $output );
 	}
 
 	/**
 	 * @covers ::wp_presence_render_network_sites_column
 	 */
-	public function test_sites_column_shows_dash_for_archived_site()
-	{
+	public function test_sites_column_shows_dash_for_archived_site() {
 		$this->become_network_admin();
 
 		$blog_id = $this->create_blog();
-		$this->set_presence_on_site($blog_id, self::$editor_id);
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
 
-		update_blog_status($blog_id, 'archived', 1);
+		update_blog_status( $blog_id, 'archived', 1 );
 		wp_presence_flush_network_summary_cache();
 
 		ob_start();
-		wp_presence_render_network_sites_column('presence_online', $blog_id);
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
 		$output = ob_get_clean();
 
-		$this->assertSame('&#8212;', $output, 'An archived site must show a dash in the Online column.');
+		$this->assertSame( '&#8212;', $output, 'An archived site must show a dash in the Online column.' );
 	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -247,4 +247,28 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 		$this->assertCount( 1, $this->presence_for_user( self::$editor_id ), 'Deleting one user should not clear anybody else.' );
 		restore_current_blog();
 	}
+
+	/**
+	 * A summary row survives until cleanup runs even if the site is later
+	 * archived. An archived site with a fresh row must not appear in the
+	 * network snapshot, or it reads as live on the dashboard widget and the
+	 * Users list column.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 */
+	public function test_snapshot_excludes_archived_site_with_fresh_row() {
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		// Archive the site after the summary row has been pushed.
+		update_blog_status( $blog_id, 'archived', 1 );
+
+		// Flush the request cache so the next read recomputes from the database
+		// rather than serving the value built before the site was archived.
+		wp_presence_flush_network_summary_cache();
+
+		$snapshot = wp_presence_get_network_snapshot();
+
+		$this->assertArrayNotHasKey( $blog_id, $snapshot['sites'], 'An archived site must not appear in the network snapshot.' );
+	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -250,25 +250,25 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 
 	/**
 	 * A summary row survives until cleanup runs even if the site is later
-	 * archived. An archived site with a fresh row must not appear in the
+	 * marked as deleted. A deleted site with a fresh row must not appear in the
 	 * network snapshot, or it reads as live on the dashboard widget and the
 	 * Users list column.
 	 *
 	 * @covers ::wp_presence_compute_network_snapshot
 	 */
-	public function test_snapshot_excludes_archived_site_with_fresh_row() {
+	public function test_snapshot_excludes_deleted_site_with_fresh_row() {
 		$blog_id = $this->create_blog();
 		$this->set_presence_on_site( $blog_id, self::$editor_id );
 
-		// Archive the site after the summary row has been pushed.
-		update_blog_status( $blog_id, 'archived', 1 );
+		// Mark the site as deleted after the summary row has been pushed.
+		update_blog_status( $blog_id, 'deleted', 1 );
 
 		// Flush the request cache so the next read recomputes from the database
-		// rather than serving the value built before the site was archived.
+		// rather than serving the value built before the site was deleted.
 		wp_presence_flush_network_summary_cache();
 
 		$snapshot = wp_presence_get_network_snapshot();
 
-		$this->assertArrayNotHasKey( $blog_id, $snapshot['sites'], 'An archived site must not appear in the network snapshot.' );
+		$this->assertArrayNotHasKey( $blog_id, $snapshot['sites'], 'A deleted site must not appear in the network snapshot.' );
 	}
 }

--- a/tests/test-network-users-list.php
+++ b/tests/test-network-users-list.php
@@ -197,4 +197,26 @@ class WP_Test_Network_Users_List extends WP_Presence_Network_UnitTestCase {
 
 		$this->assertArrayHasKey( 'presence_online', $columns );
 	}
+
+	/**
+	 * The Network Users "Online" column lists the sites a user is active on.
+	 * If the user's only active site is archived, the column must show a dash
+	 * rather than naming a site that is no longer live.
+	 *
+	 * @covers ::wp_presence_render_network_users_column
+	 * @covers ::wp_presence_get_network_sites_for_user
+	 */
+	public function test_users_column_omits_archived_site() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		update_blog_status( $blog_id, 'archived', 1 );
+		wp_presence_flush_network_summary_cache();
+
+		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
+
+		$this->assertSame( '&#8212;', $output, 'An archived site must not appear in the Online column for a user.' );
+	}
 }

--- a/tests/test-network-users-list.php
+++ b/tests/test-network-users-list.php
@@ -200,23 +200,23 @@ class WP_Test_Network_Users_List extends WP_Presence_Network_UnitTestCase {
 
 	/**
 	 * The Network Users "Online" column lists the sites a user is active on.
-	 * If the user's only active site is archived, the column must show a dash
+	 * If the user's only active site is marked as spam, the column must show a dash
 	 * rather than naming a site that is no longer live.
 	 *
 	 * @covers ::wp_presence_render_network_users_column
 	 * @covers ::wp_presence_get_network_sites_for_user
 	 */
-	public function test_users_column_omits_archived_site() {
+	public function test_users_column_omits_spam_site() {
 		$this->become_network_admin();
 
 		$blog_id = $this->create_blog();
 		$this->set_presence_on_site( $blog_id, self::$editor_id );
 
-		update_blog_status( $blog_id, 'archived', 1 );
+		update_blog_status( $blog_id, 'spam', 1 );
 		wp_presence_flush_network_summary_cache();
 
 		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
 
-		$this->assertSame( '&#8212;', $output, 'An archived site must not appear in the Online column for a user.' );
+		$this->assertSame( '&#8212;', $output, 'A spam site must not appear in the Online column for a user.' );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -46,10 +46,13 @@ global $wpdb;
 if ( is_multisite() ) {
 	$sites = get_sites(
 		array(
-			'fields' => 'ids',
-			'number' => 0,
+			'fields'                 => 'ids',
+			'number'                 => 0,
+			'update_site_meta_cache' => false,
 		)
 	);
+
+	$sites = is_array( $sites ) ? $sites : array();
 
 	foreach ( $sites as $site_id ) {
 		switch_to_blog( $site_id );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to the Presence API feature plugin.

This GitHub repository is where the feature plugin's work happens — issues
track scope and PRs land changes. Keep larger design discussions in the
linked issue and use this Pull Request for code review.

If this is your first time contributing, the following may be helpful:
- Contributing guide: ../blob/main/.github/CONTRIBUTING.md
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

`get_sites()` was previously called with only `site__in`, and because `WP_Site_Query` defaults `archived`, `spam`, and `deleted` parameters to empty strings (`''`), no status filtering was performed. Archived or spammed sites with fresh summary rows were returned and treated as live across network surfaces.

**Changes Made:**
- Added explicit status exclusions (`'archived' => 0, 'spam' => 0, 'deleted' => 0`) to three `get_sites()` calls in `includes/network-functions.php`.
  - `wp_presence_compute_network_snapshot()`: Excludes dead sites from the network snapshot powering the Network Admin Dashboard Widget and Users list view count.
  - `wp_presence_hydrate_network_snapshot()`: Guards site object hydration during rendering.
  - `wp_presence_get_network_sites_for_user()`: Ensures the Network Users list column omits archived/spam/deleted sites.
- Added `$sites = is_array( $sites ) ? $sites : array();` to `uninstall.php` for array type safety.
- Added regression tests covering each surface.
  - `test_snapshot_excludes_deleted_site_with_fresh_row` in `tests/test-network-summary-push.php` (tests `deleted` status flag)
  - `test_sites_column_shows_dash_for_archived_site` in `tests/test-network-sites-column.php` (tests `archived` status flag)
  - `test_users_column_omits_spam_site` in `tests/test-network-users-list.php` (tests `spam` status flag)

Fixes #351

<!--
Put the issue number directly after the keyword, e.g. "Fixes #12", so the issue
closes when this Pull Request merges. GitHub only parses the keyword when the
reference follows it on the same line, so "Resolves Issue: #12" and a "Fixes"
line followed by a bulleted "- #12" both leave the issue open.

If this Pull Request should not close an issue, use "Related: #12" instead.
-->

<details>
<summary>Use of AI Tools</summary>

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example:
-->

- AI assistance: Yes
- Tool(s): Claude, Gemini
- Model(s): 3.7 Sonnet, 3.6 Flash
- Used for: Understanding the codebase architecture, researching default query behaviors, reviewing the per-surface fix, drafting unit tests, and adding inline documentation; final implementation, code formatting, and test execution were reviewed and verified by contributor.

</details>