### PR TITLE
fix: count everyone present, including yourself, on every surface

### DIFF
--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -137,7 +137,9 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 	foreach ( $here as $entry ) {
 		$stack_ids[] = (int) $entry->user_id;
 	}
-	$stack_ids = array_slice( array_unique( $stack_ids ), 0, 10 );
+	// You, plus nine others. The cap counts you now that you are in the stack.
+	$stack_limit = 10;
+	$stack_ids   = array_slice( array_unique( $stack_ids ), 0, $stack_limit );
 
 	$stack_html = '<span class="presence-bar-avatars">';
 	$z          = count( $stack_ids );

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -130,8 +130,6 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 		}
 	}
 
-	$current_user = get_userdata( $current_uid );
-
 	// You first, then others on this page. Mirrors the flyout's "On this page".
 	$stack_ids = array( $current_uid );
 	foreach ( $here as $entry ) {
@@ -193,6 +191,8 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 	);
 
 	// Current user first.
+	$current_user = get_userdata( $current_uid );
+
 	$wp_admin_bar->add_node(
 		array(
 			'parent' => 'presence-online',

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -153,13 +153,7 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 
 	$stack_html .= '</span>';
 
-	// Subtract by identity, never arithmetic: your row is absent on screens
-	// that are not writing heartbeats, so the total is already others-only.
-	$online_ids = array_map( 'intval', array_unique( wp_list_pluck( $entries, 'user_id' ) ) );
-	if ( $current_uid && ! in_array( $current_uid, $online_ids, true ) ) {
-		$online_ids[] = $current_uid;
-	}
-	$online_count = count( $online_ids );
+	$online_count = count( wp_presence_online_user_ids( $entries ) );
 
 	/* translators: %d: Number of online users, including the current user. */
 	$label = sprintf( _n( '%d online', '%d online', $online_count, 'presence-api' ), $online_count );

--- a/includes/admin-bar.php
+++ b/includes/admin-bar.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Adds a presence indicator to the admin bar showing other online users.
+ * Adds a presence indicator to the admin bar showing online users.
  *
  * @param WP_Admin_Bar $wp_admin_bar The admin bar instance.
  */
@@ -22,7 +22,8 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 	$entries     = wp_get_presence( wp_presence_admin_room() );
 	$current_uid = get_current_user_id();
 
-	// Only show the admin bar node when other users are online.
+	// The count includes you, the gate does not. A lone user gets no node,
+	// but once anyone else is here the number matches every other surface.
 	$others = array_filter(
 		$entries,
 		function ( $e ) use ( $current_uid ) {
@@ -129,19 +130,20 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 		}
 	}
 
-	// "Here" count includes you.
-	$here_count      = count( $here ) + 1; // +1 for current user.
-	$elsewhere_count = count( $elsewhere );
-
-	// Build avatar stack from users on this page only (not current user), capped at 10.
-	$stack_html   = '<span class="presence-bar-avatars">';
 	$current_user = get_userdata( $current_uid );
-	$stack_limit  = 10;
-	$stack_show   = array_slice( $here, 0, $stack_limit );
-	$z            = count( $stack_show );
 
-	foreach ( $stack_show as $entry ) {
-		$user = get_userdata( $entry->user_id );
+	// You first, then others on this page. Mirrors the flyout's "On this page".
+	$stack_ids = array( $current_uid );
+	foreach ( $here as $entry ) {
+		$stack_ids[] = (int) $entry->user_id;
+	}
+	$stack_ids = array_slice( array_unique( $stack_ids ), 0, 10 );
+
+	$stack_html = '<span class="presence-bar-avatars">';
+	$z          = count( $stack_ids );
+
+	foreach ( $stack_ids as $stack_uid ) {
+		$user = get_userdata( $stack_uid );
 		if ( ! $user ) {
 			continue;
 		}
@@ -151,10 +153,16 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 
 	$stack_html .= '</span>';
 
-	$others_count = count( $others );
+	// Subtract by identity, never arithmetic: your row is absent on screens
+	// that are not writing heartbeats, so the total is already others-only.
+	$online_ids = array_map( 'intval', array_unique( wp_list_pluck( $entries, 'user_id' ) ) );
+	if ( $current_uid && ! in_array( $current_uid, $online_ids, true ) ) {
+		$online_ids[] = $current_uid;
+	}
+	$online_count = count( $online_ids );
 
-	/* translators: %d: Number of other online users (excluding current user). */
-	$label = sprintf( _n( '%d online', '%d online', $others_count, 'presence-api' ), $others_count );
+	/* translators: %d: Number of online users, including the current user. */
+	$label = sprintf( _n( '%d online', '%d online', $online_count, 'presence-api' ), $online_count );
 
 	$wp_admin_bar->add_node(
 		array(
@@ -165,9 +173,9 @@ function wp_presence_admin_bar_node( $wp_admin_bar ) {
 				'class'      => 'presence-bar-node menupop',
 				'tabindex'   => 0,
 				'aria-label' => sprintf(
-				/* translators: %d: Number of other users currently online. */
-					_n( '%d other user online', '%d other users online', $others_count, 'presence-api' ),
-					$others_count
+				/* translators: %d: Number of users currently online. */
+					_n( '%d user online', '%d users online', $online_count, 'presence-api' ),
+					$online_count
 				),
 			),
 		)

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -93,14 +93,39 @@ function wp_get_presence( $room, $timeout = WP_PRESENCE_DEFAULT_TTL ) {
  * @return int[] Unique user IDs.
  */
 function wp_presence_online_user_ids( $entries ) {
-	$online_ids = array_unique( array_map( 'intval', wp_list_pluck( $entries, 'user_id' ) ) );
+	$online_ids = array_map( 'intval', wp_list_pluck( wp_presence_with_current_user( $entries ), 'user_id' ) );
+
+	return array_values( array_unique( $online_ids ) );
+}
+
+/**
+ * Adds an entry for the current user to a set of entries when their row is absent.
+ *
+ * @access private
+ *
+ * @param array $entries Presence entries, as returned by wp_get_presence().
+ * @return array Entries with the current user included.
+ */
+function wp_presence_with_current_user( $entries ) {
 	$current_id = get_current_user_id();
 
-	if ( $current_id && ! in_array( $current_id, $online_ids, true ) ) {
-		$online_ids[] = $current_id;
+	if ( ! $current_id ) {
+		return $entries;
 	}
 
-	return array_values( $online_ids );
+	foreach ( $entries as $entry ) {
+		if ( (int) $entry->user_id === $current_id ) {
+			return $entries;
+		}
+	}
+
+	$entries[] = (object) array(
+		'user_id'  => $current_id,
+		'date_gmt' => current_time( 'mysql', true ),
+		'data'     => array(),
+	);
+
+	return $entries;
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,6 +81,29 @@ function wp_get_presence( $room, $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 }
 
 /**
+ * Returns the user IDs present in a set of entries, the current user included.
+ *
+ * The current user's own row is absent on screens that never ping and once it
+ * ages past the TTL, so it is added by identity rather than by adding one,
+ * which would double-count whenever the row is there.
+ *
+ * @access private
+ *
+ * @param array $entries Presence entries, as returned by wp_get_presence().
+ * @return int[] Unique user IDs.
+ */
+function wp_presence_online_user_ids( $entries ) {
+	$online_ids = array_unique( array_map( 'intval', wp_list_pluck( $entries, 'user_id' ) ) );
+	$current_id = get_current_user_id();
+
+	if ( $current_id && ! in_array( $current_id, $online_ids, true ) ) {
+		$online_ids[] = $current_id;
+	}
+
+	return array_values( $online_ids );
+}
+
+/**
  * Upserts a client's presence state in a room.
  *
  * Uses INSERT ... ON DUPLICATE KEY UPDATE for atomic upserts

--- a/includes/user-list.php
+++ b/includes/user-list.php
@@ -23,15 +23,8 @@ function wp_presence_users_views( $views ) {
 		return $views;
 	}
 
-	$entries         = wp_get_presence( wp_presence_admin_room() );
-	$online_ids      = array_map( 'intval', array_unique( wp_list_pluck( $entries, 'user_id' ) ) );
-	$current_user_id = get_current_user_id();
-
-	if ( $current_user_id && ! in_array( $current_user_id, $online_ids, true ) ) {
-		$online_ids[] = $current_user_id;
-	}
-
-	$online_count = count( $online_ids );
+	$entries      = wp_get_presence( wp_presence_admin_room() );
+	$online_count = count( wp_presence_online_user_ids( $entries ) );
 	$is_current   = isset( $_GET['presence_status'] ) && 'online' === $_GET['presence_status']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	$class = $is_current ? 'current' : '';
@@ -76,13 +69,7 @@ function wp_presence_filter_online_users( $query ) {
 		return;
 	}
 
-	$entries         = wp_get_presence( wp_presence_admin_room() );
-	$online_ids      = array_map( 'intval', array_unique( wp_list_pluck( $entries, 'user_id' ) ) );
-	$current_user_id = get_current_user_id();
+	$entries = wp_get_presence( wp_presence_admin_room() );
 
-	if ( $current_user_id && ! in_array( $current_user_id, $online_ids, true ) ) {
-		$online_ids[] = $current_user_id;
-	}
-
-	$query->set( 'include', array_map( 'intval', $online_ids ) );
+	$query->set( 'include', wp_presence_online_user_ids( $entries ) );
 }

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -277,7 +277,7 @@ class WP_Presence_Widget_Whos_Online {
 		$urls_json = wp_json_encode( $screen_urls );
 		$i18n_json = wp_json_encode(
 			array(
-				'noUsersOnline'   => __( 'No other users are online.', 'presence-api' ),
+				'noUsersOnline'   => __( 'No users are online.', 'presence-api' ),
 				'onlineNow'       => __( 'Online now', 'presence-api' ),
 				'usersOnline'     => __( 'Users currently online', 'presence-api' ),
 				'additionalUsers' => __( 'Additional online users', 'presence-api' ),
@@ -307,7 +307,6 @@ class WP_Presence_Widget_Whos_Online {
 	var screenLabels = %s;
 	var screenUrls = %s;
 	var i18n = %s;
-	var currentUserId = %d;
 	var idleThreshold = %d;
 	var overflowThreshold = %d;
 	var usersUrl = %s;
@@ -472,9 +471,7 @@ class WP_Presence_Widget_Whos_Online {
 			return;
 		}
 
-		var entries = data['presence-online'].filter(function(e) {
-			return e.user_id !== currentUserId;
-		});
+		var entries = data['presence-online'];
 		lastEntries = entries;
 
 		if (!entries.length) {
@@ -553,7 +550,6 @@ JS,
 			$labels_json,
 			$urls_json,
 			$i18n_json,
-			get_current_user_id(),
 			self::IDLE_THRESHOLD,
 			self::get_overflow_threshold(),
 			wp_json_encode( admin_url( 'users.php?presence_status=online' ) ),
@@ -622,21 +618,14 @@ JS,
 	 * Renders the dashboard widget.
 	 */
 	public static function render() {
-		$entries     = wp_get_presence( wp_presence_admin_room() );
-		$current_uid = get_current_user_id();
-		$entries     = array_values(
-			array_filter(
-				$entries,
-				function ( $e ) use ( $current_uid ) {
-					return (int) $e->user_id !== $current_uid;
-				}
-			)
-		);
+		// Lists everyone present, you included, so the count agrees with the
+		// admin bar and the users list.
+		$entries = array_values( wp_get_presence( wp_presence_admin_room() ) );
 
 		echo '<div id="presence-whos-online-list" aria-live="polite" tabindex="-1">';
 
 		if ( empty( $entries ) ) {
-			echo '<p>' . esc_html__( 'No other users are online.', 'presence-api' ) . '</p>';
+			echo '<p>' . esc_html__( 'No users are online.', 'presence-api' ) . '</p>';
 		} else {
 			cache_users( wp_list_pluck( $entries, 'user_id' ) );
 

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -625,85 +625,81 @@ JS,
 	 * Renders the dashboard widget.
 	 */
 	public static function render() {
-		// Lists everyone present, you included, so the count agrees with the
-		// admin bar and the users list.
-		$entries = array_values( wp_get_presence( wp_presence_admin_room() ) );
+		// Lists everyone present, you included, so the rows and the count agree
+		// with the admin bar and the users list. You are always one of them.
+		$entries = array_values( wp_presence_with_current_user( wp_get_presence( wp_presence_admin_room() ) ) );
 
 		echo '<div id="presence-whos-online-list" aria-live="polite" tabindex="-1">';
 
-		if ( empty( $entries ) ) {
-			echo '<p>' . esc_html__( 'No users are online.', 'presence-api' ) . '</p>';
-		} else {
-			cache_users( wp_list_pluck( $entries, 'user_id' ) );
+		cache_users( wp_list_pluck( $entries, 'user_id' ) );
 
-			$visible  = array_slice( $entries, 0, self::VISIBLE_ROWS );
-			$overflow = array_slice( $entries, self::VISIBLE_ROWS );
+		$visible  = array_slice( $entries, 0, self::VISIBLE_ROWS );
+		$overflow = array_slice( $entries, self::VISIBLE_ROWS );
 
-			echo '<ul class="presence-user-list" aria-label="' . esc_attr__( 'Users currently online', 'presence-api' ) . '">';
+		echo '<ul class="presence-user-list" aria-label="' . esc_attr__( 'Users currently online', 'presence-api' ) . '">';
 
-			foreach ( $visible as $entry ) {
-				$user = get_userdata( $entry->user_id );
+		foreach ( $visible as $entry ) {
+			$user = get_userdata( $entry->user_id );
 
-				if ( ! $user ) {
+			if ( ! $user ) {
+				continue;
+			}
+
+			self::render_user_row( $entry, $user );
+		}
+
+		echo '</ul>';
+
+		if ( ! empty( $overflow ) ) {
+			$stack_max   = min( count( $overflow ), self::AVATAR_STACK_MAX );
+			$stack_users = array();
+
+			foreach ( array_slice( $overflow, 0, $stack_max ) as $oentry ) {
+				$ouser = get_userdata( $oentry->user_id );
+
+				if ( ! $ouser ) {
 					continue;
 				}
 
-				self::render_user_row( $entry, $user );
+				$stack_users[] = array(
+					'display_name' => $ouser->display_name,
+					'avatar_url'   => get_avatar_url( $ouser->ID, array( 'size' => 24 ) ),
+				);
 			}
 
-			echo '</ul>';
+			if ( count( $overflow ) > self::get_overflow_threshold() ) {
+				// Summary mode: avatar stack + count linking to Users page.
+				echo '<a href="' . esc_url( admin_url( 'users.php?presence_status=online' ) ) . '" class="presence-overflow-toggle">';
+				echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, self::AVATAR_STACK_MAX ) );
+				echo '<span class="presence-overflow-text">';
+				/* translators: %d: Number of additional online users. */
+				echo esc_html( sprintf( __( '+%d more — view all users', 'presence-api' ), count( $overflow ) ) );
+				echo '</span></a>';
+			} else {
+				// Expandable list mode.
+				echo '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="false" aria-controls="presence-overflow-list">';
+				echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, self::AVATAR_STACK_MAX ) );
+				echo '<span class="presence-overflow-text">';
+				/* translators: %d: Number of additional online users. */
+				echo esc_html( sprintf( __( '+%d more', 'presence-api' ), count( $overflow ) ) );
+				echo '</span></button>';
 
-			if ( ! empty( $overflow ) ) {
-				$stack_max   = min( count( $overflow ), self::AVATAR_STACK_MAX );
-				$stack_users = array();
+				echo '<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' . esc_attr__( 'Additional online users', 'presence-api' ) . '" style="display:none">';
 
-				foreach ( array_slice( $overflow, 0, $stack_max ) as $oentry ) {
-					$ouser = get_userdata( $oentry->user_id );
+				foreach ( $overflow as $entry ) {
+					$user = get_userdata( $entry->user_id );
 
-					if ( ! $ouser ) {
+					if ( ! $user ) {
 						continue;
 					}
 
-					$stack_users[] = array(
-						'display_name' => $ouser->display_name,
-						'avatar_url'   => get_avatar_url( $ouser->ID, array( 'size' => 24 ) ),
-					);
+					self::render_user_row( $entry, $user );
 				}
 
-				if ( count( $overflow ) > self::get_overflow_threshold() ) {
-					// Summary mode: avatar stack + count linking to Users page.
-					echo '<a href="' . esc_url( admin_url( 'users.php?presence_status=online' ) ) . '" class="presence-overflow-toggle">';
-					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, self::AVATAR_STACK_MAX ) );
-					echo '<span class="presence-overflow-text">';
-					/* translators: %d: Number of additional online users. */
-					echo esc_html( sprintf( __( '+%d more — view all users', 'presence-api' ), count( $overflow ) ) );
-					echo '</span></a>';
-				} else {
-					// Expandable list mode.
-					echo '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="false" aria-controls="presence-overflow-list">';
-					echo wp_kses_post( wp_presence_render_avatar_stack( $stack_users, self::AVATAR_STACK_MAX ) );
-					echo '<span class="presence-overflow-text">';
-					/* translators: %d: Number of additional online users. */
-					echo esc_html( sprintf( __( '+%d more', 'presence-api' ), count( $overflow ) ) );
-					echo '</span></button>';
-
-					echo '<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' . esc_attr__( 'Additional online users', 'presence-api' ) . '" style="display:none">';
-
-					foreach ( $overflow as $entry ) {
-						$user = get_userdata( $entry->user_id );
-
-						if ( ! $user ) {
-							continue;
-						}
-
-						self::render_user_row( $entry, $user );
-					}
-
-					echo '</ul>';
-					echo '<button type="button" class="presence-overflow-toggle" data-action="collapse" aria-expanded="false" aria-controls="presence-overflow-list" style="display:none">';
-					echo esc_html__( 'Show less', 'presence-api' );
-					echo '</button>';
-				}
+				echo '</ul>';
+				echo '<button type="button" class="presence-overflow-toggle" data-action="collapse" aria-expanded="false" aria-controls="presence-overflow-list" style="display:none">';
+				echo esc_html__( 'Show less', 'presence-api' );
+				echo '</button>';
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ On a multisite network, Network Admin gets its own view of the same data: a Who'
 
 * Who's Online dashboard widget with idle detection
 * Active Posts dashboard widget grouped by post
-* Admin bar indicator showing who is on the same page
+* Admin bar indicator showing who's online, grouped by who's on this page
 * Editors column in the post list
 * Online filter in the Users list
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ On a multisite network, Network Admin gets its own view of the same data: a Who'
 
 * Who's Online dashboard widget with idle detection
 * Active Posts dashboard widget grouped by post
-* Admin bar indicator showing other users on the same page
+* Admin bar indicator showing who is on the same page
 * Editors column in the post list
 * Online filter in the Users list
 

--- a/tests/e2e/presence-widgets.test.js
+++ b/tests/e2e/presence-widgets.test.js
@@ -235,6 +235,8 @@ test.describe( 'Presence Widgets', () => {
 	} ) => {
 		const others = 26;
 		const visibleRows = 3;
+		// The seeded users plus you, who the widget counts as well.
+		const online = others + 1;
 
 		try {
 			await page.addInitScript( () => {
@@ -273,7 +275,7 @@ test.describe( 'Presence Widgets', () => {
 
 			await tick();
 
-			await expect( summary ).toContainText( `+${ others - visibleRows } more` );
+			await expect( summary ).toContainText( `+${ online - visibleRows } more` );
 			await expect(
 				page.locator( '#presence-whos-online-list #presence-overflow-list' )
 			).toHaveCount( 0 );
@@ -288,7 +290,7 @@ test.describe( 'Presence Widgets', () => {
 			await tick();
 
 			await expect( summary ).toContainText(
-				`+${ others - visibleRows - 1 } more`
+				`+${ online - visibleRows - 1 } more`
 			);
 		} finally {
 			wpCli(

--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -113,6 +113,24 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * Backdates a user's entry so it falls outside the TTL window.
+	 *
+	 * @param int $user_id     The user whose entry to backdate.
+	 * @param int $seconds_ago How far in the past to date the entry.
+	 */
+	private function age_entry( $user_id, $seconds_ago ) {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - $seconds_ago ) ),
+			array( 'client_id' => 'user-' . $user_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+	}
+
+	/**
 	 * The menu labels each online user with the post they are editing. A
 	 * contributor has `edit_posts`, which is all the node itself requires, but
 	 * must not learn the title of a draft they cannot edit.
@@ -248,13 +266,16 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 	}
 
 	/**
-	 * Your row is absent on screens that never ping, so the total is already
-	 * others-only and must not be decremented again.
+	 * Your own row ages past the TTL while you are still on the screen, so the
+	 * count has to add you back by identity.
 	 */
 	public function test_the_count_includes_you_when_your_own_row_has_expired() {
 		$this->put_user_on_screen( 'dashboard' );
 
 		wp_set_current_user( self::$editor_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array( 'screen' => 'dashboard' ), self::$editor_id );
+		$this->age_entry( self::$editor_id, WP_PRESENCE_DEFAULT_TTL + 1 );
+
 		$nodes = $this->render_nodes();
 
 		$this->assertStringContainsString( '2 online', $nodes['presence-online']->title );

--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -180,8 +180,8 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 	}
 
 	/**
-	 * The indicator counts other people, so on your own it says nothing rather
-	 * than reporting a room of one.
+	 * The count includes you, but the node still hides on your own rather than
+	 * reporting a room of one.
 	 */
 	public function test_no_indicator_when_you_are_the_only_one_online() {
 		wp_set_current_user( self::$editor_id );
@@ -222,8 +222,42 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 		$this->assertArrayHasKey( 'presence-group-here', $nodes );
 		$this->assertArrayHasKey( 'presence-group-elsewhere', $nodes );
 		$this->assertArrayHasKey( 'presence-user-' . $here->ID, $nodes );
-		// The avatar stack is built from the people on this page only.
+		// The avatar stack is built from the people on this page, you included.
 		$this->assertStringContainsString( 'alt="' . esc_attr( $here->display_name ) . '"', $nodes['presence-online']->title );
+		$this->assertStringContainsString(
+			'alt="' . esc_attr( get_userdata( self::$editor_id )->display_name ) . '"',
+			$nodes['presence-online']->title
+		);
+	}
+
+	/**
+	 * The count agrees with the users list and the network Sites column, all of
+	 * which count everyone present rather than everyone but you.
+	 */
+	public function test_the_count_includes_you() {
+		$this->put_user_on_screen( 'dashboard' );
+		$this->put_user_on_screen( 'edit' );
+
+		wp_set_current_user( self::$editor_id );
+		wp_set_presence( 'admin/online', 'user-' . self::$editor_id, array( 'screen' => 'dashboard' ), self::$editor_id );
+
+		$nodes = $this->render_nodes();
+
+		$this->assertStringContainsString( '3 online', $nodes['presence-online']->title );
+		$this->assertSame( '3 users online', $nodes['presence-online']->meta['aria-label'] );
+	}
+
+	/**
+	 * Your row is absent on screens that never ping, so the total is already
+	 * others-only and must not be decremented again.
+	 */
+	public function test_the_count_includes_you_when_your_own_row_has_expired() {
+		$this->put_user_on_screen( 'dashboard' );
+
+		wp_set_current_user( self::$editor_id );
+		$nodes = $this->render_nodes();
+
+		$this->assertStringContainsString( '2 online', $nodes['presence-online']->title );
 	}
 
 	/**

--- a/tests/test-admin-bar.php
+++ b/tests/test-admin-bar.php
@@ -282,6 +282,32 @@ class WP_Test_Presence_Admin_Bar extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * The three surfaces that report a number have to report the same one. Each
+	 * assembles its own set, so a fix to any single one can drift from the rest.
+	 *
+	 * @covers ::wp_presence_users_views
+	 * @covers WP_Presence_Widget_Whos_Online::render
+	 */
+	public function test_every_surface_reports_the_same_number_when_your_row_is_absent() {
+		$this->put_user_on_screen( 'dashboard' );
+		$this->put_user_on_screen( 'edit' );
+
+		wp_set_current_user( self::$editor_id );
+
+		$nodes = $this->render_nodes();
+
+		ob_start();
+		WP_Presence_Widget_Whos_Online::render();
+		$widget = ob_get_clean();
+
+		$views = wp_presence_users_views( array() );
+
+		$this->assertStringContainsString( '3 online', $nodes['presence-online']->title );
+		$this->assertStringContainsString( '(3)', $views['presence_online'] );
+		$this->assertSame( 3, substr_count( $widget, 'class="presence-user-item"' ) );
+	}
+
+	/**
 	 * An admin page with no entry in the map still groups correctly, keyed on
 	 * its filename, which is what the client reports as window.pagenow.
 	 */

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -377,10 +377,10 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	/**
 	 * @covers WP_Presence_Widget_Whos_Online::render
 	 */
-	public function test_render_reports_when_nobody_else_is_online() {
+	public function test_render_reports_when_nobody_is_online() {
 		$html = $this->render();
 
-		$this->assertStringContainsString( 'No other users are online.', $html );
+		$this->assertStringContainsString( 'No users are online.', $html );
 		$this->assertStringNotContainsString( '<ul', $html );
 	}
 

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -77,9 +77,12 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 		$response = $this->tick();
 
+		$ids = wp_list_pluck( $response['presence-online'], 'user_id' );
+
 		$this->assertArrayHasKey( 'presence-online', $response );
-		$this->assertCount( 1, $response['presence-online'] );
-		$this->assertSame( $other_id, $response['presence-online'][0]['user_id'] );
+		$this->assertCount( 2, $response['presence-online'] );
+		$this->assertContains( $other_id, $ids );
+		$this->assertContains( self::$editor_id, $ids );
 		$this->assertArrayHasKey( 'avatar_url', $response['presence-online'][0] );
 		$this->assertArrayHasKey( 'date_gmt', $response['presence-online'][0] );
 	}
@@ -264,16 +267,16 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 		// Should only send VISIBLE_ROWS + OVERFLOW_THRESHOLD entries.
 		$this->assertCount( 23, $response['presence-online'] );
 
-		// Total should reflect every user the widget would list.
-		$this->assertSame( 30, $response['presence-online-total'] );
+		// Total should reflect every user the widget would list, you included.
+		$this->assertSame( 31, $response['presence-online-total'] );
 	}
 	/**
 	 * The client derives the overflow count from the total, so the total has to
-	 * describe the set the widget renders, which never includes the viewer.
+	 * describe the set the widget renders, which counts the viewer.
 	 *
 	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
 	 */
-	public function test_online_total_excludes_the_pinging_user() {
+	public function test_online_total_includes_the_pinging_user() {
 		wp_set_current_user( self::$editor_id );
 
 		for ( $i = 0; $i < 30; $i++ ) {
@@ -282,32 +285,32 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 
 		$response = $this->tick();
 
-		$this->assertSame( 30, $response['presence-online-total'] );
+		$this->assertSame( 31, $response['presence-online-total'] );
 	}
 
 	/**
 	 * At exactly the expandable maximum the client renders the overflow from
-	 * the payload rather than the count, so the cap has to leave room for every
-	 * other user once the viewer's own entry is gone.
+	 * the payload rather than the count, so nobody the widget would list can
+	 * fall off the cap.
 	 *
 	 * @covers WP_Presence_Widget_Whos_Online::heartbeat_received
 	 */
-	public function test_heartbeat_payload_holds_every_other_user_at_the_expandable_maximum() {
+	public function test_heartbeat_payload_holds_everyone_at_the_expandable_maximum() {
 		wp_set_current_user( self::$editor_id );
 
-		$others = WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + WP_Presence_Widget_Whos_Online::get_overflow_threshold();
+		$cap = WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + WP_Presence_Widget_Whos_Online::get_overflow_threshold();
 
 		// Stagger the ages. wp_get_presence() orders by date_gmt, and at a
 		// shared timestamp where the viewer lands is an unspecified tie, so the
-		// cap could exclude their entry by luck and hide the bug.
-		for ( $i = 0; $i < $others; $i++ ) {
+		// cap could drop someone by luck and hide the bug.
+		for ( $i = 0; $i < $cap - 1; $i++ ) {
 			$this->add_user_to_room( 'dashboard', $i + 1 );
 		}
 
 		$ids = wp_list_pluck( $this->tick()['presence-online'], 'user_id' );
 
-		$this->assertNotContains( self::$editor_id, $ids );
-		$this->assertCount( $others, $ids );
+		$this->assertContains( self::$editor_id, $ids );
+		$this->assertCount( $cap, $ids );
 	}
 
 	/**
@@ -421,13 +424,17 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * You are viewing the dashboard, so the list is never empty.
+	 *
 	 * @covers WP_Presence_Widget_Whos_Online::render
 	 */
-	public function test_render_reports_when_nobody_is_online() {
+	public function test_render_lists_you_when_nobody_else_is_online() {
+		wp_set_current_user( self::$editor_id );
+
 		$html = $this->render();
 
-		$this->assertStringContainsString( 'No users are online.', $html );
-		$this->assertStringNotContainsString( '<ul', $html );
+		$this->assertStringContainsString( 'data-user-id="' . self::$editor_id . '"', $html );
+		$this->assertStringNotContainsString( 'No users are online.', $html );
 	}
 
 	/**
@@ -480,7 +487,10 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	 * @covers WP_Presence_Widget_Whos_Online::render
 	 */
 	public function test_render_hides_a_short_overflow_behind_an_expand_toggle() {
-		for ( $i = 0; $i < WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + 2; $i++ ) {
+		wp_set_current_user( self::$editor_id );
+
+		// One short, because the render counts you as well.
+		for ( $i = 0; $i < WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + 1; $i++ ) {
 			$this->add_user_to_room( 'dashboard', 0 );
 		}
 
@@ -499,9 +509,12 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 	 * @covers WP_Presence_Widget_Whos_Online::render
 	 */
 	public function test_render_collapses_a_long_overflow_into_a_link_to_all_users() {
+		wp_set_current_user( self::$editor_id );
+
 		$overflow = WP_Presence_Widget_Whos_Online::get_overflow_threshold() + 1;
 
-		for ( $i = 0; $i < WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + $overflow; $i++ ) {
+		// One short, because the render counts you as well.
+		for ( $i = 0; $i < WP_Presence_Widget_Whos_Online::VISIBLE_ROWS + $overflow - 1; $i++ ) {
 			$this->add_user_to_room( 'dashboard', 0 );
 		}
 


### PR DESCRIPTION
Presence counts disagreed across surfaces because the admin bar and the Who's Online widget filtered out the current user while the users list, the network Sites column and the admin bar flyout did not.

Fixes #423

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with the count convention and its test coverage

</details>
