### PR TITLE
fix: public surface read constants

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,7 +83,7 @@ A new label joins an existing color. If it genuinely needs its own, check it in 
 
 ### Public surfaces
 
-A hook, REST route, WP-CLI command, guarded constant, or browser global that a site can reach is a promise: renaming it later breaks that site. `public-surface.yml` labels any pull request that adds one and comments with the ones nothing has been written about yet.
+A hook, REST route, WP-CLI command, constant, or browser global that a site can reach is a promise: renaming it later breaks that site. `public-surface.yml` labels any pull request that adds one and comments with the ones nothing has been written about yet.
 
 Written about means a docblock directly above it with a sentence saying what it is for. That is where WordPress core's code reference reads from, and it keeps the write-up next to the code instead of in a hand-kept list that drifts the first time someone forgets it. `README.md` narrates the surfaces worth a worked example; it is not the inventory.
 

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// A hook, route, guarded constant, CLI command, or browser global is a promise:
+// A hook, route, constant, CLI command, or browser global is a promise:
 // once a site depends on one, renaming it breaks that site. This flags the pull
 // request that adds one and names the ones with nothing written above them.
 //
@@ -13,14 +13,39 @@
 const SCANNED = [/^includes\//, /^assets\/js\//, /^src\//, /^(presence-api|uninstall)\.php$/];
 const IGNORED = [/^assets\/js\/build\//, /\/test\//, /\.test\.js$/];
 
+// WordPress's own, which a plugin reads without ever owning. `ABSPATH` alone
+// opens every file in the tree, so without this the surfaces that are the
+// plugin's drown in guards that promise a site nothing.
+const CORE_CONSTANTS = new Set([
+  // Bootstrap and paths.
+  'ABSPATH', 'WPINC', 'WP_LANG_DIR', 'WP_CONTENT_DIR', 'WP_CONTENT_URL',
+  'WP_PLUGIN_DIR', 'WP_PLUGIN_URL', 'WPMU_PLUGIN_DIR', 'WPMU_PLUGIN_URL',
+  // Debugging.
+  'WP_DEBUG', 'WP_DEBUG_LOG', 'WP_DEBUG_DISPLAY', 'SCRIPT_DEBUG', 'SAVEQUERIES',
+  // Which kind of request this is.
+  'DOING_AJAX', 'DOING_CRON', 'DOING_AUTOSAVE', 'REST_REQUEST', 'XMLRPC_REQUEST',
+  'WP_ADMIN', 'WP_NETWORK_ADMIN', 'WP_USER_ADMIN', 'WP_CLI', 'WP_INSTALLING',
+  'WP_INSTALLING_NETWORK', 'WP_SETUP_CONFIG', 'WP_REPAIRING', 'WP_SANDBOX_SCRAPING',
+  'WP_UNINSTALL_PLUGIN',
+  // Multisite.
+  'MULTISITE', 'SUBDOMAIN_INSTALL', 'DOMAIN_CURRENT_SITE', 'PATH_CURRENT_SITE',
+  'SITE_ID_CURRENT_SITE', 'BLOG_ID_CURRENT_SITE',
+  // Behaviour a site configures in `wp-config.php`, WordPress's rather than ours.
+  'WP_CACHE', 'WP_ENVIRONMENT_TYPE', 'WP_DEVELOPMENT_MODE', 'WP_MEMORY_LIMIT',
+  'WP_MAX_MEMORY_LIMIT', 'DISALLOW_FILE_EDIT', 'DISALLOW_FILE_MODS', 'DISABLE_WP_CRON',
+  'ALTERNATE_WP_CRON', 'WP_CRON_LOCK_TIMEOUT', 'EMPTY_TRASH_DAYS', 'AUTOSAVE_INTERVAL',
+  'WP_POST_REVISIONS', 'MEDIA_TRASH', 'FORCE_SSL_ADMIN', 'COOKIE_DOMAIN',
+]);
+
 const PHP_RULES = [
   [
     /\b(apply_filters|do_action)(?:_ref_array|_deprecated)?\s*\(\s*(['"])(.*?)\2/g,
     (m) => `${'apply_filters' === m[1] ? 'filter' : 'action'}:${m[3]}`,
   ],
-  // Only the guarded form, and only the plugin's own prefix: a bare `define()`
-  // is an internal a site cannot override, and every file opens with `ABSPATH`.
-  [/if\s*\(\s*!\s*defined\s*\(\s*(['"])(WP_PRESENCE_[A-Z0-9_]*)\1\s*\)\s*\)/g, (m) => `constant:${m[2]}`],
+  // Every constant the plugin asks after, in either form a site can reach it:
+  // the guarded define, where a value already in `wp-config.php` wins, and the
+  // bare read of one only a site ever sets. Renaming either breaks that site.
+  [/\bdefined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1\s*\)/g, (m) => `constant:${m[2]}`],
   // Routes are usually concatenated (`'/' . $this->rest_base . '/rooms'`), so
   // take the whole second argument rather than the first literal inside it.
   [/register_rest_route\s*\(\s*[^,]+,\s*([^,]+?)\s*,/g, (m) => `rest:${route(m[1])}`],
@@ -83,16 +108,42 @@ function describes(block) {
     .some((line) => '' !== line && !line.startsWith('@'));
 }
 
+// The constants this file defines outright. A `define()` with no `! defined()`
+// guard anywhere leaves a site nothing to set, so the name is the plugin's own
+// rather than a promise to anyone, however often the code reads it back.
+function ownConstants(source) {
+  const named = (regex) => new Set([...source.matchAll(regex)].map((m) => m[2]));
+  const own = named(/\bdefine\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g);
+
+  for (const name of named(/!\s*defined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g)) {
+    own.delete(name);
+  }
+
+  return own;
+}
+
 // Identifiers are `kind:name` and carry no path, so the same hook found at a new
 // location is the same surface. Each one also reports whether the docblock above
 // it describes it; a private marker in that docblock withdraws it entirely.
 function findSurfaces(source, path) {
   const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
+  const own = ownConstants(source);
+
+  // A constant is only a promise if a site can set it.
+  const reachable = (id) => {
+    if (!id.startsWith('constant:')) {
+      return true;
+    }
+
+    const name = id.slice('constant:'.length);
+
+    return !CORE_CONSTANTS.has(name) && !own.has(name);
+  };
 
   return rules.flatMap(([regex, build]) =>
     [...source.matchAll(regex)]
       .map((m) => ({ id: build(m), block: docblockAbove(source, m.index) }))
-      .filter(({ id, block }) => !id.endsWith(':') && !PRIVATE.test(block))
+      .filter(({ id, block }) => !id.endsWith(':') && !PRIVATE.test(block) && reachable(id))
       .map(({ id, block }) => ({ id, documented: describes(block) }))
   );
 }

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -15,26 +15,63 @@ const IGNORED = [/^assets\/js\/build\//, /\/test\//, /\.test\.js$/];
 
 // WordPress's own, which a plugin reads without ever owning. `ABSPATH` alone
 // opens every file in the tree, so without this the surfaces that are the
-// plugin's drown in guards that promise a site nothing.
+// plugin's drown in guards that promise a site nothing. This is core's
+// documented `wp-config.php` set plus the flags it defines at run time; a name
+// core adds later belongs here too.
 const CORE_CONSTANTS = new Set([
-  // Bootstrap and paths.
+  // Bootstrap, paths, and URLs.
   'ABSPATH', 'WPINC', 'WP_LANG_DIR', 'WP_CONTENT_DIR', 'WP_CONTENT_URL',
   'WP_PLUGIN_DIR', 'WP_PLUGIN_URL', 'WPMU_PLUGIN_DIR', 'WPMU_PLUGIN_URL',
-  // Debugging.
+  'WP_TEMP_DIR', 'WP_HOME', 'WP_SITEURL', 'UPLOADS', 'TEMPLATEPATH',
+  'STYLESHEETPATH', 'WP_DEFAULT_THEME', 'WP_USE_THEMES', 'SHORTINIT',
+  // Debugging and asset loading.
   'WP_DEBUG', 'WP_DEBUG_LOG', 'WP_DEBUG_DISPLAY', 'SCRIPT_DEBUG', 'SAVEQUERIES',
+  'WP_DISABLE_FATAL_ERROR_HANDLER', 'WP_START_TIMESTAMP', 'WP_MEMORY_LIMIT',
+  'WP_MAX_MEMORY_LIMIT', 'CONCATENATE_SCRIPTS', 'COMPRESS_SCRIPTS',
+  'COMPRESS_CSS', 'ENFORCE_GZIP',
   // Which kind of request this is.
   'DOING_AJAX', 'DOING_CRON', 'DOING_AUTOSAVE', 'REST_REQUEST', 'XMLRPC_REQUEST',
-  'WP_ADMIN', 'WP_NETWORK_ADMIN', 'WP_USER_ADMIN', 'WP_CLI', 'WP_INSTALLING',
-  'WP_INSTALLING_NETWORK', 'WP_SETUP_CONFIG', 'WP_REPAIRING', 'WP_SANDBOX_SCRAPING',
-  'WP_UNINSTALL_PLUGIN',
+  'WP_ADMIN', 'WP_BLOG_ADMIN', 'WP_NETWORK_ADMIN', 'WP_USER_ADMIN', 'WP_CLI',
+  'WP_INSTALLING', 'WP_INSTALLING_NETWORK', 'WP_SETUP_CONFIG', 'WP_REPAIRING',
+  'WP_ALLOW_REPAIR', 'WP_SANDBOX_SCRAPING', 'WP_UNINSTALL_PLUGIN',
+  'WP_LOAD_IMPORTERS', 'WP_IMPORTING', 'IS_PROFILE_PAGE', 'WP_RUN_CORE_TESTS',
   // Multisite.
-  'MULTISITE', 'SUBDOMAIN_INSTALL', 'DOMAIN_CURRENT_SITE', 'PATH_CURRENT_SITE',
-  'SITE_ID_CURRENT_SITE', 'BLOG_ID_CURRENT_SITE',
-  // Behaviour a site configures in `wp-config.php`, WordPress's rather than ours.
-  'WP_CACHE', 'WP_ENVIRONMENT_TYPE', 'WP_DEVELOPMENT_MODE', 'WP_MEMORY_LIMIT',
-  'WP_MAX_MEMORY_LIMIT', 'DISALLOW_FILE_EDIT', 'DISALLOW_FILE_MODS', 'DISABLE_WP_CRON',
-  'ALTERNATE_WP_CRON', 'WP_CRON_LOCK_TIMEOUT', 'EMPTY_TRASH_DAYS', 'AUTOSAVE_INTERVAL',
-  'WP_POST_REVISIONS', 'MEDIA_TRASH', 'FORCE_SSL_ADMIN', 'COOKIE_DOMAIN',
+  'MULTISITE', 'WP_ALLOW_MULTISITE', 'SUBDOMAIN_INSTALL', 'VHOST', 'SUNRISE',
+  'DOMAIN_CURRENT_SITE', 'PATH_CURRENT_SITE', 'SITE_ID_CURRENT_SITE',
+  'BLOG_ID_CURRENT_SITE', 'NOBLOGREDIRECT', 'UPLOADBLOGSDIR', 'BLOGUPLOADDIR',
+  'WPMU_ACCEL_REDIRECT', 'WPMU_SENDFILE',
+  // Cron.
+  'DISABLE_WP_CRON', 'ALTERNATE_WP_CRON', 'WP_CRON_LOCK_TIMEOUT',
+  // Updates and the filesystem API.
+  'WP_AUTO_UPDATE_CORE', 'AUTOMATIC_UPDATER_DISABLED',
+  'CORE_UPGRADE_SKIP_NEW_BUNDLED', 'DISALLOW_FILE_EDIT', 'DISALLOW_FILE_MODS',
+  'DISALLOW_UNFILTERED_HTML', 'ALLOW_UNFILTERED_UPLOADS', 'FS_METHOD',
+  'FS_CHMOD_DIR', 'FS_CHMOD_FILE', 'FTP_BASE', 'FTP_CONTENT_DIR',
+  'FTP_PLUGIN_DIR', 'FTP_HOST', 'FTP_USER', 'FTP_PASS', 'FTP_SSL', 'FTP_PUBKEY',
+  'FTP_PRIKEY',
+  // Content and editing.
+  'EMPTY_TRASH_DAYS', 'AUTOSAVE_INTERVAL', 'WP_POST_REVISIONS', 'MEDIA_TRASH',
+  'IMAGE_EDIT_OVERWRITE',
+  // Database.
+  'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'DB_CHARSET', 'DB_COLLATE',
+  'CUSTOM_USER_TABLE', 'CUSTOM_USER_META_TABLE',
+  // Cookies, keys, and salts.
+  'FORCE_SSL_ADMIN', 'FORCE_SSL_LOGIN', 'COOKIE_DOMAIN', 'COOKIEPATH',
+  'SITECOOKIEPATH', 'ADMIN_COOKIE_PATH', 'PLUGINS_COOKIE_PATH', 'COOKIEHASH',
+  'AUTH_COOKIE', 'SECURE_AUTH_COOKIE', 'LOGGED_IN_COOKIE', 'TEST_COOKIE',
+  'USER_COOKIE', 'PASS_COOKIE', 'RECOVERY_MODE_COOKIE', 'RECOVERY_MODE_EMAIL',
+  'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT',
+  'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT',
+  // Caching and environment.
+  'WP_CACHE', 'WP_CACHE_KEY_SALT', 'WP_ENVIRONMENT_TYPE', 'WP_DEVELOPMENT_MODE',
+  'WP_LOCAL_DEV',
+  // Localization.
+  'WPLANG', 'WP_LANG',
+  // The time and byte spans core defines for everyone.
+  'MINUTE_IN_SECONDS', 'HOUR_IN_SECONDS', 'DAY_IN_SECONDS', 'WEEK_IN_SECONDS',
+  'MONTH_IN_SECONDS', 'YEAR_IN_SECONDS', 'KB_IN_BYTES', 'MB_IN_BYTES',
+  'GB_IN_BYTES', 'TB_IN_BYTES', 'PB_IN_BYTES', 'EB_IN_BYTES', 'ZB_IN_BYTES',
+  'YB_IN_BYTES',
 ]);
 
 const PHP_RULES = [
@@ -108,12 +145,15 @@ function describes(block) {
     .some((line) => '' !== line && !line.startsWith('@'));
 }
 
-// The constants this file defines outright. A `define()` with no `! defined()`
-// guard anywhere leaves a site nothing to set, so the name is the plugin's own
-// rather than a promise to anyone, however often the code reads it back.
-function ownConstants(source) {
-  const named = (regex) => new Set([...source.matchAll(regex)].map((m) => m[2]));
-  const own = named(/\bdefine\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g);
+// The constants a body of source defines outright. A `define()` with no
+// `! defined()` guard anywhere leaves a site nothing to set, so the name is the
+// plugin's own rather than a promise, however often the code reads it back.
+// Sources are weighed together rather than one at a time: the file that defines
+// a constant is rarely the file that reads it, and either half alone misreads
+// the other. The CLI passes the whole ref.
+function ownConstants(sources) {
+  const named = (regex) => sources.flatMap((source) => [...source.matchAll(regex)].map((m) => m[2]));
+  const own = new Set(named(/\bdefine\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g));
 
   for (const name of named(/!\s*defined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g)) {
     own.delete(name);
@@ -125,9 +165,10 @@ function ownConstants(source) {
 // Identifiers are `kind:name` and carry no path, so the same hook found at a new
 // location is the same surface. Each one also reports whether the docblock above
 // it describes it; a private marker in that docblock withdraws it entirely.
-function findSurfaces(source, path) {
+// `own` names the constants something else already defines outright, which only
+// a caller holding the whole ref can know; alone, a file speaks for itself.
+function findSurfaces(source, path, own = ownConstants([source])) {
   const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
-  const own = ownConstants(source);
 
   // A constant is only a promise if a site can set it.
   const reachable = (id) => {
@@ -140,12 +181,20 @@ function findSurfaces(source, path) {
     return !CORE_CONSTANTS.has(name) && !own.has(name);
   };
 
-  return rules.flatMap(([regex, build]) =>
+  const found = rules.flatMap(([regex, build]) =>
     [...source.matchAll(regex)]
       .map((m) => ({ id: build(m), block: docblockAbove(source, m.index) }))
-      .filter(({ id, block }) => !id.endsWith(':') && !PRIVATE.test(block) && reachable(id))
-      .map(({ id, block }) => ({ id, documented: describes(block) }))
+      .filter(({ id }) => !id.endsWith(':') && reachable(id))
   );
+
+  // The marker withdraws the name, not the one occurrence carrying it: a
+  // constant declared private and consulted again later is private at the read
+  // too, and nothing is gained by making someone repeat the docblock.
+  const withdrawn = new Set(found.filter(({ block }) => PRIVATE.test(block)).map(({ id }) => id));
+
+  return found
+    .filter(({ id }) => !withdrawn.has(id))
+    .map(({ id, block }) => ({ id, documented: describes(block) }));
 }
 
 // Additions only. A hook fired from two places is documented once and
@@ -197,6 +246,7 @@ module.exports.newSurfaces = newSurfaces;
 module.exports.formatAudit = formatAudit;
 module.exports.formatComment = formatComment;
 module.exports.isScanned = isScanned;
+module.exports.ownConstants = ownConstants;
 module.exports.MARKER = MARKER;
 
 // CLI: `node detect-public-surface.js <base-ref> <head-ref>`. Reads both trees
@@ -223,11 +273,19 @@ if (require.main === module) {
     }
   };
 
-  const scan = (ref) =>
-    git(['ls-tree', '-r', '--name-only', ref])
+  const scan = (ref) => {
+    const files = git(['ls-tree', '-r', '--name-only', ref])
       .split('\n')
       .filter(isScanned)
-      .flatMap((path) => findSurfaces(read(ref, path), path));
+      .map((path) => ({ path, source: read(ref, path) }));
+
+    // One owned set for the whole ref. A constant defined outright in
+    // `presence-api.php` is the plugin's own in every file that reads it, which
+    // no file can tell on its own.
+    const own = ownConstants(files.map(({ source }) => source));
+
+    return files.flatMap(({ path, source }) => findSurfaces(source, path, own));
+  };
 
   const surfaces = newSurfaces(scan(baseRef), scan(headRef));
 

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -4,7 +4,8 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const findSurfaces = require('./detect-public-surface.js');
-const { newSurfaces, formatAudit, formatComment, isScanned, MARKER } = findSurfaces;
+const { newSurfaces, ownConstants, formatAudit, formatComment, isScanned, MARKER } =
+  findSurfaces;
 
 const ids = (surfaces) => surfaces.map((s) => s.id);
 const php = (source) => ids(findSurfaces(source, 'includes/functions.php'));
@@ -134,6 +135,62 @@ if ( defined( 'WP_PRESENCE_INTERNAL_OFF' ) && WP_PRESENCE_INTERNAL_OFF ) {}`;
   assert.deepEqual(php(source.replace(' * @access private\n', '')), [
     'constant:WP_PRESENCE_INTERNAL_OFF',
   ]);
+});
+
+test('the core list covers the constants a plugin actually guards on', () => {
+  const source = `
+    if ( defined( 'SHORTINIT' ) && SHORTINIT ) {}
+    if ( defined( 'WP_USE_THEMES' ) && WP_USE_THEMES ) {}
+    if ( defined( 'WP_ALLOW_REPAIR' ) && WP_ALLOW_REPAIR ) {}
+    if ( defined( 'WP_AUTO_UPDATE_CORE' ) ) {}
+    if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {}
+    if ( defined( 'DAY_IN_SECONDS' ) ) {}
+    if ( defined( 'DB_HOST' ) ) {}
+    if ( defined( 'COOKIEHASH' ) ) {}
+    if ( defined( 'SUNRISE' ) && SUNRISE ) {}
+  `;
+  assert.deepEqual(php(source), []);
+});
+
+test("a constant defined in one file is the plugin's own in every other", () => {
+  const bootstrap = "define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );";
+  const reader = "if ( defined( 'WP_PRESENCE_MAX_KEY_LENGTH' ) ) {}";
+
+  // Alone, the reading file cannot tell an internal from a promise.
+  assert.deepEqual(php(reader), ['constant:WP_PRESENCE_MAX_KEY_LENGTH']);
+
+  // Weighed with the file that defines it, the way the CLI weighs a whole ref.
+  const own = ownConstants([bootstrap, reader]);
+  assert.deepEqual(ids(findSurfaces(reader, 'includes/functions.php', own)), []);
+});
+
+test('a guard anywhere in the ref keeps the constant settable', () => {
+  const bootstrap = `if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
+      define( 'WP_PRESENCE_DEFAULT_TTL', 150 );
+    }`;
+  const reader = "if ( defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {}";
+  const own = ownConstants([bootstrap, reader]);
+
+  assert.deepEqual(ids(findSurfaces(reader, 'includes/functions.php', own)), [
+    'constant:WP_PRESENCE_DEFAULT_TTL',
+  ]);
+});
+
+test('a private declaration stays private where the constant is read again', () => {
+  const source = `/**
+ * Internal kill switch.
+ *
+ * @since 0.1.0
+ * @access private
+ */
+if ( ! defined( 'WP_PRESENCE_INTERNAL' ) ) {
+	define( 'WP_PRESENCE_INTERNAL', 5 );
+}
+
+if ( defined( 'WP_PRESENCE_INTERNAL' ) && WP_PRESENCE_INTERNAL ) {
+	return;
+}`;
+  assert.deepEqual(php(source), []);
 });
 
 test('reads a route through a variable namespace', () => {

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -54,6 +54,88 @@ test('counts a guarded constant, ignores a bare define and core guards', () => {
   assert.deepEqual(php(source), ['constant:WP_PRESENCE_DEFAULT_TTL']);
 });
 
+test('counts a constant the plugin only ever reads', () => {
+  // Nothing here defines it: a site sets it in `wp-config.php` or it stays
+  // undefined, which is what makes the name a promise in the first place.
+  const source = `
+    if ( defined( 'DISABLE_WP_PRESENCE' ) && DISABLE_WP_PRESENCE ) {
+      return;
+    }
+  `;
+  assert.deepEqual(php(source), ['constant:DISABLE_WP_PRESENCE']);
+});
+
+test("a name outside the plugin's prefix is still the plugin's promise", () => {
+  assert.deepEqual(php("if ( defined( 'PRESENCE_API_DEBUG' ) ) {}"), [
+    'constant:PRESENCE_API_DEBUG',
+  ]);
+});
+
+test("core constants are WordPress's promise, in either form", () => {
+  const source = `
+    if ( ! defined( 'ABSPATH' ) ) {
+      exit;
+    }
+    if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+      exit;
+    }
+    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {}
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {}
+    if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {}
+  `;
+  assert.deepEqual(php(source), []);
+});
+
+test('a constant defined outright stays internal, however often it is read', () => {
+  const source = `
+    define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );
+    if ( defined( 'WP_PRESENCE_MAX_KEY_LENGTH' ) ) {
+      $max = WP_PRESENCE_MAX_KEY_LENGTH;
+    }
+  `;
+  assert.deepEqual(php(source), []);
+});
+
+test('a guarded define and a read of it are the one surface', () => {
+  const source = `
+    if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
+      define( 'WP_PRESENCE_DEFAULT_TTL', 150 );
+    }
+    if ( defined( 'WP_PRESENCE_DEFAULT_TTL' ) && WP_PRESENCE_DEFAULT_TTL ) {
+      $ttl = WP_PRESENCE_DEFAULT_TTL;
+    }
+  `;
+  assert.deepEqual(ids(newSurfaces([], findSurfaces(source, 'includes/functions.php'))), [
+    'constant:WP_PRESENCE_DEFAULT_TTL',
+  ]);
+});
+
+test('a docblock above the read documents the constant', () => {
+  const [read] = findSurfaces(
+    `/**
+ * Whether presence is switched off for the whole site.
+ */
+if ( defined( 'DISABLE_WP_PRESENCE' ) && DISABLE_WP_PRESENCE ) {}`,
+    'includes/functions.php'
+  );
+  assert.equal(read.id, 'constant:DISABLE_WP_PRESENCE');
+  assert.equal(read.documented, true);
+});
+
+test('@access private withdraws a constant the same way', () => {
+  const source = `/**
+ * Internal kill switch.
+ *
+ * @since 0.1.0
+ * @access private
+ */
+if ( defined( 'WP_PRESENCE_INTERNAL_OFF' ) && WP_PRESENCE_INTERNAL_OFF ) {}`;
+  assert.deepEqual(php(source), []);
+  assert.deepEqual(php(source.replace(' * @access private\n', '')), [
+    'constant:WP_PRESENCE_INTERNAL_OFF',
+  ]);
+});
+
 test('reads a route through a variable namespace', () => {
   assert.deepEqual(
     php("register_rest_route( $this->namespace, '/presence', array() );"),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to the Presence API feature plugin.

This GitHub repository is where the feature plugin's work happens — issues
track scope and PRs land changes. Keep larger design discussions in the
linked issue and use this Pull Request for code review.

If this is your first time contributing, the following may be helpful:
- Contributing guide: ../blob/main/.github/CONTRIBUTING.md
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Fixes #410 

<!--
Put the issue number directly after the keyword, e.g. "Fixes #12", so the issue
closes when this Pull Request merges. GitHub only parses the keyword when the
reference follows it on the same line, so "Resolves Issue: #12" and a "Fixes"
line followed by a bulleted "- #12" both leave the issue open.

If this Pull Request should not close an issue, use "Related: #12" instead.
-->

<details>
<summary>Use of AI Tools</summary>

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example:
-->

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.

</details>
