### PR TITLE
fix: run workflows on the release pull request's final commit

### DIFF
--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -198,20 +198,16 @@ jobs:
             const url = process.env.PLAYGROUND_URL;
             const url40 = process.env.PLAYGROUND_URL_40;
             const urlMultisite = process.env.PLAYGROUND_URL_MULTISITE;
-            const sha = process.env.HEAD_SHA;
+            const sha = process.env.HEAD_SHA.slice(0, 7);
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const badge = (variant) =>
               `https://img.shields.io/badge/Playground-${variant}-3858E9?logo=wordpress&logoColor=white`;
 
             const body = [
               marker,
-              '## ▶ Preview in WordPress Playground',
+              `[![Single site](${badge('Single%20site')})](${url}) [![Multisite](${badge('Multisite')})](${urlMultisite}) [![40 users](${badge('40%20users')})](${url40})`,
               '',
-              `[![Single site](${badge('Single%20site')})](${url}) [![Multisite network](${badge('Multisite%20network')})](${urlMultisite})`,
-              '',
-              "Both boot a fresh WordPress with this PR's presence-api build and log you in. Single site seeds 5 demo users and lands on the dashboard. Multisite network adds three sub-sites alongside the main one, seeds 5 users on each, and lands on Network Admin.",
-              '',
-              `<sub>Stress-test variant: [40 demo users](${url40}) · Built from \`${sha}\`. Auto-updates when you push.</sub>`,
+              `<sub>Fresh WordPress with this PR's build, logged in and seeded. Built from \`${sha}\`, rebuilt on every push.</sub>`,
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,9 +64,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ fromJSON(needs.release-please.outputs.pr).number }}
         run: node .github/scripts/sync-contributors.js readme.txt
+      # Pushed with the same token release-please uses. A commit pushed under
+      # GITHUB_TOKEN leaves the PR's head build stuck at `action_required`, so
+      # the release PR never gets a Playground preview of what is shipping.
       - name: Commit synced versions back to the release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           if ! git diff --quiet; then
             git config user.name "github-actions[bot]"


### PR DESCRIPTION
The release PR has never had a Playground preview, which is the one PR where a spot check of the staged build matters most.

Fixes #419

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with tracing why the publish run never posted

</details>
