### PR TITLE
chore: drop the chip background from the preview sha

### DIFF
--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -203,6 +203,8 @@ jobs:
             const urlMultisite = process.env.PLAYGROUND_URL_MULTISITE;
             const urlMultisite40 = process.env.PLAYGROUND_URL_MULTISITE_40;
             const fullSha = process.env.HEAD_SHA;
+            const sha = fullSha.slice(0, 7);
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${fullSha}`;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const badge = 'https://img.shields.io/badge/Launch-3858E9?style=for-the-badge&logo=wordpress&logoColor=white';
 
@@ -214,10 +216,10 @@ jobs:
               marker,
               '### 🛝 WordPress Playgrounds',
               '',
-              // Below the heading rather than in it, so the sha inherits body
-              // weight and size, and left bare so GitHub autolinks it into the
-              // same abbreviated commit link the timeline above uses.
-              `Built from ${fullSha}`,
+              // Below the heading so the sha keeps body weight, and in <samp>
+              // because GitHub chips `code` and the `tt` its own autolinker
+              // emits, which the timeline's sha links are not.
+              `Built from <a href="${commitUrl}"><samp>${sha}</samp></a>`,
               '',
               '|  | 5 users | 40 users |',
               '| --- | --- | --- |',


### PR DESCRIPTION
GitHub's markdown stylesheet chips both `code` and the `tt` its own commit autolinker emits, so the sha carried a rounded background the timeline's sha links do not have.

<details>
<summary>AI disclosure</summary>

Used for: Assisting with the comment formatting.

</details>