### PR TITLE
fix: prune network summary rows past the read cutoff

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -403,6 +403,78 @@ function wp_presence_on_delete_site( $old_site ) {
 }
 
 /**
+ * Deletes summary rows that are already past the read cutoff.
+ *
+ * Runs on wp_delete_expired_presence_data. Every site prunes the whole table
+ * rather than its own row: the site whose row went stale is the one whose cron
+ * has stopped firing.
+ *
+ * Not gated on wp_presence_network_aggregation_enabled(), which stops rows
+ * being written without clearing the ones already there.
+ *
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ */
+function wp_presence_delete_expired_network_summary_rows() {
+	global $wpdb;
+
+	if ( ! wp_presence_has_network_summary_table() ) {
+		return;
+	}
+
+	$timeout = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
+	$cutoff  = gmdate( 'Y-m-d H:i:s', time() - $timeout );
+
+	/** This filter is documented in includes/functions.php */
+	$batch_size = (int) apply_filters( 'wp_presence_cleanup_batch_size', 1000 );
+
+	/** This filter is documented in includes/functions.php */
+	$max_passes = (int) apply_filters( 'wp_presence_cleanup_max_passes', 10 );
+
+	if ( $batch_size < 1 || $max_passes < 1 ) {
+		return;
+	}
+
+	$deleted = false;
+
+	for ( $pass = 0; $pass < $max_passes; $pass++ ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$blog_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT blog_id FROM {$wpdb->presence_network_summary} WHERE updated_gmt <= %s ORDER BY blog_id ASC LIMIT %d",
+				$cutoff,
+				$batch_size
+			)
+		);
+
+		if ( empty( $blog_ids ) ) {
+			break;
+		}
+
+		$blog_ids     = array_map( 'intval', $blog_ids );
+		$placeholders = implode( ', ', array_fill( 0, count( $blog_ids ), '%d' ) );
+
+		// The repeated cutoff keeps a row re-pushed since the select above.
+		//
+		// IDs are cast to integers above and passed to prepare() as %d
+		// replacements, so the interpolated placeholder list is safe.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->presence_network_summary} WHERE blog_id IN ( $placeholders ) AND updated_gmt <= %s", array_merge( $blog_ids, array( $cutoff ) ) ) );
+
+		$deleted = true;
+
+		if ( count( $blog_ids ) < $batch_size ) {
+			break;
+		}
+	}
+
+	if ( $deleted ) {
+		wp_presence_flush_network_summary_cache();
+	}
+}
+
+/**
  * Returns the capability required to see network-wide presence data.
  *
  * @access private

--- a/presence-api.php
+++ b/presence-api.php
@@ -326,6 +326,7 @@ if ( is_multisite() ) {
 	add_action( 'wp_presence_admin_room_changed', 'wp_presence_push_network_summary' );
 	add_action( 'wp_presence_admin_room_changed', 'wp_presence_flush_network_summary_cache' );
 	add_action( 'wp_delete_site', 'wp_presence_on_delete_site' );
+	add_action( 'wp_delete_expired_presence_data', 'wp_presence_delete_expired_network_summary_rows' );
 }
 // Priority 99 to run after core's wp_initialize_site() at 10.
 add_action( 'wp_initialize_site', 'wp_presence_on_initialize_site', 99 );

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -182,6 +182,89 @@ class WP_Test_Network_Presence extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * The read only hides an expired row. Nothing else takes it off disk, so a
+	 * site that goes idle would hold the user IDs it last pushed indefinitely.
+	 *
+	 * @covers ::wp_presence_delete_expired_network_summary_rows
+	 */
+	public function test_cleanup_deletes_a_row_past_the_read_cutoff() {
+		$blog_id = $this->create_blog();
+
+		$this->set_network_summary_row(
+			$blog_id,
+			array( self::$editor_id ),
+			gmdate( 'Y-m-d H:i:s', time() - WP_PRESENCE_DEFAULT_TTL - 1 )
+		);
+
+		wp_presence_delete_expired_network_summary_rows();
+
+		$this->assertNull( $this->get_network_summary_row( $blog_id ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_delete_expired_network_summary_rows
+	 */
+	public function test_cleanup_leaves_a_row_inside_the_read_cutoff() {
+		$blog_id = $this->create_blog();
+
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		wp_presence_delete_expired_network_summary_rows();
+
+		$this->assertNotNull( $this->get_network_summary_row( $blog_id ) );
+	}
+
+	/**
+	 * A single invocation deletes at most batch_size * max_passes rows and
+	 * leaves the remainder for the next scheduled run.
+	 *
+	 * @covers ::wp_presence_delete_expired_network_summary_rows
+	 */
+	public function test_cleanup_is_bounded_per_invocation() {
+		global $wpdb;
+
+		$expired = gmdate( 'Y-m-d H:i:s', time() - WP_PRESENCE_DEFAULT_TTL - 1 );
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->set_network_summary_row( $this->create_blog(), array( self::$editor_id ), $expired );
+		}
+
+		$before = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence_network_summary}" );
+
+		$two = static function () {
+			return 2;
+		};
+		add_filter( 'wp_presence_cleanup_batch_size', $two );
+		add_filter( 'wp_presence_cleanup_max_passes', $two );
+
+		wp_presence_delete_expired_network_summary_rows();
+
+		$this->assertSame(
+			$before - 4,
+			(int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->presence_network_summary}" ),
+			'One invocation should delete batch_size * max_passes (4) rows and leave the rest.'
+		);
+
+		remove_filter( 'wp_presence_cleanup_batch_size', $two );
+		remove_filter( 'wp_presence_cleanup_max_passes', $two );
+	}
+
+	/**
+	 * Cron can fire in the request between network activation and the first
+	 * push, before the table exists.
+	 *
+	 * @covers ::wp_presence_delete_expired_network_summary_rows
+	 */
+	public function test_cleanup_is_a_no_op_before_the_table_is_provisioned() {
+		$version = get_site_option( 'wp_presence_network_summary_db_version' );
+		delete_site_option( 'wp_presence_network_summary_db_version' );
+
+		$this->assertNull( wp_presence_delete_expired_network_summary_rows() );
+
+		update_site_option( 'wp_presence_network_summary_db_version', $version );
+	}
+
+	/**
 	 * The read path is reached on a network whose table has not been provisioned
 	 * yet -- the plugin is network activated one request before the first push --
 	 * so it answers from the empty shape rather than querying a missing table.


### PR DESCRIPTION
A site that goes idle stops pushing, and until now its last summary row stayed on disk with the user IDs it was holding.

Fixes #395.

## Design notes

**Every site prunes the whole table, not just its own row.** The site whose row went stale is the site whose cron has stopped firing, so per-site pruning cannot reach the rows that need it.

**The `DELETE` repeats the cutoff rather than deleting by ID alone.** A site can push between the select and the delete, and that row has to survive. It is also the whole of the concurrency story: nothing reads, modifies and writes back, so a second overlapping run matches nothing.

**Not gated on `wp_presence_network_aggregation_enabled()`.** A network that switches aggregation off stops writing rows and keeps every row it already wrote.

No `@since`: the function is `@access private` and adds no filter, and `Detect new public surfaces` reports none.

## Verification

| Check | Result |
| --- | --- |
| PHPUnit multisite | 400 tests, 877 assertions, 2 skipped |
| PHPUnit single site | 400 tests, 676 assertions, 101 skipped |
| phpcs | clean |
| phpstan | clean |

Each test was checked against a mutation rather than a green run:

| Mutation | Caught by |
| --- | --- |
| Prune disabled entirely | `deletes_a_row_past_the_read_cutoff`, `is_bounded_per_invocation` |
| Both cutoffs removed | all three, and only `leaves_a_row_inside_the_read_cutoff` catches deleting a live row |
| Select cutoff removed, delete cutoff kept | nothing, correctly. The select cutoff is batching, the delete cutoff is the guard |

The re-push race is hand-traced only. Nothing in the suite runs two cron invocations concurrently.

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with implementation and testing

</details>
