### PR TITLE
docs: document the label groups and collapse CONTRIBUTING's long sections

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,25 @@ Assignment is not a commitment. If you stop, comment and we will unassign it. If
 
 Assigned issues left quiet for two weeks may be unassigned. Comment to pick one back up.
 
+### Labels
+
+Every open issue carries one `[Type]`, at least one `[Area]`, and a milestone. `[Area] Infrastructure` covers CI and the toolchain, so tooling issues get an area like everything else.
+
+Color groups labels rather than identifying them. Anything that sits on most rows stays in a highlighter tone, saturation is reserved for the few that want something from you, and anything applied automatically is gray.
+
+| Group | Color | Labels |
+| --- | --- | --- |
+| Area | `#FEF298` | the nine `[Area]` labels |
+| Type | `#FFB7B0` `#E2C8FF` `#B5E0FF` `#B8EAE0` | `Bug`, `Enhancement`, `Feature`, `Documentation` |
+| Cross-cutting | `#DED6B0` | `Performance`, `Privacy`, `Public API` |
+| Open to contributors | `#97EDA0` | `Good First Issue`, `Good First Review`, `help wanted` |
+| Waiting on a decision | `#F2994A` | `Needs Decision`, `Needs Discussion`, `Needs WP.org Link`, `Close Candidate` |
+| Waiting on something external | `#DC3545` | `blocked` |
+| Applied automatically | `#CED4DA` | `php`, `javascript`, `dependencies`, `github_actions`, `props-bot`, `skip changelog`, `maybelater`, `autorelease: pending`, `autorelease: tagged` |
+| Resolution | `#ADB5BD` | `duplicate`, `invalid`, and `wontfix` at `#ffffff` |
+
+A new label joins an existing group's color instead of taking a new hue. If it genuinely needs one, check it in both light and dark mode: GitHub picks the text color from the label's lightness and lightens the label itself on dark backgrounds, so a color that only works in one theme is common.
+
 ## Pull requests
 
 1. Branch off `main`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,25 +43,31 @@ Assigned issues left quiet for two weeks may be unassigned. Comment to pick one 
 
 ### Labels
 
-Every open issue carries one `[Type]`, at least one `[Area]`, and a milestone. `[Area] Infrastructure` covers CI and the toolchain, so tooling issues get an area like everything else.
+Every open issue carries one `[Type]`, at least one `[Area]`, and a milestone. `[Area] Infrastructure` covers CI and the toolchain.
 
-Color groups labels rather than identifying them. Anything that sits on most rows stays in a highlighter tone, saturation is reserved for the few that want something from you, and anything applied automatically is gray.
+Color groups labels rather than identifying them. Labels on most rows stay in a highlighter tone, saturation is reserved for the few that want something from you, and anything a bot applies is gray.
 
 <details>
-<summary>The groups and their colors</summary>
+<summary>The twelve colors</summary>
 
-| Group | Color | Labels |
-| --- | --- | --- |
-| Area | `#FEF298` | the nine `[Area]` labels |
-| Type | `#FFB7B0` `#E2C8FF` `#B5E0FF` `#B8EAE0` | `Bug`, `Enhancement`, `Feature`, `Documentation` |
-| Cross-cutting | `#DED6B0` | `Performance`, `Privacy`, `Public API` |
-| Open to contributors | `#97EDA0` | `Good First Issue`, `Good First Review`, `help wanted` |
-| Waiting on a decision | `#F2994A` | `Needs Decision`, `Needs Discussion`, `Needs WP.org Link`, `Close Candidate` |
-| Waiting on something external | `#DC3545` | `blocked` |
-| Applied automatically | `#CED4DA` | `php`, `javascript`, `dependencies`, `github_actions`, `props-bot`, `skip changelog`, `maybelater`, `autorelease: pending`, `autorelease: tagged` |
-| Resolution | `#ADB5BD` | `duplicate`, `invalid`, and `wontfix` at `#ffffff` |
+| Color | Labels |
+| --- | --- |
+| `#FEF298` | the nine `[Area]` labels |
+| `#FFB7B0` | `[Type] Bug` |
+| `#E2C8FF` | `[Type] Enhancement` |
+| `#B5E0FF` | `[Type] Feature` |
+| `#B8EAE0` | `[Type] Documentation` |
+| `#DED6B0` | `Performance`, `Privacy`, `Public API` |
+| `#97EDA0` | `Good First Issue`, `Good First Review`, `help wanted` |
+| `#F2994A` | the three `Needs` labels and `Close Candidate` |
+| `#DC3545` | `blocked` |
+| `#CED4DA` | anything a bot applies, languages included |
+| `#ADB5BD` | `duplicate`, `invalid` |
+| `#FFFFFF` | `wontfix` |
 
