### PR TITLE
test: cover the Network Admin Sites list Online column

### DIFF
--- a/tests/e2e/network-helpers.js
+++ b/tests/e2e/network-helpers.js
@@ -1,0 +1,149 @@
+/**
+ * Presence API — helpers shared by the Network Admin specs.
+ *
+ * The other specs each carry their own copy of `wpCli`. These do not, because
+ * every command here has to reach the multisite wp-env instance rather than
+ * the default one, and that instance is selected by the working directory the
+ * command runs from — a detail worth stating once.
+ *
+ * The fixture network itself (the sub-site and the users named below) is
+ * created by scripts/start-multisite-env.sh, not by the specs.
+ *
+ * @package WordPress
+ */
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+/**
+ * Holds the .wp-env.json for the multisite instance.
+ *
+ * wp-env picks an instance by the directory it runs in, so every wp-env
+ * command below runs from here.
+ */
+const MULTISITE_ENV_DIR = path.resolve( __dirname, 'multisite' );
+
+const BASE_URL = (
+	process.env.WP_MULTISITE_BASE_URL || 'http://localhost:8890'
+).replace( /\/$/, '' );
+
+/**
+ * The sub-site seeded by scripts/start-multisite-env.sh.
+ *
+ * @type {string}
+ */
+export const SITE_SLUG = 'team';
+
+/**
+ * The users seeded by scripts/start-multisite-env.sh, members of both sites.
+ *
+ * Logins carry no underscores because multisite rejects anything but lowercase
+ * letters and numbers.
+ */
+export const NETWORK_USERS = {
+	a: { login: 'presencenetusera', displayName: 'Network UserA' },
+	b: { login: 'presencenetuserb', displayName: 'Network UserB' },
+};
+
+/**
+ * Returns the admin URL of a site on the fixture network.
+ *
+ * @param {string} [slug] Sub-site slug, omitted for the main site.
+ * @returns {string} Site URL, with a trailing slash.
+ */
+export function siteUrl( slug = '' ) {
+	return slug ? `${ BASE_URL }/${ slug }/` : `${ BASE_URL }/`;
+}
+
+/**
+ * Runs a WP-CLI command against the multisite instance.
+ *
+ * @param {string} command WP-CLI command, without the leading `wp`.
+ * @param {Object} [options]
+ * @param {string} [options.url] Site to run against, for a per-site command.
+ * @returns {string} The command's last line of output, trimmed.
+ */
+export function wpCli( command, { url } = {} ) {
+	const scope = url ? ` --url=${ url }` : '';
+
+	const raw = execSync( `npx wp-env run cli wp ${ command }${ scope }`, {
+		cwd: MULTISITE_ENV_DIR,
+		encoding: 'utf8',
+		stdio: 'pipe',
+		timeout: 60_000,
+	} );
+
+	return raw.trim().split( '\n' ).pop().trim();
+}
+
+/**
+ * Marks a seeded user as online on one site of the fixture network.
+ *
+ * @param {Object} options
+ * @param {string} options.login    Seeded user's login.
+ * @param {string} [options.slug]   Sub-site slug, omitted for the main site.
+ * @param {string} [options.client] Client ID, for seeding one user twice.
+ */
+export function setNetworkPresence( { login, slug = '', client = 'e2e' } ) {
+	wpCli(
+		`eval 'wp_set_presence( wp_presence_admin_room(), "${ client }", array( "screen" => "dashboard" ), get_user_by( "login", "${ login }" )->ID );'`,
+		{ url: siteUrl( slug ) }
+	);
+}
+
+/**
+ * Empties every site's presence table and rewrites the network summary.
+ *
+ * The summary table is a materialized push rather than a view, so deleting the
+ * rows a site pushed from is not enough on its own: without the push the site
+ * stays in the summary until its row ages out, and the screen under test keeps
+ * drawing people who are no longer there.
+ */
+export function clearNetworkPresence() {
+	wpCli(
+		`eval '
+			global $wpdb;
+			foreach ( get_sites( array( "fields" => "ids" ) ) as $blog_id ) {
+				switch_to_blog( $blog_id );
+				$wpdb->query( "DELETE FROM {$wpdb->presence}" );
+				wp_presence_push_network_summary();
+				restore_current_blog();
+			}
+		'`
+	);
+}
+
+/**
+ * Forces a Heartbeat tick and resolves once the response has been handled.
+ *
+ * Every admin screen enqueues the ping, network admin included, so a tick is
+ * available on all three screens under test.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+export async function forceHeartbeatTick( page ) {
+	await page.waitForFunction(
+		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+
+	await page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				jQuery( document ).one( 'heartbeat-tick', () => resolve() );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+/**
+ * Returns the blog ID of a site on the fixture network.
+ *
+ * @param {string} slug Sub-site slug.
+ * @returns {number} Blog ID.
+ */
+export function networkSiteId( slug ) {
+	return parseInt(
+		wpCli( `eval 'echo get_id_from_blogname( "${ slug }" );'` ),
+		10
+	);
+}

