### PR TITLE
chore: count the undocumented surfaces in the bot comment headline

### DIFF
--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -132,9 +132,13 @@ function formatAudit(surfaces) {
 // the same way down a thread.
 function formatComment(surfaces) {
   const one = 1 === surfaces.length;
-  const headline = surfaces.every((s) => s.documented)
-    ? `${one ? 'It is' : 'They are'} already documented.`
-    : 'Add a docblock above each one saying what it is for.';
+  // Counted, not asserted, so the sentence tracks the list below when only
+  // some of the surfaces are documented.
+  const missing = surfaces.filter((s) => !s.documented).length;
+  const headline =
+    0 === missing
+      ? `${one ? 'It is' : 'All are'} documented.`
+      : `${missing} ${1 === missing ? 'needs' : 'need'} a docblock saying what ${1 === missing ? 'it is' : 'they are'} for.`;
 
   return [
     MARKER,

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -116,14 +116,14 @@ function newSurfaces(base, head) {
 }
 
 // Kind first, so every line opens on the same kind of token instead of a name
-// of arbitrary length. Nothing else: the sentence above carries the docblock
-// count, and a second mark down here competes with the flag in the heading.
+// of arbitrary length, and a missing docblock qualifies that kind rather than
+// earning a mark of its own.
 function formatAudit(surfaces) {
   return surfaces
-    .map(({ id }) => {
+    .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\``;
+      return `- (${documented ? '' : 'undocumented '}${id.slice(0, at)}) \`${id.slice(at + 1)}\``;
     })
     .join('\n');
 }
@@ -131,17 +131,9 @@ function formatAudit(surfaces) {
 // An h3 heading, matching the Playground preview comment, so the two bots read
 // the same way down a thread.
 function formatComment(surfaces) {
-  const one = 1 === surfaces.length;
-  // Undocumented reads as an adjective when it covers every surface and as a
-  // count when it covers some, so the sentence never repeats the same number.
-  const missing = surfaces.filter((s) => !s.documented).length;
-  const all = missing === surfaces.length;
-
   return [
     MARKER,
-    `### 🚩 New public surface${one ? '' : 's'}`,
-    '',
-    `This branch adds ${surfaces.length} ${all ? 'undocumented ' : ''}extension point${one ? '' : 's'} that sites can depend on${missing && !all ? `, ${missing} undocumented` : ''}.`,
+    `### 🚩 New public surface${1 === surfaces.length ? '' : 's'}`,
     '',
     formatAudit(surfaces),
     '',

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -115,14 +115,15 @@ function newSurfaces(base, head) {
     .sort((a, b) => a.id.localeCompare(b.id));
 }
 
-// The sentence above already counts what is missing, so an entry only has to
-// say which one it is: a mark on the exceptions, nothing on the rest.
+// Kind first, so every line opens on the same kind of token instead of a name
+// of arbitrary length. The sentence above already counts what is missing, so
+// only the exceptions carry a mark.
 function formatAudit(surfaces) {
   return surfaces
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- ${documented ? '' : '⚠️ '}\`${id.slice(at + 1)}\` (${id.slice(0, at)})`;
+      return `- ${documented ? '' : '⚠️ '}(${id.slice(0, at)}) \`${id.slice(at + 1)}\``;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -116,14 +116,14 @@ function newSurfaces(base, head) {
 }
 
 // Kind first, so every line opens on the same kind of token instead of a name
-// of arbitrary length, and a missing docblock qualifies that kind rather than
-// earning a mark of its own.
+// of arbitrary length, and a missing docblock joins it in the same parentheses
+// rather than earning a mark of its own.
 function formatAudit(surfaces) {
   return surfaces
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- (${documented ? '' : 'undocumented '}${id.slice(0, at)}) \`${id.slice(at + 1)}\``;
+      return `- (${id.slice(0, at)}${documented ? '' : ', needs docs'}) \`${id.slice(at + 1)}\``;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -115,15 +115,14 @@ function newSurfaces(base, head) {
     .sort((a, b) => a.id.localeCompare(b.id));
 }
 
-// The instruction is the same for every entry, so it is given once in the lead
-// sentence and each entry here is just the name and what kind of thing it is.
+// The sentence above already counts what is missing, so an entry only has to
+// say which one it is: a mark on the exceptions, nothing on the rest.
 function formatAudit(surfaces) {
   return surfaces
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
-      const entry = `- \`${id.slice(at + 1)}\` (${id.slice(0, at)})`;
 
-      return documented ? entry : `${entry}: undocumented`;
+      return `- ${documented ? '' : '⚠️ '}\`${id.slice(at + 1)}\` (${id.slice(0, at)})`;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -116,14 +116,14 @@ function newSurfaces(base, head) {
 }
 
 // Kind first, so every line opens on the same kind of token instead of a name
-// of arbitrary length, and a missing docblock joins it in the same parentheses
-// rather than earning a mark of its own.
+// of arbitrary length, and what is left to do trails the name in italics so it
+// reads as an aside rather than part of the surface.
 function formatAudit(surfaces) {
   return surfaces
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- (${id.slice(0, at)}${documented ? '' : ', needs docs'}) \`${id.slice(at + 1)}\``;
+      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' *needs docs*'}`;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -132,19 +132,16 @@ function formatAudit(surfaces) {
 // the same way down a thread.
 function formatComment(surfaces) {
   const one = 1 === surfaces.length;
-  // Counted, not asserted, so the sentence tracks the list below when only
-  // some of the surfaces are documented.
+  // One clause of a fixed shape rather than a second sentence, so nothing but
+  // the counts moves and nothing has to agree with them.
   const missing = surfaces.filter((s) => !s.documented).length;
-  const headline =
-    0 === missing
-      ? `${one ? 'It is' : 'All are'} documented.`
-      : `${missing} ${1 === missing ? 'needs' : 'need'} a docblock saying what ${1 === missing ? 'it is' : 'they are'} for.`;
+  const gap = missing ? `, ${missing} without a docblock` : '';
 
   return [
     MARKER,
     `### 🚩 New public surface${one ? '' : 's'}`,
     '',
-    `This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on. ${headline}`,
+    `This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on${gap}.`,
     '',
     formatAudit(surfaces),
     '',

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -123,7 +123,7 @@ function formatAudit(surfaces) {
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' *needs docs*'}`;
+      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' - *needs docs*'}`;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -123,7 +123,7 @@ function formatAudit(surfaces) {
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' - *needs documentation*'}`;
+      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' - *requires documentation*'}`;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -123,7 +123,7 @@ function formatAudit(surfaces) {
     .map(({ id, documented }) => {
       const at = id.indexOf(':');
 
-      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' - *needs docs*'}`;
+      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' - *needs documentation*'}`;
     })
     .join('\n');
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -148,8 +148,6 @@ function formatComment(surfaces) {
     '',
     formatAudit(surfaces),
     '',
-    'Worth a line in `README.md`, and `readme.txt` if user-facing.',
-    '',
   ].join('\n');
 }
 

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -116,14 +116,14 @@ function newSurfaces(base, head) {
 }
 
 // Kind first, so every line opens on the same kind of token instead of a name
-// of arbitrary length. The sentence above already counts what is missing, so
-// only the exceptions carry a mark.
+// of arbitrary length. Nothing else: the sentence above carries the docblock
+// count, and a second mark down here competes with the flag in the heading.
 function formatAudit(surfaces) {
   return surfaces
-    .map(({ id, documented }) => {
+    .map(({ id }) => {
       const at = id.indexOf(':');
 
-      return `- ${documented ? '' : '⚠️ '}(${id.slice(0, at)}) \`${id.slice(at + 1)}\``;
+      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\``;
     })
     .join('\n');
 }
@@ -132,16 +132,16 @@ function formatAudit(surfaces) {
 // the same way down a thread.
 function formatComment(surfaces) {
   const one = 1 === surfaces.length;
-  // One clause of a fixed shape rather than a second sentence, so nothing but
-  // the counts moves and nothing has to agree with them.
+  // Undocumented reads as an adjective when it covers every surface and as a
+  // count when it covers some, so the sentence never repeats the same number.
   const missing = surfaces.filter((s) => !s.documented).length;
-  const gap = missing ? `, ${missing} without a docblock` : '';
+  const all = missing === surfaces.length;
 
   return [
     MARKER,
     `### 🚩 New public surface${one ? '' : 's'}`,
     '',
-    `This branch adds ${surfaces.length} extension point${one ? '' : 's'} that sites can depend on${gap}.`,
+    `This branch adds ${surfaces.length} ${all ? 'undocumented ' : ''}extension point${one ? '' : 's'} that sites can depend on${missing && !all ? `, ${missing} undocumented` : ''}.`,
     '',
     formatAudit(surfaces),
     '',

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,11 +233,11 @@ test('scans shipped code only', () => {
 
 test('marks what is undocumented and leaves the rest bare', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- ⚠️ `wp_presence_new_hook` (filter)\n- `b` (action)');
+  assert.equal(report, '- ⚠️ (filter) `wp_presence_new_hook`\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {
-  assert.match(formatAudit([surface('js-filter:presence.entry', true)]), /`presence\.entry` \(js-filter\)/);
+  assert.match(formatAudit([surface('js-filter:presence.entry', true)]), /\(js-filter\) `presence\.entry`/);
 });
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -251,12 +251,21 @@ test('leads with the marker so the workflow can find its own comment', () => {
 test('asks for a docblock only while something is undocumented', () => {
   const missing = formatComment([surface('filter:a')]);
   const covered = formatComment([surface('filter:a', true)]);
-  assert.match(missing, /adds 1 extension point that sites can depend on\. Add a docblock/);
-  assert.match(covered, /adds 1 extension point that sites can depend on\. It is already documented\./);
+  assert.match(missing, /adds 1 extension point that sites can depend on\. 1 needs a docblock saying what it is for\./);
+  assert.match(covered, /adds 1 extension point that sites can depend on\. It is documented\./);
+});
+
+// The count is what is left to do, not the total, so a branch that documents
+// one of two is not told to write a docblock above the one it documented.
+test('counts only the undocumented surfaces', () => {
+  const mixed = formatComment([surface('filter:a', true), surface('action:b')]);
+  assert.match(mixed, /\. 1 needs a docblock saying what it is for\./);
 });
 
 test('agrees in number', () => {
   const two = formatComment([surface('filter:a', true), surface('action:b', true)]);
   assert.match(two, /^### 🚩 New public surfaces$/m);
-  assert.match(two, /adds 2 extension points that sites can depend on\. They are already documented\./);
+  assert.match(two, /adds 2 extension points that sites can depend on\. All are documented\./);
+  const none = formatComment([surface('filter:a'), surface('action:b')]);
+  assert.match(none, /\. 2 need a docblock saying what they are for\./);
 });

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -231,9 +231,9 @@ test('scans shipped code only', () => {
 // formatAudit
 // ---------------------------------------------------------------------------
 
-test('marks what is undocumented and leaves the rest bare', () => {
+test('leads each entry with its kind and marks nothing', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- ⚠️ (filter) `wp_presence_new_hook`\n- (action) `b`');
+  assert.equal(report, '- (filter) `wp_presence_new_hook`\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {
@@ -251,7 +251,7 @@ test('leads with the marker so the workflow can find its own comment', () => {
 test('names the gap only while something is undocumented', () => {
   const missing = formatComment([surface('filter:a')]);
   const covered = formatComment([surface('filter:a', true)]);
-  assert.match(missing, /adds 1 extension point that sites can depend on, 1 without a docblock\./);
+  assert.match(missing, /adds 1 undocumented extension point that sites can depend on\./);
   assert.match(covered, /adds 1 extension point that sites can depend on\./);
 });
 
@@ -259,7 +259,7 @@ test('names the gap only while something is undocumented', () => {
 // one of two is not told both are missing.
 test('counts only the undocumented surfaces', () => {
   const mixed = formatComment([surface('filter:a', true), surface('action:b')]);
-  assert.match(mixed, /adds 2 extension points that sites can depend on, 1 without a docblock\./);
+  assert.match(mixed, /adds 2 extension points that sites can depend on, 1 undocumented\./);
 });
 
 test('agrees in number', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,7 +233,7 @@ test('scans shipped code only', () => {
 
 test('leads each entry with its kind and qualifies the undocumented ones', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (filter, needs docs) `wp_presence_new_hook`\n- (action) `b`');
+  assert.equal(report, '- (filter) `wp_presence_new_hook` *needs docs*\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,7 +233,7 @@ test('scans shipped code only', () => {
 
 test('leads each entry with its kind and qualifies the undocumented ones', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (undocumented filter) `wp_presence_new_hook`\n- (action) `b`');
+  assert.equal(report, '- (filter, needs docs) `wp_presence_new_hook`\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,7 +233,7 @@ test('scans shipped code only', () => {
 
 test('leads each entry with its kind and qualifies the undocumented ones', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (filter) `wp_presence_new_hook` - *needs documentation*\n- (action) `b`');
+  assert.equal(report, '- (filter) `wp_presence_new_hook` - *requires documentation*\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -248,24 +248,22 @@ test('leads with the marker so the workflow can find its own comment', () => {
   assert.ok(formatComment([surface('filter:a')]).startsWith(`${MARKER}\n### 🚩 New public surface\n`));
 });
 
-test('asks for a docblock only while something is undocumented', () => {
+test('names the gap only while something is undocumented', () => {
   const missing = formatComment([surface('filter:a')]);
   const covered = formatComment([surface('filter:a', true)]);
-  assert.match(missing, /adds 1 extension point that sites can depend on\. 1 needs a docblock saying what it is for\./);
-  assert.match(covered, /adds 1 extension point that sites can depend on\. It is documented\./);
+  assert.match(missing, /adds 1 extension point that sites can depend on, 1 without a docblock\./);
+  assert.match(covered, /adds 1 extension point that sites can depend on\./);
 });
 
 // The count is what is left to do, not the total, so a branch that documents
-// one of two is not told to write a docblock above the one it documented.
+// one of two is not told both are missing.
 test('counts only the undocumented surfaces', () => {
   const mixed = formatComment([surface('filter:a', true), surface('action:b')]);
-  assert.match(mixed, /\. 1 needs a docblock saying what it is for\./);
+  assert.match(mixed, /adds 2 extension points that sites can depend on, 1 without a docblock\./);
 });
 
 test('agrees in number', () => {
   const two = formatComment([surface('filter:a', true), surface('action:b', true)]);
   assert.match(two, /^### 🚩 New public surfaces$/m);
-  assert.match(two, /adds 2 extension points that sites can depend on\. All are documented\./);
-  const none = formatComment([surface('filter:a'), surface('action:b')]);
-  assert.match(none, /\. 2 need a docblock saying what they are for\./);
+  assert.match(two, /adds 2 extension points that sites can depend on\./);
 });

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -231,9 +231,9 @@ test('scans shipped code only', () => {
 // formatAudit
 // ---------------------------------------------------------------------------
 
-test('leads each entry with its kind and marks nothing', () => {
+test('leads each entry with its kind and qualifies the undocumented ones', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (filter) `wp_presence_new_hook`\n- (action) `b`');
+  assert.equal(report, '- (undocumented filter) `wp_presence_new_hook`\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {
@@ -248,22 +248,7 @@ test('leads with the marker so the workflow can find its own comment', () => {
   assert.ok(formatComment([surface('filter:a')]).startsWith(`${MARKER}\n### 🚩 New public surface\n`));
 });
 
-test('names the gap only while something is undocumented', () => {
-  const missing = formatComment([surface('filter:a')]);
-  const covered = formatComment([surface('filter:a', true)]);
-  assert.match(missing, /adds 1 undocumented extension point that sites can depend on\./);
-  assert.match(covered, /adds 1 extension point that sites can depend on\./);
-});
-
-// The count is what is left to do, not the total, so a branch that documents
-// one of two is not told both are missing.
-test('counts only the undocumented surfaces', () => {
-  const mixed = formatComment([surface('filter:a', true), surface('action:b')]);
-  assert.match(mixed, /adds 2 extension points that sites can depend on, 1 undocumented\./);
-});
-
 test('agrees in number', () => {
   const two = formatComment([surface('filter:a', true), surface('action:b', true)]);
   assert.match(two, /^### 🚩 New public surfaces$/m);
-  assert.match(two, /adds 2 extension points that sites can depend on\./);
 });

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,7 +233,7 @@ test('scans shipped code only', () => {
 
 test('marks what is undocumented and leaves the rest bare', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- `wp_presence_new_hook` (filter): undocumented\n- `b` (action)');
+  assert.equal(report, '- ⚠️ `wp_presence_new_hook` (filter)\n- `b` (action)');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,7 +233,7 @@ test('scans shipped code only', () => {
 
 test('leads each entry with its kind and qualifies the undocumented ones', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (filter) `wp_presence_new_hook` *needs docs*\n- (action) `b`');
+  assert.equal(report, '- (filter) `wp_presence_new_hook` - *needs docs*\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -233,7 +233,7 @@ test('scans shipped code only', () => {
 
 test('leads each entry with its kind and qualifies the undocumented ones', () => {
   const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (filter) `wp_presence_new_hook` - *needs docs*\n- (action) `b`');
+  assert.equal(report, '- (filter) `wp_presence_new_hook` - *needs documentation*\n- (action) `b`');
 });
 
 test('splits on the first colon so a namespaced hook name survives', () => {


### PR DESCRIPTION
The headline was an all-or-nothing assertion, so it read as boilerplate and told a branch that documented one of two surfaces to write a docblock above the one it had already documented.

<details>
<summary>AI disclosure</summary>

Used for: Assisting with the wording and tests.

</details>