### PR TITLE
fix: preserve accessible names across heartbeat re-renders in the network Who's Online widget

### DIFF
--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -231,7 +231,11 @@ class WP_Presence_Network_Widget_Whos_Online {
 		$i18n_json = wp_json_encode(
 			array(
 				'noUsersOnline' => __( 'No users are currently online anywhere on the network.', 'presence-api' ),
-				'viewAll'       => __( 'view all', 'presence-api' ),
+				'sitesOnline'   => __( 'Sites with online users', 'presence-api' ),
+				/* translators: %d: Number of additional sites with online users. */
+				'moreSite'      => __( '+%d more site — view all', 'presence-api' ),
+				/* translators: %d: Number of additional sites with online users. */
+				'moreSites'     => __( '+%d more sites — view all', 'presence-api' ),
 			)
 		);
 
@@ -295,7 +299,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
 		}
 
-		var html = '<ul class="presence-user-list">';
+		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.sitesOnline) + '">';
 		sites.forEach(function(site) {
 			html += '<li class="presence-site-item" data-blog-id="' + parseInt(site.blog_id, 10) + '">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
 			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
@@ -304,7 +308,10 @@ class WP_Presence_Network_Widget_Whos_Online {
 		html += '</ul>';
 
 		if (overflow > 0) {
-			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">+' + overflow + ' — ' + esc(i18n.viewAll) + '</a>';
+			// Both forms come from the server because _n() cannot be called from
+			// here; picking on the count is as close as this gets to its rules.
+			var moreLabel = (overflow === 1 ? i18n.moreSite : i18n.moreSites).replace('%%d', overflow);
+			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">' + esc(moreLabel) + '</a>';
 		}
 
 		return html;

--- a/tests/e2e/network-helpers.js
+++ b/tests/e2e/network-helpers.js
@@ -165,8 +165,35 @@ export function networkUserId( login ) {
  * @returns {number} Blog ID.
  */
 export function networkSiteId( slug ) {
-	return parseInt(
-		wpCli( `eval 'echo get_id_from_blogname( "${ slug }" );'` ),
+	const id = parseInt(
+		wpCli( `eval 'echo (int) get_id_from_blogname( "${ slug }" );'` ),
 		10
 	);
+
+	return Number.isNaN( id ) ? 0 : id;
+}
+
+/**
+ * Creates a sub-site if the fixture network does not have it yet.
+ *
+ * Used by the overflow case, which needs more sites online than the widget
+ * shows. They are left behind on purpose: the other specs address rows by ID,
+ * so a wider network costs them nothing, and creating a site is slow enough to
+ * be worth doing once per environment rather than once per run.
+ *
+ * @param {string} slug Sub-site slug.
+ * @returns {number} Blog ID.
+ */
+export function ensureNetworkSite( slug ) {
+	const existing = networkSiteId( slug );
+
+	if ( existing ) {
+		return existing;
+	}
+
+	wpCli(
+		`site create --slug=${ slug } --title="${ slug }" --email=wordpress@example.com`
+	);
+
+	return networkSiteId( slug );
 }

--- a/tests/e2e/presence-network-widget.test.js
+++ b/tests/e2e/presence-network-widget.test.js
@@ -1,0 +1,194 @@
+/**
+ * Presence API — Network Admin "Who's Online" dashboard widget E2E Tests
+ *
+ * The one screen of the three that updates over Heartbeat: the server renders
+ * the site list, and every tick replaces it in place.
+ *
+ * Runs against the multisite instance, not the site the other specs use. See
+ * scripts/start-multisite-env.sh.
+ *
+ * The admin driving these tests counts as online: rendering any admin screen
+ * writes the viewer into the admin room server-side, so the main site is always
+ * one of the sites listed. See wp_presence_enqueue_heartbeat_ping().
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js --project chromium-multisite
+ *
+ * @package WordPress
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import {
+	NETWORK_USERS,
+	SITE_SLUG,
+	clearNetworkPresence,
+	ensureNetworkSite,
+	forceHeartbeatTick,
+	networkSiteId,
+	setNetworkPresence,
+	siteLabel,
+} from './network-helpers';
+
+/**
+ * Sub-sites created for the overflow case, on top of the main site and the one
+ * the fixture network already has.
+ *
+ * Five is what it takes to push past the widget's own VISIBLE_SITES of 5 and
+ * leave sites over for the "more sites" link to count.
+ */
+const OVERFLOW_SLUGS = [ 'over1', 'over2', 'over3', 'over4', 'over5' ];
+
+let mainSiteId;
+let teamSiteId;
+
+test.describe( 'Network Who\'s Online widget', () => {
+	test.beforeAll( () => {
+		mainSiteId = 1;
+		teamSiteId = networkSiteId( SITE_SLUG );
+	} );
+
+	test.beforeEach( () => {
+		clearNetworkPresence();
+	} );
+
+	test.afterAll( () => {
+		clearNetworkPresence();
+	} );
+
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 * @returns {import('@playwright/test').Locator}
+	 */
+	function widgetList( page ) {
+		return page.locator( '#presence-network-widget-list ul.presence-user-list' );
+	}
+
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 * @param {number} blogId
+	 * @returns {import('@playwright/test').Locator}
+	 */
+	function siteItem( page, blogId ) {
+		return page.locator(
+			`#presence-network-widget-list [data-blog-id="${ blogId }"]`
+		);
+	}
+
+	test( 'lists a site with online users, under an accessible name', async ( {
+		admin,
+		page,
+	} ) => {
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+
+		await admin.visitAdminPage( 'network/' );
+
+		await expect( widgetList( page ) ).toHaveAttribute(
+			'aria-label',
+			'Sites with online users'
+		);
+
+		const team = siteItem( page, teamSiteId );
+
+		await expect(
+			team.locator( '.presence-avatar-stack img' )
+		).toHaveAttribute( 'alt', NETWORK_USERS.a.displayName );
+		await expect( team.locator( '.presence-site-info a' ) ).toHaveText(
+			siteLabel( SITE_SLUG )
+		);
+		await expect( team.locator( '.presence-site-count' ) ).toHaveText( '1' );
+	} );
+
+	test( 'adds a site over a heartbeat tick, without a reload', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'network/' );
+
+		await expect( siteItem( page, mainSiteId ) ).toBeVisible();
+		await expect( siteItem( page, teamSiteId ) ).toHaveCount( 0 );
+
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+		await forceHeartbeatTick( page );
+
+		await expect( siteItem( page, teamSiteId ) ).toBeVisible();
+		await expect(
+			siteItem( page, teamSiteId ).locator( '.presence-site-count' )
+		).toHaveText( '1' );
+	} );
+
+	test( 'keeps focus on a site link across a heartbeat re-render', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'network/' );
+
+		const mainLink = siteItem( page, mainSiteId ).locator(
+			'.presence-site-info a'
+		);
+
+		await mainLink.focus();
+		await expect( mainLink ).toBeFocused();
+
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+		await forceHeartbeatTick( page );
+
+		await expect( siteItem( page, teamSiteId ) ).toBeVisible();
+		await expect(
+			siteItem( page, mainSiteId ).locator( '.presence-site-info a' )
+		).toBeFocused();
+	} );
+
+	test( 'keeps the accessible name of the list across a heartbeat re-render', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'network/' );
+
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+		await forceHeartbeatTick( page );
+
+		await expect( siteItem( page, teamSiteId ) ).toBeVisible();
+		await expect( widgetList( page ) ).toHaveAttribute(
+			'aria-label',
+			'Sites with online users'
+		);
+	} );
+
+	test( 'keeps the accessible name of the overflow link across a heartbeat re-render', async ( {
+		admin,
+		page,
+	} ) => {
+		OVERFLOW_SLUGS.forEach( ( slug ) => ensureNetworkSite( slug ) );
+
+		// Six sites online — the main site plus five — leaves one over the
+		// widget's five, so the server renders the singular link.
+		setNetworkPresence( { login: NETWORK_USERS.a.login, slug: SITE_SLUG } );
+		OVERFLOW_SLUGS.slice( 0, 4 ).forEach( ( slug ) =>
+			setNetworkPresence( {
+				login: NETWORK_USERS.a.login,
+				slug,
+				client: `e2e-${ slug }`,
+			} )
+		);
+
+		await admin.visitAdminPage( 'network/' );
+
+		const moreLink = page.locator(
+			'#presence-network-widget-list .presence-more-link'
+		);
+
+		await expect( moreLink ).toHaveText( '+1 more site — view all' );
+
+		// A seventh site online takes the overflow to two, so the tick has to
+		// redraw the link, and it has to still say what it counts.
+		setNetworkPresence( {
+			login: NETWORK_USERS.a.login,
+			slug: OVERFLOW_SLUGS[ 4 ],
+			client: `e2e-${ OVERFLOW_SLUGS[ 4 ] }`,
+		} );
+		await forceHeartbeatTick( page );
+
+		// The seventh site is what the link counts, not something it shows, so
+		// the link's own text is the only place the tick is visible.
+		await expect( moreLink ).toHaveText( '+2 more sites — view all' );
+	} );
+} );

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -219,6 +219,21 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 		$this->assertSame( 'Renamed Editor', $second['presence-network-widget'][0]['users'][0]['display_name'] );
 	}
 
