### PR TITLE
feat: add a site and network switch for whether presence is recorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Post types opt in via `add_post_type_support( 'post', 'presence' )`.
 
 ## PHP API
 
-The following public functions are part of the stable public API contract. All other helper functions in `includes/functions.php` (such as `wp_get_active_rooms()`, `wp_get_presence_summary()`, etc.) are marked `@access private`, are intended for internal plugin use only, and may change or be removed without notice.
+The following public functions are part of the stable public API contract. All other helper functions in `includes/functions.php` and `includes/network-functions.php` (such as `wp_get_active_rooms()`, `wp_get_presence_summary()`, etc.) are marked `@access private`, are intended for internal plugin use only, and may change or be removed without notice.
 
 ```php
 // Read all presence entries in a room.
@@ -68,6 +68,15 @@ wp_presence_recording_enabled();
 ```
 
 Each entry object returned by `wp_get_presence()` has: `room`, `client_id`, `user_id`, `data` (array), `date_gmt`.
+
+### Network
+
+Multisite only, from `includes/network-functions.php`. Returns `false` outside multisite.
+
+```php
+// Whether this network assembles its sites' rows into the network-wide view.
+wp_presence_network_aggregation_enabled();
+```
 
 ## Extension Points
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Post types opt in via `add_post_type_support( 'post', 'presence' )`.
 
 ## PHP API
 
-The following six public functions are part of the stable public API contract. All other helper functions in `includes/functions.php` (such as `wp_get_active_rooms()`, `wp_get_presence_summary()`, etc.) are marked `@access private`, are intended for internal plugin use only, and may change or be removed without notice.
+The following public functions are part of the stable public API contract. All other helper functions in `includes/functions.php` (such as `wp_get_active_rooms()`, `wp_get_presence_summary()`, etc.) are marked `@access private`, are intended for internal plugin use only, and may change or be removed without notice.
 
 ```php
 // Read all presence entries in a room.
@@ -62,6 +62,9 @@ wp_can_access_presence_room( $room, $user_id = 0 );
 // Return the canonical room string for a post, or false if the post type
 // does not support presence.
 $room = wp_presence_post_room( $post );
+
+// Whether this site records presence at all.
+wp_presence_recording_enabled();
 ```
 
 Each entry object returned by `wp_get_presence()` has: `room`, `client_id`, `user_id`, `data` (array), `date_gmt`.
