### PR TITLE
perf: store network summary rows compact

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -310,11 +310,10 @@ function wp_presence_record_network_summary_push( array $user_ids ) {
  * Shaped to be read in a database client, the only place this column is looked
  * at directly:
  *
- *     {
- *         "site": "example.com/shop/",
- *         "scheme": "https",
- *         "online_user_ids": [ 3, 7 ]
- *     }
+ *     {"site":"example.com/shop/","scheme":"https","online_user_ids":[3,7]}
+ *
+ * Three keys stay legible compact, and the read selects this column in full for
+ * every site on each network-admin request, so pretty-printing doubled it.
  *
  * The site label is for that reader; the read path resolves the site from
  * blog_id and ignores it. Logins are left out because resolving them would
@@ -338,7 +337,7 @@ function wp_presence_encode_network_summary_row( $blog_id, array $user_ids ) {
 			'scheme'          => is_ssl() ? 'https' : 'http',
 			'online_user_ids' => $user_ids,
 		),
-		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+		JSON_UNESCAPED_SLASHES
 	);
 }
 

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -285,7 +285,7 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 
 		$this->assertSame( $site->domain . $site->path, $decoded['site'] );
 		$this->assertSame( array( self::$editor_id ), $decoded['online_user_ids'] );
-		$this->assertStringContainsString( "\n", $data, 'Stored pretty-printed to stay readable.' );
+		$this->assertStringNotContainsString( "\n", $data, 'Stored compact: the column is read in full on every request.' );
 	}
 
 	/**


### PR DESCRIPTION
The `data` column is selected in full for every site on each network-admin request, and the measurement on #329 put pretty-printing at twice the stored and transferred bytes for no latency difference.

Fixes #329

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5

Used for: Assisting with the change and running the multisite suite

</details>
