### PR TITLE
chore: lay the Playground preview links out as a grid

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -16,6 +16,7 @@ build
 blueprint.json
 blueprint-40.json
 blueprint-multisite.json
+blueprint-multisite-40.json
 CHANGELOG.md
 README.md
 SECURITY.md

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -175,6 +175,7 @@ jobs:
           BLUEPRINT=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint.json)
           BLUEPRINT_40=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint-40.json)
           BLUEPRINT_MS=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint-multisite.json)
+          BLUEPRINT_MS40=$(transform "$PLUGIN_URL" "$SEEDER_URL" "$HELPER_URL" blueprint-multisite-40.json)
 
           encode() { printf '%s' "$1" | base64 -w0; }
 
@@ -182,6 +183,7 @@ jobs:
             echo "url=https://playground.wordpress.net/#$(encode "$BLUEPRINT")"
             echo "url_40=https://playground.wordpress.net/#$(encode "$BLUEPRINT_40")"
             echo "url_multisite=https://playground.wordpress.net/#$(encode "$BLUEPRINT_MS")"
+            echo "url_multisite_40=https://playground.wordpress.net/#$(encode "$BLUEPRINT_MS40")"
           } >> "$GITHUB_OUTPUT"
 
       - name: Post or update sticky comment
@@ -192,22 +194,29 @@ jobs:
           PLAYGROUND_URL: ${{ steps.playground.outputs.url }}
           PLAYGROUND_URL_40: ${{ steps.playground.outputs.url_40 }}
           PLAYGROUND_URL_MULTISITE: ${{ steps.playground.outputs.url_multisite }}
+          PLAYGROUND_URL_MULTISITE_40: ${{ steps.playground.outputs.url_multisite_40 }}
         with:
           script: |
             const marker = '<!-- presence-api:playground-preview -->';
             const url = process.env.PLAYGROUND_URL;
             const url40 = process.env.PLAYGROUND_URL_40;
             const urlMultisite = process.env.PLAYGROUND_URL_MULTISITE;
-            const sha = process.env.HEAD_SHA.slice(0, 7);
+            const urlMultisite40 = process.env.PLAYGROUND_URL_MULTISITE_40;
+            const fullSha = process.env.HEAD_SHA;
+            const sha = fullSha.slice(0, 7);
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${fullSha}`;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const badge = (variant) =>
-              `https://img.shields.io/badge/Playground-${variant}-3858E9?logo=wordpress&logoColor=white`;
+            const badge = 'https://img.shields.io/badge/Launch-3858E9?logo=wordpress&logoColor=white';
+            const launch = (href) => `[![Launch](${badge})](${href})`;
 
             const body = [
               marker,
-              `[![Single site](${badge('Single%20site')})](${url}) [![Multisite](${badge('Multisite')})](${urlMultisite}) [![40 users](${badge('40%20users')})](${url40})`,
+              '| Playground | 5 users | 40 users |',
+              '| --- | --- | --- |',
+              `| **Single site** | ${launch(url)} | ${launch(url40)} |`,
+              `| **Multisite** | ${launch(urlMultisite)} | ${launch(urlMultisite40)} |`,
               '',
-              `<sub>Fresh WordPress with this PR's build, logged in and seeded. Built from \`${sha}\`, rebuilt on every push.</sub>`,
+              `<sub>Boots WordPress Playground with this PR's build, logged in and seeded.<br>Built from [\`${sha}\`](${commitUrl}), rebuilt on every push.</sub>`,
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Schema-validate blueprints
         run: |
           set -euo pipefail
-          for f in blueprint.json blueprint-40.json blueprint-multisite.json; do
+          for f in blueprint.json blueprint-40.json blueprint-multisite.json blueprint-multisite-40.json; do
             # This step is the base's, the checkout is the PR's head.
             if [ ! -f "$f" ]; then
               echo "::notice::$f is not on this branch, so nothing to validate."

--- a/blueprint-multisite-40.json
+++ b/blueprint-multisite-40.json
@@ -53,7 +53,7 @@
 		},
 		{
 			"step": "wp-cli",
-			"command": "wp eval 'require \"/wordpress/wp-content/plugins/presence-api/demo-seeder.php\"; $counts = array( 2, 1, 1, 1 ); $offset = 0; foreach ( get_sites( array( \"number\" => 100, \"orderby\" => \"id\" ) ) as $i => $site ) { $count = isset( $counts[ $i ] ) ? $counts[ $i ] : 1; $blog_id = (int) $site->blog_id; switch_to_blog( $blog_id ); foreach ( wp_presence_demo_seed( $count, $offset ) as $user_id ) { add_user_to_blog( $blog_id, $user_id, \"editor\" ); } restore_current_blog(); $offset += $count; } update_user_meta( 1, \"show_welcome_panel\", 0 );'"
+			"command": "wp eval 'require \"/wordpress/wp-content/plugins/presence-api/demo-seeder.php\"; $counts = array( 16, 10, 8, 6 ); $offset = 0; foreach ( get_sites( array( \"number\" => 100, \"orderby\" => \"id\" ) ) as $i => $site ) { $count = isset( $counts[ $i ] ) ? $counts[ $i ] : 1; $blog_id = (int) $site->blog_id; switch_to_blog( $blog_id ); foreach ( wp_presence_demo_seed( $count, $offset ) as $user_id ) { add_user_to_blog( $blog_id, $user_id, \"editor\" ); } restore_current_blog(); $offset += $count; } update_user_meta( 1, \"show_welcome_panel\", 0 );'"
 		}
 	]
 }

--- a/tests/e2e/demo-seeder.php
+++ b/tests/e2e/demo-seeder.php
@@ -235,11 +235,14 @@ function wp_presence_demo_ensure_posts() {
  * Creates N demo users and seeds their presence entries.
  *
  * @since 7.1.0
+ * @since 0.2.2 Added the `$offset` parameter.
  *
- * @param int $count Number of users to create.
+ * @param int $count  Number of users to create.
+ * @param int $offset Index to start the username sequence at. Multisite users are
+ *                    network-global, so each site needs its own slice.
  * @return array Array of created user IDs.
  */
-function wp_presence_demo_seed( $count ) {
+function wp_presence_demo_seed( $count, $offset = 0 ) {
 	$user_ids = array();
 	$has_cli  = defined( 'WP_CLI' ) && WP_CLI;
 
@@ -251,13 +254,13 @@ function wp_presence_demo_seed( $count ) {
 	}
 
 	for ( $i = 0; $i < $count; $i++ ) {
-		$username = 'presence-demo-' . ( $i + 1 );
+		$username = 'presence-demo-' . ( $offset + $i + 1 );
 		$user     = get_user_by( 'login', $username );
 
 		if ( $user ) {
 			$user_ids[] = $user->ID;
 		} else {
-			$name = wp_presence_demo_name( $i );
+			$name = wp_presence_demo_name( $offset + $i );
 
 			$user_id = wp_insert_user(
 				array(


### PR DESCRIPTION
Three preview links in a row gave no indication of what they launched or how they differed, and the variants are really two dimensions rather than three options.

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with the comment layout and the multisite seeding offset

</details>