-A new label joins an existing group's color instead of taking a new hue. If it genuinely needs one, check it in both light and dark mode: GitHub picks the text color from the label's lightness and lightens the label itself on dark backgrounds, so a color that only works in one theme is common.
+Rendered, they are on the [labels page](https://github.com/WordPress/presence-api/labels).
+
+A new label joins an existing color. If it genuinely needs its own, check it in both themes: GitHub picks the text color from the label's lightness and lightens the label itself on dark backgrounds.
 
 </details>
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,6 +47,9 @@ Every open issue carries one `[Type]`, at least one `[Area]`, and a milestone. `
 
 Color groups labels rather than identifying them. Anything that sits on most rows stays in a highlighter tone, saturation is reserved for the few that want something from you, and anything applied automatically is gray.
 
+<details>
+<summary>The groups and their colors</summary>
+
 | Group | Color | Labels |
 | --- | --- | --- |
 | Area | `#FEF298` | the nine `[Area]` labels |
@@ -59,6 +62,8 @@ Color groups labels rather than identifying them. Anything that sits on most row
 | Resolution | `#ADB5BD` | `duplicate`, `invalid`, and `wontfix` at `#ffffff` |
 
 A new label joins an existing group's color instead of taking a new hue. If it genuinely needs one, check it in both light and dark mode: GitHub picks the text color from the label's lightness and lightens the label itself on dark backgrounds, so a color that only works in one theme is common.
+
+</details>
 
 ## Pull requests
 
@@ -73,7 +78,12 @@ A hook, REST route, WP-CLI command, guarded constant, or browser global that a s
 
 Written about means a docblock directly above it with a sentence saying what it is for. That is where WordPress core's code reference reads from, and it keeps the write-up next to the code instead of in a hand-kept list that drifts the first time someone forgets it. `README.md` narrates the surfaces worth a worked example; it is not the inventory.
 
-Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those private in that same docblock and the check leaves them alone. In PHP use `@access private`, the marker [core's documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) name, directly below `@since`:
+Some names are reachable without being a promise, like a global that only exists so two enqueued scripts can share a renderer. Mark those private in that same docblock and the check leaves them alone.
+
+<details>
+<summary>Marking a name private</summary>
+
+In PHP use `@access private`, the marker [core's documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) name, directly below `@since`:
 
 ```php
 /**
@@ -95,6 +105,8 @@ JavaScript has no `@since` line to sit under, so `@private` on its own is enough
  */
 window.wpPresenceBuildAvatarStack = function ( users, max ) {};
 ```
+
+</details>
 
 ## Getting credited
 
@@ -118,8 +130,13 @@ Releases are automated by [release-please](https://github.com/googleapis/release
 
 When the release-please PR is merged, the tag, GitHub Release, and zip asset are produced automatically.
 
+<details>
+<summary>Keeping the version numbers in step</summary>
+
 `scripts/sync-versions.sh` reads the version from `.release-please-manifest.json` and updates the plugin header `Version:`, the `WP_PRESENCE_VERSION` constant, and `readme.txt`'s `Stable tag:`. The release-please workflow runs it on every release PR; you can run it locally too:
 
 ```bash
 bash scripts/sync-versions.sh
 ```
+
+</details>

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,18 +48,18 @@ Every open issue carries one `[Type]`, at least one `[Area]`, and a milestone. `
 Color groups labels rather than identifying them. Labels on most rows stay in a highlighter tone, saturation is reserved for the few that want something from you, and anything a bot applies is gray.
 
 <details>
-<summary>The twelve colors</summary>
+<summary>What each color marks</summary>
 
 | Color | Labels |
 | --- | --- |
-| `#FEF298` | the nine `[Area]` labels |
+| `#FEF298` | every `[Area]` label |
 | `#FFB7B0` | `[Type] Bug` |
 | `#E2C8FF` | `[Type] Enhancement` |
 | `#B5E0FF` | `[Type] Feature` |
 | `#B8EAE0` | `[Type] Documentation` |
 | `#DED6B0` | `Performance`, `Privacy`, `Public API` |
 | `#97EDA0` | `Good First Issue`, `Good First Review`, `help wanted` |
-| `#F2994A` | the three `Needs` labels and `Close Candidate` |
+| `#F2994A` | the `Needs` labels and `Close Candidate` |
 | `#DC3545` | `blocked` |
 | `#CED4DA` | anything a bot applies, languages included |
 | `#ADB5BD` | `duplicate`, `invalid` |


### PR DESCRIPTION
The label colors and groupings only existed on GitHub, so nothing in the repo told a contributor what a color meant or which group a new label should join, and writing that down pushed CONTRIBUTING past the length anyone reads top to bottom.

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with measuring label contrast and adjacency across both GitHub themes

</details>