@@ -110,6 +113,20 @@ add_filter( 'wp_presence_current_screen_key', function( $key, $screen ) {
 ```
 
 Keys follow the plugin's slash-separated room convention and are truncated to 191 characters (`WP_PRESENCE_SCREEN_KEY_LIMIT`). Use the same key when bumping the revision from JS via `wp.presence.markScreenStale()`.
+
+#### `wp_presence_recording_enabled`
+Filters whether presence is recorded on this site. Default: `true`. Return `false` and nothing further is written; every surface empties within one TTL as the rows already stored expire, so there is nothing else to clear.
+```php
+add_filter( 'wp_presence_recording_enabled', '__return_false' );
+```
+
+On multisite, `wp_presence_network_recording_enabled` does the same for every site at once. It is consulted only once the site-level filter has allowed recording, so either switch turning off wins and neither can turn the other back on.
+
+#### `wp_presence_network_aggregation_enabled`
+Filters whether a network assembles its sites' rows into the network-wide view behind Network Admin. Default: `true` below [`wp_is_large_network()`](https://developer.wordpress.org/reference/functions/wp_is_large_network/), which answers write concentration rather than policy. Independent of recording: a network can go on recording site by site and still switch the aggregate off.
+```php
+add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+```
 
 ### Actions
 #### `wp_presence_screen_revision_bumped`

--- a/includes/class-wp-rest-presence-controller.php
+++ b/includes/class-wp-rest-presence-controller.php
@@ -422,6 +422,15 @@ class WP_REST_Presence_Controller extends WP_REST_Controller {
 	public function create_item( $request ) {
 		global $wpdb;
 
+		// 501 rather than the 503 below: recording is switched off, not pending a table.
+		if ( ! wp_presence_recording_enabled() ) {
+			return new WP_Error(
+				'rest_presence_recording_disabled',
+				__( 'Presence is not recorded on this site.', 'presence-api' ),
+				array( 'status' => 501 )
+			);
+		}
+
 		if ( ! wp_presence_has_table() ) {
 			return new WP_Error(
 				'rest_presence_unavailable',

--- a/includes/cli/class-wp-presence-cli-command.php
+++ b/includes/cli/class-wp-presence-cli-command.php
@@ -46,6 +46,10 @@ class WP_Presence_CLI_Command extends WP_CLI_Command {
 		$room    = $args[0];
 		$user_id = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'user', 0 );
 
+		if ( ! wp_presence_recording_enabled() ) {
+			WP_CLI::error( __( 'Presence is not recorded on this site.', 'presence-api' ) );
+		}
+
 		if ( $user_id && ! get_user_by( 'id', $user_id ) ) {
 			WP_CLI::error( __( 'User not found.', 'presence-api' ) );
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2,7 +2,7 @@
 /**
  * Presence API functions.
  *
- * Public API (7 functions):
+ * Public API:
  *   wp_get_presence()
  *   wp_set_presence()
  *   wp_remove_presence()
@@ -10,6 +10,7 @@
  *   wp_can_access_presence_room()
  *   wp_presence_post_room()
  *   wp_presence_admin_room()
+ *   wp_presence_recording_enabled()
  *
  * @package Presence_API
  */
@@ -81,6 +82,53 @@ function wp_get_presence( $room, $timeout = WP_PRESENCE_DEFAULT_TTL ) {
 }
 
 /**
+ * Whether presence is recorded on this site.
+ *
+ * The controller-level switch, checked at the single write path. Nothing new is
+ * stored while this is false and every surface empties within one
+ * WP_PRESENCE_DEFAULT_TTL as the rows already there expire, so there is no
+ * separate teardown to run.
+ *
+ * Recording is on by default. Presence is a negative signal, and the post lock
+ * bridge is where its absence stops two people overwriting each other, so the
+ * default is the safe one; a site that would rather not process it at all
+ * switches it off here and says so in its privacy policy.
+ *
+ * Aggregating those rows into the network-wide view is a separate switch. See
+ * wp_presence_network_aggregation_enabled().
+ *
+ * @since 0.3.0
+ *
+ * @return bool Whether presence is recorded.
+ */
+function wp_presence_recording_enabled() {
+	/**
+	 * Filters whether presence is recorded on this site.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param bool $enabled Whether to record presence. Default true.
+	 */
+	$enabled = (bool) apply_filters( 'wp_presence_recording_enabled', true );
+
+	if ( ! $enabled || ! is_multisite() ) {
+		return $enabled;
+	}
+
+	/**
+	 * Filters whether presence is recorded anywhere on this network.
+	 *
+	 * Consulted only once the site-level filter has allowed recording, so
+	 * either switch turning off wins and neither can turn the other back on.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param bool $enabled Whether to record presence. Default true.
+	 */
+	return (bool) apply_filters( 'wp_presence_network_recording_enabled', true );
+}
+
+/**
  * Upserts a client's presence state in a room.
  *
  * Uses INSERT ... ON DUPLICATE KEY UPDATE for atomic upserts
@@ -94,6 +142,10 @@ function wp_get_presence( $room, $timeout = WP_PRESENCE_DEFAULT_TTL ) {
  */
 function wp_set_presence( $room, $client_id, $state, $user_id = 0 ) {
 	global $wpdb;
+
+	if ( ! wp_presence_recording_enabled() ) {
+		return false;
+	}
 
 	if ( ! wp_presence_has_table() ) {
 		return false;

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -72,15 +72,22 @@ function wp_presence_has_network_summary_table() {
 /**
  * Whether this network aggregates presence into the summary table.
  *
+ * The network-wide half of the controller-level switch, independent of
+ * wp_presence_recording_enabled(): a network can go on recording presence site
+ * by site and still decline to assemble the view across all of them.
+ *
  * An ms_global_tables entry pins the summary table to the global cluster on a
  * sharded network, so write concentration grows with the site count however
  * rarely any single site pushes. Defaults off above wp_is_large_network()
  * rather than having a network inherit that cost from installing the plugin.
+ * That default answers write concentration rather than policy, so a network
+ * with a view either way should set it deliberately.
  *
  * The read path checks this too, or a network that stopped aggregating would go
  * on drawing the rows it already had with nothing to say the feed had stopped.
  *
- * @access private
+ * @since 0.2.0
+ *
  * @return bool
  */
 function wp_presence_network_aggregation_enabled() {

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -87,6 +87,7 @@ function wp_presence_has_network_summary_table() {
  * on drawing the rows it already had with nothing to say the feed had stopped.
  *
  * @since 0.2.0
+ * @since 0.3.0 Promoted from an @access private helper to the public API.
  *
  * @return bool
  */

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,10 @@ Yes. Network-activate it and Network Admin gains a Who's Online dashboard widget
 
 Anyone with the `manage_network` capability, which on a default network means super admins. The `wp_presence_network_capability` filter changes what is required.
 
+= Can a site stop recording presence? =
+
+Yes. The `wp_presence_recording_enabled` filter switches the write off, and every screen empties within one TTL as the rows already stored expire. On multisite, `wp_presence_network_recording_enabled` does the same for every site at once; whichever switch is off decides.
+
 == Changelog ==
 
 = 0.2.1 =

--- a/tests/test-cli-command.php
+++ b/tests/test-cli-command.php
@@ -105,6 +105,20 @@ class WP_Test_Presence_CLI_Command extends WP_Presence_UnitTestCase {
 	/**
 	 * @covers WP_Presence_CLI_Command::set
 	 */
+	public function test_set_reports_recording_being_switched_off() {
+		add_filter( 'wp_presence_recording_enabled', '__return_false' );
+
+		$this->assert_halts_with(
+			function () {
+				$this->command->set( array( 'admin/online' ), array( 'user' => self::$user_id ) );
+			},
+			'Presence is not recorded on this site.'
+		);
+	}
+
+	/**
+	 * @covers WP_Presence_CLI_Command::set
+	 */
 	public function test_set_rejects_an_unknown_user() {
 		$unknown = self::$user_id + 1000;
 

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -823,4 +823,51 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		$this->assertStringNotContainsString( 'Ana', $html );
 		$this->assertStringContainsString( 'z-index:1', $html, 'The z-index counts the avatars drawn, not the users passed in.' );
 	}
+
+	/**
+	 * Asserted at the table rather than only on the return value: a switch that
+	 * reports false while the row still lands is the failure that matters.
+	 *
+	 * @covers ::wp_presence_recording_enabled
+	 * @covers ::wp_set_presence
+	 */
+	public function test_switching_recording_off_writes_nothing() {
+		add_filter( 'wp_presence_recording_enabled', '__return_false' );
+
+		$result = wp_set_presence( 'test/room', 'client-1', array(), self::$editor_id );
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), wp_get_presence( 'test/room' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_recording_enabled
+	 */
+	public function test_the_network_can_switch_off_a_site_that_allows_recording() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		add_filter( 'wp_presence_recording_enabled', '__return_true' );
+		add_filter( 'wp_presence_network_recording_enabled', '__return_false' );
+
+		$this->assertFalse( wp_presence_recording_enabled() );
+	}
+
+	/**
+	 * The other half of the same rule, and the one a network-level filter could
+	 * quietly undo if it were consulted unconditionally.
+	 *
+	 * @covers ::wp_presence_recording_enabled
+	 */
+	public function test_a_site_can_switch_off_what_the_network_allows() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		add_filter( 'wp_presence_recording_enabled', '__return_false' );
+		add_filter( 'wp_presence_network_recording_enabled', '__return_true' );
+
+		$this->assertFalse( wp_presence_recording_enabled() );
+	}
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -825,6 +825,15 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * The documented default, and the one the privacy note in the readme states.
+	 *
+	 * @covers ::wp_presence_recording_enabled
+	 */
+	public function test_recording_is_on_with_no_filters_added() {
+		$this->assertTrue( wp_presence_recording_enabled() );
+	}
+
+	/**
 	 * Asserted at the table rather than only on the return value: a switch that
 	 * reports false while the row still lands is the failure that matters.
 	 *

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -404,6 +404,27 @@ class WP_Test_Presence_REST_Controller extends WP_Presence_UnitTestCase {
 	}
 
 	/**
+	 * Not the generic 500, which invites a retry nothing will ever store.
+	 *
+	 * @covers WP_REST_Presence_Controller::create_item
+	 */
+	public function test_rest_create_reports_recording_being_switched_off() {
+		wp_set_current_user( self::$editor_id );
+		add_filter( 'wp_presence_recording_enabled', '__return_false' );
+
+		$request = new WP_REST_Request( 'POST', '/wp-presence/v1/presence' );
+		$request->set_param( 'room', 'room/off' );
+		$request->set_param( 'client_id', 'client-off' );
+
+		$controller = new WP_REST_Presence_Controller();
+		$response   = $controller->create_item( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$this->assertSame( 'rest_presence_recording_disabled', $response->get_error_code() );
+		$this->assertSame( 501, $response->get_error_data()['status'] );
+	}
+
+	/**
 	 * @covers WP_REST_Presence_Controller::bump_screen_revision
 	 */
 	public function test_bump_screen_revision_success() {


### PR DESCRIPTION
Settles the three open questions on the issue as a filter rather than a stored setting, recording and aggregation as separate switches, and strictest-wins precedence on multisite.

Refs #400

<details>
<summary>AI disclosure</summary>

Used for: Assisting with the implementation and tests.

</details>