### PR TITLE
fix: count Who's Online overflow from the heartbeat total

### DIFF
--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -407,18 +407,18 @@ class WP_Presence_Widget_Whos_Online {
 		return html;
 	}
 
-	function buildFullHtml(visible, overflow) {
+	function buildFullHtml(visible, overflow, overflowTotal) {
 		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.usersOnline) + '">';
 		visible.forEach(function(entry) {
 			html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
 		});
 		html += '</ul>';
 		if (overflow.length) {
-			if (overflow.length > overflowThreshold) {
+			if (overflowTotal > overflowThreshold) {
 				// Summary mode: avatar stack + count linking to Users page.
 				html += '<a href="' + esc(usersUrl) + '" class="presence-overflow-toggle">';
 				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
-				html += '<span class="presence-overflow-text">' + esc(i18n.moreCountLink.replace('%%d', overflow.length)) + '</span></a>';
+				html += '<span class="presence-overflow-text">' + esc(i18n.moreCountLink.replace('%%d', overflowTotal)) + '</span></a>';
 			} else {
 				// Expandable list mode.
 				html += '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="presence-overflow-list"';
@@ -496,13 +496,20 @@ class WP_Presence_Widget_Whos_Online {
 		var visible = entries.slice(0, maxRows);
 		var overflow = entries.slice(maxRows);
 
-		// Build a signature of user IDs + screens to detect real changes.
-		var sig = entries.map(function(e) { return e.user_id + ':' + (e.screen || ''); }).join(',');
+		// The payload is capped, so its length understates a large room. Below
+		// the threshold the cap cannot bite and the array holds all of them.
+		var total = typeof data['presence-online-total'] === 'number' ? data['presence-online-total'] : entries.length;
+		var overflowTotal = total - maxRows;
+
+		// Build a signature of user IDs + screens to detect real changes. The
+		// total leads it because the overflow count is now derived from the
+		// total, which moves while the capped entries stay identical.
+		var sig = total + '|' + entries.map(function(e) { return e.user_id + ':' + (e.screen || ''); }).join(',');
 
 		if (sig !== lastSignature) {
 			// Content changed — swap HTML instantly.
 			var focusInfo = captureFocus(container);
-			container.html(buildFullHtml(visible, overflow));
+			container.html(buildFullHtml(visible, overflow, overflowTotal));
 			restoreFocus(container, focusInfo);
 			lastSignature = sig;
 		} else {
@@ -619,12 +626,19 @@ JS,
 	}
 
 	/**
-	 * Renders the dashboard widget.
+	 * Drops the viewer's own entry from a room's presence list.
+	 *
+	 * The widget never lists the person reading it, so the server render and the
+	 * Heartbeat payload have to describe the same set. When they diverge the
+	 * overflow count the client derives from the total is one too high.
+	 *
+	 * @param array $entries Presence entries for the admin room.
+	 * @return array Entries for every user but the current one.
 	 */
-	public static function render() {
-		$entries     = wp_get_presence( wp_presence_admin_room() );
+	private static function without_current_user( $entries ) {
 		$current_uid = get_current_user_id();
-		$entries     = array_values(
+
+		return array_values(
 			array_filter(
 				$entries,
 				function ( $e ) use ( $current_uid ) {
@@ -632,6 +646,13 @@ JS,
 				}
 			)
 		);
+	}
+
+	/**
+	 * Renders the dashboard widget.
+	 */
+	public static function render() {
+		$entries = self::without_current_user( wp_get_presence( wp_presence_admin_room() ) );
 
 		echo '<div id="presence-whos-online-list" aria-live="polite" tabindex="-1">';
 
@@ -751,12 +772,14 @@ JS,
 			return $response;
 		}
 
+		$others = self::without_current_user( $entries );
+
 		// Cap to visible rows plus overflow threshold (expandable list max).
 		$cap                               = self::VISIBLE_ROWS + self::get_overflow_threshold();
 		$response['presence-online']       = self::build_online_entries(
-			array_slice( $entries, 0, $cap )
+			array_slice( $others, 0, $cap )
 		);
-		$response['presence-online-total'] = count( $entries );
+		$response['presence-online-total'] = count( $others );
 		$response['presence-online-hash']  = $hash;
 
 		return $response;

--- a/tests/e2e/presence-widgets.test.js
+++ b/tests/e2e/presence-widgets.test.js
@@ -223,4 +223,74 @@ test.describe( 'Presence Widgets', () => {
 		);
 		await expect( postLink ).toBeFocused();
 	} );
+	/**
+	 * The heartbeat payload is capped well below a large room, so the overflow
+	 * count and its link to the Users screen can only come from the total the
+	 * response carries. Reading them off the capped array instead replaces a
+	 * correct server render with a smaller count on the first tick.
+	 */
+	test( "Who's Online counts the overflow from the payload total", async ( {
+		admin,
+		page,
+	} ) => {
+		const others = 26;
+		const visibleRows = 3;
+
+		wpCli(
+			`eval-file wp-content/plugins/presence-api/tests/e2e/whos-online-overflow-seeder.php ${ others }`
+		);
+
+		try {
+			await page.addInitScript( () => {
+				window.__presenceTicks = 0;
+				document.addEventListener( 'DOMContentLoaded', () => {
+					jQuery( document ).on( 'heartbeat-tick', ( event, data ) => {
+						if ( data[ 'presence-online' ] ) {
+							window.__presenceTicks++;
+						}
+					} );
+				} );
+			} );
+
+			await admin.visitAdminPage( '/' );
+
+			const summary = page.locator(
+				'#presence-whos-online-list a.presence-overflow-toggle'
+			);
+
+			const tick = async () => {
+				const before = await page.evaluate( () => window.__presenceTicks );
+				await page.evaluate( () => wp.heartbeat.connectNow() );
+				await page.waitForFunction(
+					( seen ) => window.__presenceTicks > seen,
+					before,
+					{ timeout: 30_000 }
+				);
+			};
+
+			await tick();
+
+			await expect( summary ).toContainText( `+${ others - visibleRows } more` );
+			await expect(
+				page.locator( '#presence-whos-online-list #presence-overflow-list' )
+			).toHaveCount( 0 );
+
+			// Drop a user ranked below the payload cap: the entries the client
+			// receives are byte-identical and only the total moves, so a
+			// signature built from the entries alone leaves the count stale.
+			wpCli(
+				'eval-file wp-content/plugins/presence-api/tests/e2e/whos-online-overflow-seeder.php drop-oldest'
+			);
+
+			await tick();
+
+			await expect( summary ).toContainText(
+				`+${ others - visibleRows - 1 } more`
+			);
+		} finally {
+			wpCli(
+				'eval-file wp-content/plugins/presence-api/tests/e2e/whos-online-overflow-seeder.php clean'
+			);
+		}
+	} );
 } );

--- a/tests/e2e/presence-widgets.test.js
+++ b/tests/e2e/presence-widgets.test.js
@@ -236,10 +236,6 @@ test.describe( 'Presence Widgets', () => {
 		const others = 26;
 		const visibleRows = 3;
 
-		wpCli(
-			`eval-file wp-content/plugins/presence-api/tests/e2e/whos-online-overflow-seeder.php ${ others }`
-		);
-
 		try {
 			await page.addInitScript( () => {
 				window.__presenceTicks = 0;
@@ -253,6 +249,13 @@ test.describe( 'Presence Widgets', () => {
 			} );
 
 			await admin.visitAdminPage( '/' );
+
+			// Seed after the page load tick, not before. Seeding first lets that
+			// tick carry the final state, and the forced tick then comes back
+			// `presence-online-unchanged`, which never reaches the listener.
+			wpCli(
+				`eval-file wp-content/plugins/presence-api/tests/e2e/whos-online-overflow-seeder.php ${ others }`
+			);
 
 			const summary = page.locator(
 				'#presence-whos-online-list a.presence-overflow-toggle'

--- a/tests/e2e/whos-online-overflow-seeder.php
+++ b/tests/e2e/whos-online-overflow-seeder.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Seeds the admin presence room for the Who's Online overflow spec.
+ *
+ * Populating the room through the UI would need one logged-in browser per
+ * user, so the rows go in directly:
+ *
+ *   wp eval-file .../whos-online-overflow-seeder.php <count>
+ *   wp eval-file .../whos-online-overflow-seeder.php drop-oldest
+ *   wp eval-file .../whos-online-overflow-seeder.php clean
+ *
+ * @package Presence_API
+ */
+
+global $wpdb;
+
+$room = wp_presence_admin_room();
+$mode = isset( $args[0] ) ? $args[0] : 'clean';
+
+if ( 'drop-oldest' === $mode ) {
+	$entries = wp_get_presence( $room );
+	$oldest  = end( $entries );
+
+	wp_remove_presence( $room, $oldest->client_id );
+
+	echo $oldest->client_id . " removed\n";
+
+	return;
+}
+
+foreach ( wp_get_presence( $room ) as $entry ) {
+	wp_remove_presence( $room, $entry->client_id );
+}
+
+if ( 'clean' === $mode ) {
+	$stale = get_users(
+		array(
+			'search'         => 'presence_overflow_*',
+			'search_columns' => array( 'user_login' ),
+			'fields'         => 'ID',
+		)
+	);
+
+	foreach ( $stale as $user_id ) {
+		wp_delete_user( $user_id );
+	}
+
+	echo count( $stale ) . " removed\n";
+
+	return;
+}
+
+for ( $i = 1; $i <= (int) $mode; $i++ ) {
+	$login   = 'presence_overflow_' . $i;
+	$user_id = username_exists( $login );
+
+	if ( ! $user_id ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => $login,
+				'user_pass'    => wp_generate_password(),
+				'user_email'   => $login . '@example.com',
+				'display_name' => 'Overflow ' . $i,
+				'role'         => 'editor',
+			)
+		);
+	}
+
+	wp_set_presence( $room, 'user-' . $user_id, array( 'screen' => 'dashboard' ), $user_id );
+
+	// wp_get_presence() orders by date_gmt, so stagger the rows to make
+	// "oldest" deterministic. Well inside the 150 second TTL at any count
+	// this spec uses.
+	$wpdb->update(
+		$wpdb->presence,
+		array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - $i ) ),
+		array(
+			'room'      => $room,
+			'client_id' => 'user-' . $user_id,
+		),
+		array( '%s' ),
+		array( '%s', '%s' )
+	);
+}
+
+echo count( wp_get_presence( $room ) ) . " online\n";

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -73,11 +73,13 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	public function test_heartbeat_received_returns_online_users() {
 		wp_set_current_user( self::$editor_id );
 
+		$other_id = $this->add_user_to_room( 'dashboard', 0 );
+
 		$response = $this->tick();
 
 		$this->assertArrayHasKey( 'presence-online', $response );
 		$this->assertCount( 1, $response['presence-online'] );
-		$this->assertSame( self::$editor_id, $response['presence-online'][0]['user_id'] );
+		$this->assertSame( $other_id, $response['presence-online'][0]['user_id'] );
 		$this->assertArrayHasKey( 'avatar_url', $response['presence-online'][0] );
 		$this->assertArrayHasKey( 'date_gmt', $response['presence-online'][0] );
 	}
@@ -101,6 +103,8 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	 */
 	public function test_heartbeat_response_returns_structured_data() {
 		wp_set_current_user( self::$editor_id );
+
+		$this->add_user_to_room( 'dashboard', 0 );
 
 		$response = $this->tick();
 
@@ -260,8 +264,47 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 		// Should only send VISIBLE_ROWS + OVERFLOW_THRESHOLD entries.
 		$this->assertCount( 23, $response['presence-online'] );
 
-		// Total should reflect all users.
-		$this->assertSame( 31, $response['presence-online-total'] );
+		// Total should reflect every user the widget would list.
+		$this->assertSame( 30, $response['presence-online-total'] );
+	}
+	/**
+	 * The client derives the overflow count from the total, so the total has to
+	 * describe the set the widget renders, which never includes the viewer.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_online_total_excludes_the_pinging_user() {
+		wp_set_current_user( self::$editor_id );
+
+		for ( $i = 0; $i < 30; $i++ ) {
+			$this->add_user_to_room( 'dashboard', 0 );
+		}
+
+		$response = $this->tick();
+
+		$this->assertSame( 30, $response['presence-online-total'] );
+	}
+
+	/**
+	 * At exactly the expandable maximum the client renders the overflow from
+	 * the payload rather than the count, so the cap has to leave room for every
+	 * other user once the viewer's own entry is gone.
+	 *
+	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
+	 */
+	public function test_heartbeat_payload_holds_every_other_user_at_the_expandable_maximum() {
+		wp_set_current_user( self::$editor_id );
+
+		$others = WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + WP_Presence_Widget_Whos_Online::get_overflow_threshold();
+
+		for ( $i = 0; $i < $others; $i++ ) {
+			$this->add_user_to_room( 'dashboard', 0 );
+		}
+
+		$ids = wp_list_pluck( $this->tick()['presence-online'], 'user_id' );
+
+		$this->assertNotContains( self::$editor_id, $ids );
+		$this->assertCount( $others, $ids );
 	}
 
 	/**

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -297,8 +297,11 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 		$others = WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + WP_Presence_Widget_Whos_Online::get_overflow_threshold();
 
+		// Stagger the ages. wp_get_presence() orders by date_gmt, and at a
+		// shared timestamp where the viewer lands is an unspecified tie, so the
+		// cap could exclude their entry by luck and hide the bug.
 		for ( $i = 0; $i < $others; $i++ ) {
-			$this->add_user_to_room( 'dashboard', 0 );
+			$this->add_user_to_room( 'dashboard', $i + 1 );
 		}
 
 		$ids = wp_list_pluck( $this->tick()['presence-online'], 'user_id' );


### PR DESCRIPTION
The load render is correct and the first tick regresses it. `render()` branches on the full overflow list, so 50 people online loads as `+47 more — view all users`. The tick response caps at `VISIBLE_ROWS + OVERFLOW_THRESHOLD`, the client splits 3 visible rows off that capped array, and `overflow.length > overflowThreshold` can never be true afterwards, so the link is replaced by a `+19 more` expandable list and 28 people become unreachable.

Both the branch and the count now come from `presence-online-total`, which was already in the response and unread.

**The decision this needed that the issue does not cover.** `presence-online-total` counted the viewer, while `render()` and the widget JS both filter the viewer out, so the total was one too high and could not be used as it stood. Rather than subtracting one on the client, `heartbeat_received()` now filters the viewer the same way `render()` does, through a shared `without_current_user()`. Two consequences worth your review:

- `presence-online` no longer carries the viewer's own entry. Three existing tests asserted that it did, including one where the viewer was the only person in the room. They now assert the same payload shape against a second user.
- It also fixes the cap boundary. The cap ran before the viewer was filtered, so at exactly 23 other users the client received 22 and the expanded list silently dropped one.

The client signature now leads with the total. Without that, a user leaving from below the cap moves the count while the capped entries stay identical, and the widget keeps showing the old number.

One correction to the issue body: the count saturates at 19, not 20, for the same off by one reason.

Verified on a local site with 50 users online. Before: server render `+47 more — view all users`, first tick payload `entries: 23, total: 51`, widget then shows `+19 more` with the link gone. After: same server render, payload `total: 50`, widget still shows `+47 more — view all users`.

PHPUnit goes 401 to 403, both green. The new e2e spec covers the tick, and its second phase covers the stale count. Each new guard was mutation checked.

Fixes #360

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Implementation, the PHPUnit and e2e tests, and the local reproduction rig. I reviewed the change and checked the before and after on a local site before opening this.

</details>