+	/**
+	 * The tick replaces the whole list, so anything the server render says has
+	 * to be said again by the script that rebuilds it. The list's name and the
+	 * overflow link's wording were dropped there and are cheap to lose again.
+	 */
+	public function test_inline_script_carries_the_accessible_names_the_render_uses() {
+		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'index.php' );
+
+		$script = implode( '', (array) wp_scripts()->get_data( 'presence-network-widget', 'after' ) );
+
+		$this->assertStringContainsString( 'Sites with online users', $script, 'The rebuilt list has no accessible name.' );
+		$this->assertStringContainsString( '+%d more site \u2014 view all', $script, 'The rebuilt overflow link stops saying what it counts.' );
+		$this->assertStringContainsString( '+%d more sites \u2014 view all', $script );
+	}
+
 	public function test_render_reports_nobody_online() {
 		ob_start();
 		WP_Presence_Network_Widget_Whos_Online::render();


### PR DESCRIPTION
## Description

Fixes #349. Follows #407.

`buildListHtml` dropped two things the server render has: the list's `aria-label`, and the wording of the overflow link, which went from `+2 more sites — view all` to `+2 — view all`. The rebuild runs on load through `connectNow()`, not only on some later tick, so this is what a screen reader gets within a second of opening the network dashboard. #390 fixed focus in the same function; this is the rest of it.

Both plural forms now come from the server and the count picks between them, the way the single-site widget already handles `hourAgo` and `hoursAgo` - `_n()` cannot be called from there.

| Before | After |
| --- | --- |
| <img width="526" height="295" alt="network-widget-before" src="https://github.com/user-attachments/assets/fbc63638-3574-4549-81b0-ccfdc6dca1d7" /> | <img width="526" height="295" alt="network-widget-after" src="https://github.com/user-attachments/assets/ae5a9808-7132-42ae-82b7-f8222607ec10" /> |

The link is the visible half. The list's name only shows in the accessibility tree, from the same two runs:

```
- list:                        - list "Sites with online users":
- link "+2 — view all"         - link "+2 more sites — view all"
```

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigation, implementation, and tests.

</details>
