### PR TITLE
chore: move the preview sha out of the heading

### DIFF
--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -212,9 +212,12 @@ jobs:
 
             const body = [
               marker,
-              // Left bare so GitHub autolinks it into the same abbreviated
-              // commit link, hovercard and all, that the timeline above uses.
-              `### 🛝 WordPress Playgrounds built from ${fullSha}`,
+              '### 🛝 WordPress Playgrounds',
+              '',
+              // Below the heading rather than in it, so the sha inherits body
+              // weight and size, and left bare so GitHub autolinks it into the
+              // same abbreviated commit link the timeline above uses.
+              `Built from ${fullSha}`,
               '',
               '|  | 5 users | 40 users |',
               '| --- | --- | --- |',


### PR DESCRIPTION
Inside an `h3` the autolinked sha still renders at 17.5px and weight 600, where the timeline renders one at 12px and weight 400.

<details>
<summary>AI disclosure</summary>

Used for: Assisting with the comment formatting.

</details>