--- a/tests/e2e/presence-network-sites-column.test.js
+++ b/tests/e2e/presence-network-sites-column.test.js
@@ -1,0 +1,120 @@
+/**
+ * Presence API — Network Admin Sites list "Online" column E2E Tests
+ *
+ * Runs against the multisite instance, not the site the other specs use. See
+ * scripts/start-multisite-env.sh.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js --project chromium-multisite
+ *
+ * @package WordPress
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import {
+	NETWORK_USERS,
+	SITE_SLUG,
+	clearNetworkPresence,
+	forceHeartbeatTick,
+	networkSiteId,
+	setNetworkPresence,
+} from './network-helpers';
+
+let siteId;
+
+test.describe( 'Network Sites Online column', () => {
+	test.beforeAll( () => {
+		siteId = networkSiteId( SITE_SLUG );
+	} );
+
+	test.beforeEach( () => {
+		clearNetworkPresence();
+	} );
+
+	test.afterAll( () => {
+		clearNetworkPresence();
+	} );
+
+	/**
+	 * Returns the Online cell of the sub-site's row.
+	 *
+	 * Matched on the row's own checkbox rather than on the site name, because
+	 * the main site's name is a prefix of the sub-site's on a subdirectory
+	 * network.
+	 *
+	 * @param {import('@playwright/test').Page} page
+	 * @returns {import('@playwright/test').Locator}
+	 */
+	function onlineCell( page ) {
+		return page
+			.locator( '#the-list tr' )
+			.filter( { has: page.locator( `#blog_${ siteId }` ) } )
+			.locator( '.column-presence_online' );
+	}
+
+	test( 'draws an avatar stack and a count for a site with someone online', async ( {
+		admin,
+		page,
+	} ) => {
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+
+		await admin.visitAdminPage( 'network/sites.php' );
+
+		await expect( page.locator( 'thead th#presence_online' ) ).toHaveText(
+			'Online'
+		);
+
+		const avatars = onlineCell( page ).locator( '.presence-avatar-stack img' );
+
+		await expect( avatars ).toHaveCount( 1 );
+		await expect( avatars ).toHaveAttribute(
+			'alt',
+			NETWORK_USERS.a.displayName
+		);
+		await expect( onlineCell( page ) ).toHaveText( '1' );
+	} );
+
+	test( 'draws an em dash for a site with nobody online', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'network/sites.php' );
+
+		await expect( onlineCell( page ) ).toHaveText( '—' );
+	} );
+
+	test( 'holds its page-load snapshot across a heartbeat tick, and redraws on reload', async ( {
+		admin,
+		page,
+	} ) => {
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+
+		await admin.visitAdminPage( 'network/sites.php' );
+		await expect(
+			onlineCell( page ).locator( '.presence-avatar-stack img' )
+		).toHaveCount( 1 );
+
+		setNetworkPresence( {
+			login: NETWORK_USERS.b.login,
+			slug: SITE_SLUG,
+			client: 'e2e-b',
+		} );
+
+		// The column is rendered once per page load on purpose, the same as
+		// every other column on this table — see the note on
+		// wp_presence_render_network_sites_column(). A tick has to leave it
+		// alone; only the reload below may move it.
+		await forceHeartbeatTick( page );
+
+		await expect(
+			onlineCell( page ).locator( '.presence-avatar-stack img' )
+		).toHaveCount( 1 );
+		await expect( onlineCell( page ) ).toHaveText( '1' );
+
+		await page.reload();
+
+		await expect(
+			onlineCell( page ).locator( '.presence-avatar-stack img' )
+		).toHaveCount( 2 );
+		await expect( onlineCell( page ) ).toHaveText( '2' );
+	} );
+} );


### PR DESCRIPTION
## Description

Part of #349. Follows #397.

Covers the Online column on Network Admin > Sites: the avatar stack and count for a site with someone online, the em dash for a site with nobody, and the column holding its page-load snapshot across a Heartbeat tick before redrawing on reload. That last one is the deliberate choice documented on `wp_presence_render_network_sites_column()`, and nothing checked it until now.

`clearNetworkPresence()` in the shared helpers re-pushes each site's summary after deleting its rows. Deleting alone leaves a cleared site in the summary until its row ages out, and the screen keeps drawing people who have gone.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigation, implementation, and tests; reviewed and verified by me.

</details>
