### PR TITLE
fix: add data-post-id to server-rendered Active Posts rows

### DIFF
--- a/includes/widgets/class-wp-presence-widget-active-posts.php
+++ b/includes/widgets/class-wp-presence-widget-active-posts.php
@@ -145,7 +145,7 @@ class WP_Presence_Widget_Active_Posts {
 				// Active is the default state; labeling it adds noise.
 				$status_label = $any_active ? '' : __( 'Idle', 'presence-api' );
 
-				echo '<li class="presence-active-post-item">';
+				echo '<li class="presence-active-post-item" data-post-id="' . (int) $post_data['post_id'] . '">';
 
 				// Avatar stack.
 				echo '<span class="presence-editor-stack">';

--- a/tests/widgets/test-widget-active-posts.php
+++ b/tests/widgets/test-widget-active-posts.php
@@ -434,6 +434,24 @@ class WP_Test_Presence_Widget_Active_Posts extends WP_Presence_UnitTestCase {
 	/**
 	 * @covers WP_Presence_Widget_Active_Posts::render
 	 */
+	public function test_render_tags_rows_with_the_post_id_focus_restore_keys_on() {
+		wp_set_current_user( self::$editor_id );
+
+		$room = wp_presence_post_room( self::$post_id );
+		wp_set_presence( $room, 'lock-' . self::$editor_id, array(), self::$editor_id );
+
+		ob_start();
+		WP_Presence_Widget_Active_Posts::render();
+		$html = ob_get_clean();
+
+		// Must match the attribute active-posts.js rebuilds rows with, or the
+		// first heartbeat re-render drops focus to the container.
+		$this->assertStringContainsString( 'data-post-id="' . self::$post_id . '"', $html );
+	}
+
+	/**
+	 * @covers WP_Presence_Widget_Active_Posts::render
+	 */
 	public function test_render_counts_a_crowd_and_labels_it_idle_once_everyone_goes_quiet() {
 		global $wpdb;
 


### PR DESCRIPTION
Fixes #372

The Active Posts widget renders its list twice — once server-side in `WP_Presence_Widget_Active_Posts::render()`, then again in `assets/js/active-posts.js` on each heartbeat tick whose signature changed. Only the JS build emitted `data-post-id`, and that attribute is the hook focus retention keys on.

So on the first tick after page load, `captureFocus()` found the focused link inside the container but `.closest('[data-post-id]')` matched nothing, and `restoreFocus()` fell through to `container.trigger('focus')` — moving focus to the wrapper `<div tabindex="-1">` instead of back to the post link. Focus then stayed stuck there, since `$.contains()` is false for the container itself.

Adding the attribute to the server-rendered `<li>` brings it in line with the JS build and with Who's Online, which already emits `data-user-id` on both paths — which is why only Active Posts was affected.

Note - #403: this is a real focus bug, not test noise, so retries would have hidden it rather than fixed it.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Diagnosing the root cause and verifying the fix against the e2e test

</details>