### PR TITLE
test: run Jest unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
     needs: gate
     uses: ./.github/workflows/e2e.yml
 
+  unit:
+    needs: gate
+    uses: ./.github/workflows/unit.yml
+
   plugin-check:
     needs: gate
     uses: ./.github/workflows/plugin-check.yml

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,22 @@
+name: Unit Tests
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Jest
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:unit

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -1,0 +1,11 @@
+const defaultConfig = require( '@wordpress/scripts/config/jest-unit.config' );
+
+module.exports = {
+	...defaultConfig,
+	testMatch: [
+		'<rootDir>/src/**/test/**/*.[jt]s?(x)',
+		'<rootDir>/src/**/*.test.[jt]s?(x)',
+		'<rootDir>/assets/js/test/**/*.[jt]s?(x)',
+		'<rootDir>/assets/js/**/*.test.[jt]s?(x)',
+	],
+};


### PR DESCRIPTION
## Summary

- scope Jest discovery to the unit-test directories under `src/` and `assets/js/`
- retain the `@wordpress/scripts` preset and Babel transform
- run `npm run test:unit` in the pull-request CI workflow

Fixes #405

## Testing

- `git diff --check`
- Local Jest execution could not complete because the local npm installation was incomplete; CI installs dependencies from scratch on Node 22.