### PR TITLE
test: add multisite PHPUnit command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,6 +24,9 @@ composer install
 # Unit tests (requires wp-env running)
 npm test
 
+# Multisite tests (requires wp-env running)
+npm run test:multisite
+
 # E2E tests (requires wp-env running)
 npx playwright install chromium
 npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"env:stop:multisite": "cd tests/e2e/multisite && wp-env stop",
 		"env:cli": "wp-env run cli wp",
 		"test": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit --testdox",
+		"test:multisite": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- env WP_MULTISITE=1 ./vendor/bin/phpunit --testdox",
 		"test:e2e": "playwright test --config tests/e2e/playwright.config.js",
 		"test:scripts": "node --test .github/scripts/*.test.js",
 		"test:unit": "wp-scripts test-unit-js"


### PR DESCRIPTION
Adds a dedicated `npm run test:multisite` command that runs the existing PHPUnit suite with `WP_MULTISITE=1` inside the ordinary `tests-cli` environment. This makes the network tests one command away for contributors without involving the separate Playwright multisite environment.

Fixes #404

Testing:

- `npm test` — 404 tests, 680 assertions, 102 skipped
- `npm run test:multisite` — 404 tests, 884 assertions, 2 expected skips
- The multisite command activates 100 tests and 204 assertions skipped by the ordinary command
- `npm run test:scripts` — 79 passed
- `composer validate --no-check-publish --no-interaction` — passed
- `./vendor/bin/phpcs --standard=phpcs.xml.dist --report=summary` — passed
- `./vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=2G --no-progress` — passed

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Issue triage, the proposed package-script edit, validation commands, and drafting the test notes. The final change and results were reviewed by me before submission.

</details>
