### PR TITLE
chore: ignore build output, .env, and local wp-env overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules/
 vendor/
 artifacts/
+build/
 .cache/
 .phpunit.result.cache
 coverage.xml
+.env
+.wp-env.override.json
+.DS_Store


### PR DESCRIPTION
`assets/js/build/` and `.env` were both sitting untracked and unignored in a working tree, one `git add -A` away from being committed.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with the audit of untracked paths

</details>
