### PR TITLE
chore: give both bot comments a heading and drop the small print

### DIFF
--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -138,7 +138,7 @@ function formatComment(surfaces) {
 
   return [
     MARKER,
-    '### 🚩 New public surface',
+    `### 🚩 New public surface${one ? '' : 's'}`,
     '',
     `This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
     '',

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -128,8 +128,8 @@ function formatAudit(surfaces) {
     .join('\n');
 }
 
-// A heading would open with a rule across the thread for what is usually a
-// one-line note, so the title runs inline and the aside is set small.
+// An h3 heading, matching the Playground preview comment, so the two bots read
+// the same way down a thread.
 function formatComment(surfaces) {
   const one = 1 === surfaces.length;
   const headline = surfaces.every((s) => s.documented)
@@ -138,11 +138,13 @@ function formatComment(surfaces) {
 
   return [
     MARKER,
-    `**New public surface.** This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
+    '### 🚩 New public surface',
+    '',
+    `This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
     '',
     formatAudit(surfaces),
     '',
-    '<sub>Worth a line in `README.md` too, and in `readme.txt` under `= For Developers =` if it is user-facing.</sub>',
+    'Worth a line in `README.md` too, and in `readme.txt` under `= For Developers =` if it is user-facing.',
     '',
   ].join('\n');
 }

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -257,5 +257,6 @@ test('asks for a docblock only while something is undocumented', () => {
 
 test('agrees in number', () => {
   const two = formatComment([surface('filter:a', true), surface('action:b', true)]);
+  assert.match(two, /^### 🚩 New public surfaces$/m);
   assert.match(two, /adds 2 extension points that sites can depend on\. They are already documented\./);
 });

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -245,7 +245,7 @@ test('splits on the first colon so a namespaced hook name survives', () => {
 // ---------------------------------------------------------------------------
 
 test('leads with the marker so the workflow can find its own comment', () => {
-  assert.ok(formatComment([surface('filter:a')]).startsWith(MARKER));
+  assert.ok(formatComment([surface('filter:a')]).startsWith(`${MARKER}\n### 🚩 New public surface\n`));
 });
 
 test('asks for a docblock only while something is undocumented', () => {
@@ -253,8 +253,6 @@ test('asks for a docblock only while something is undocumented', () => {
   const covered = formatComment([surface('filter:a', true)]);
   assert.match(missing, /adds 1 extension point that sites can depend on\. Add a docblock/);
   assert.match(covered, /adds 1 extension point that sites can depend on\. It is already documented\./);
-  // A heading would rule off the thread; the title carries inline instead.
-  assert.doesNotMatch(missing, /^#/m);
 });
 
 test('agrees in number', () => {

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -214,14 +214,13 @@ jobs:
 
             const body = [
               marker,
-              '### 🛝 Playground',
+              `### 🛝 WordPress Playgrounds built from [\`${sha}\`](${commitUrl})`,
               '',
               '|  | 5 users | 40 users |',
               '| --- | --- | --- |',
               `| **Single site** | ${launch(url, 'Launch single site, 5 users')} | ${launch(url40, 'Launch single site, 40 users')} |`,
               `| **Multisite** | ${launch(urlMultisite, 'Launch multisite, 5 users')} | ${launch(urlMultisite40, 'Launch multisite, 40 users')} |`,
               '',
-              `<sub>Built from [\`${sha}\`](${commitUrl}), rebuilt on every push.</sub>`,
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {


### PR DESCRIPTION
The Playground preview and public surface comments each ended in a line of `<sub>` small print that read as an afterthought next to the rest of the pull request page.

<details>
<summary>AI disclosure</summary>

Used for: Assisting with the comment formatting and tests.

</details>