### PR TITLE
feat: switch presence recording on and off from Settings and WP-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,14 @@ add_filter( 'wp_presence_current_screen_key', function( $key, $screen ) {
 Keys follow the plugin's slash-separated room convention and are truncated to 191 characters (`WP_PRESENCE_SCREEN_KEY_LIMIT`). Use the same key when bumping the revision from JS via `wp.presence.markScreenStale()`.
 
 #### `wp_presence_recording_enabled`
-Filters whether presence is recorded on this site. Default: `true`. Return `false` and nothing further is written; every surface empties within one TTL as the rows already stored expire, so there is nothing else to clear.
+Filters whether presence is recorded on this site. Default: the **Presence** checkbox on Settings > General, which is on for a new install. Return `false` and nothing further is written; every surface empties within one TTL as the rows already stored expire, so there is nothing else to clear.
 ```php
 add_filter( 'wp_presence_recording_enabled', '__return_false' );
 ```
 
-On multisite, `wp_presence_network_recording_enabled` does the same for every site at once. It is consulted only once the site-level filter has allowed recording, so either switch turning off wins and neither can turn the other back on.
+Because the checkbox is only the filter's default, a filter always has the last word over whatever an administrator has chosen.
+
+On multisite, `wp_presence_network_recording_enabled` does the same for every site at once, defaulting to the **Presence** checkbox on Network Admin > Settings. It is consulted only once the site-level filter has allowed recording, so either switch turning off wins and neither can turn the other back on.
 
 #### `wp_presence_network_aggregation_enabled`
 Filters whether a network assembles its sites' rows into the network-wide view behind Network Admin. Default: `true` below [`wp_is_large_network()`](https://developer.wordpress.org/reference/functions/wp_is_large_network/), which answers write concentration rather than policy. Independent of recording: a network can go on recording site by site and still switch the aggregate off.
@@ -176,6 +178,13 @@ wp presence summary   # Summary grouped by room
 wp presence set       # Manually upsert an entry
 wp presence cleanup   # Delete expired entries immediately
 wp presence network   # Network-wide summary (multisite only)
+wp presence recording # Read or set the recording switch
+```
+
+```
+wp presence recording get
+wp presence recording set off
+wp presence recording set off --network   # Multisite only
 ```
 
 ## Post-lock bridge

--- a/includes/cli/class-wp-presence-cli-command.php
+++ b/includes/cli/class-wp-presence-cli-command.php
@@ -280,6 +280,84 @@ class WP_Presence_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Gets or sets whether presence is recorded.
+	 *
+	 * Reports the option rather than the effective state, so a `get` still shows
+	 * what the switch is set to on a site where a filter overrides it.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Whether to read or write the switch.
+	 * ---
+	 * options:
+	 *   - get
+	 *   - set
+	 * ---
+	 *
+	 * [<state>]
+	 * : The state to store. Required for set.
+	 * ---
+	 * options:
+	 *   - on
+	 *   - off
+	 * ---
+	 *
+	 * [--network]
+	 * : Act on the network-wide switch instead. Multisite only.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp presence recording get
+	 *     wp presence recording set off
+	 *     wp presence recording get --network
+	 *     wp presence recording set off --network
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function recording( $args, $assoc_args ) {
+		$network = (bool) WP_CLI\Utils\get_flag_value( $assoc_args, 'network', false );
+
+		if ( $network && ! is_multisite() ) {
+			WP_CLI::error( __( 'This is not a multisite installation.', 'presence-api' ) );
+		}
+
+		$option  = $network ? 'wp_presence_network_recording' : 'wp_presence_recording';
+		$enabled = $network
+			? (bool) get_site_option( $option, true )
+			: (bool) get_option( $option, true );
+
+		if ( 'get' === $args[0] ) {
+			WP_CLI::log( $enabled ? 'on' : 'off' );
+			return;
+		}
+
+		if ( ! isset( $args[1] ) ) {
+			WP_CLI::error( __( 'Specify on or off.', 'presence-api' ) );
+		}
+
+		$target = 'on' === $args[1];
+
+		// Stored as '1' or '0'. A boolean false is indistinguishable from an
+		// absent option, so update_option() would discard it as unchanged.
+		$stored = $target ? '1' : '0';
+
+		if ( $network ) {
+			update_site_option( $option, $stored );
+		} else {
+			update_option( $option, $stored );
+		}
+
+		if ( $target ) {
+			WP_CLI::success( __( 'Presence recording is on.', 'presence-api' ) );
+			return;
+		}
+
+		WP_CLI::success( __( 'Presence recording is off. Existing entries expire on their own.', 'presence-api' ) );
+	}
+
+	/**
 	 * Deletes all presence entries from the table.
 	 *
 	 * ## OPTIONS

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -142,6 +142,9 @@ function wp_presence_with_current_user( $entries ) {
  * default is the safe one; a site that would rather not process it at all
  * switches it off here and says so in its privacy policy.
  *
+ * The stored options are passed as the filters' defaults, so a filter always
+ * has the last word over whatever the checkbox says.
+ *
  * Aggregating those rows into the network-wide view is a separate switch. See
  * wp_presence_network_aggregation_enabled().
  *
@@ -155,9 +158,10 @@ function wp_presence_recording_enabled() {
 	 *
 	 * @since 0.3.0
 	 *
-	 * @param bool $enabled Whether to record presence. Default true.
+	 * @param bool $enabled Whether to record presence. Default is the
+	 *                      wp_presence_recording option, true on a new install.
 	 */
-	$enabled = (bool) apply_filters( 'wp_presence_recording_enabled', true );
+	$enabled = (bool) apply_filters( 'wp_presence_recording_enabled', (bool) get_option( 'wp_presence_recording', true ) );
 
 	if ( ! $enabled || ! is_multisite() ) {
 		return $enabled;
@@ -171,9 +175,11 @@ function wp_presence_recording_enabled() {
 	 *
 	 * @since 0.3.0
 	 *
-	 * @param bool $enabled Whether to record presence. Default true.
+	 * @param bool $enabled Whether to record presence. Default is the
+	 *                      wp_presence_network_recording site option, true on a
+	 *                      new install.
 	 */
-	return (bool) apply_filters( 'wp_presence_network_recording_enabled', true );
+	return (bool) apply_filters( 'wp_presence_network_recording_enabled', (bool) get_site_option( 'wp_presence_network_recording', true ) );
 }
 
 /**

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Settings: the recording switch on Settings > General and Network Settings.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers the site recording option and its field on Settings > General.
+ *
+ * @access private
+ */
+function wp_presence_register_settings() {
+	register_setting(
+		'general',
+		'wp_presence_recording',
+		array(
+			'type'              => 'boolean',
+			'default'           => true,
+			'sanitize_callback' => 'wp_presence_sanitize_checkbox',
+			'show_in_rest'      => false,
+		)
+	);
+
+	add_settings_field(
+		'wp_presence_recording',
+		__( 'Presence', 'presence-api' ),
+		'wp_presence_render_recording_field',
+		'general',
+		'default',
+		array( 'label_for' => 'wp_presence_recording' )
+	);
+}
+
+/**
+ * Casts a checkbox to the '1' or '0' the option stores.
+ *
+ * A boolean false is indistinguishable from an absent option, so update_option()
+ * would discard it as unchanged and leave recording on.
+ *
+ * @access private
+ *
+ * @param mixed $value The submitted value.
+ * @return string '1' when recording is on, '0' when off.
+ */
+function wp_presence_sanitize_checkbox( $value ) {
+	return $value ? '1' : '0';
+}
+
+/**
+ * Renders the recording checkbox on Settings > General.
+ *
+ * @access private
+ */
+function wp_presence_render_recording_field() {
+	$enabled = (bool) get_option( 'wp_presence_recording', true );
+	?>
+	<input type="hidden" name="wp_presence_recording" value="0" />
+	<label>
+		<input type="checkbox" id="wp_presence_recording" name="wp_presence_recording" value="1" <?php checked( $enabled ); ?> />
+		<?php esc_html_e( 'Record who is working where in the admin', 'presence-api' ); ?>
+	</label>
+	<p class="description">
+		<?php esc_html_e( 'Presence rows expire on their own, so switching this off empties every presence screen within a few minutes.', 'presence-api' ); ?>
+	</p>
+	<?php
+}
+
+/**
+ * Renders the network recording checkbox on Network Admin > Settings.
+ *
+ * Network Settings has no Settings API equivalent, so the field is printed on
+ * wpmu_options and read back in wp_presence_save_network_settings().
+ *
+ * @access private
+ */
+function wp_presence_render_network_settings() {
+	$enabled = (bool) get_site_option( 'wp_presence_network_recording', true );
+	?>
+	<h2><?php esc_html_e( 'Presence', 'presence-api' ); ?></h2>
+	<table class="form-table" role="presentation">
+		<tr>
+			<th scope="row"><?php esc_html_e( 'Recording', 'presence-api' ); ?></th>
+			<td>
+				<label>
+					<input type="checkbox" name="wp_presence_network_recording" value="1" <?php checked( $enabled ); ?> />
+					<?php esc_html_e( 'Record presence on sites in this network', 'presence-api' ); ?>
+				</label>
+				<p class="description">
+					<?php esc_html_e( 'Switching this off stops recording everywhere, whatever an individual site has chosen.', 'presence-api' ); ?>
+				</p>
+			</td>
+		</tr>
+	</table>
+	<?php
+}
+
+/**
+ * Saves the network recording checkbox.
+ *
+ * Core verifies the siteoptions nonce before firing this action.
+ *
+ * @access private
+ */
+function wp_presence_save_network_settings() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Verified by core in wp-admin/network/settings.php.
+	$submitted = ! empty( $_POST['wp_presence_network_recording'] );
+
+	update_site_option( 'wp_presence_network_recording', wp_presence_sanitize_checkbox( $submitted ) );
+}

--- a/presence-api.php
+++ b/presence-api.php
@@ -104,6 +104,7 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/cron.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/post-lock-bridge.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/screen-revisions.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/lifecycle.php';
+require_once WP_PRESENCE_PLUGIN_DIR . 'includes/settings.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/admin-bar.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/user-list.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/post-list.php';
@@ -308,6 +309,8 @@ add_action( 'init', 'wp_presence_register_post_type_support' );
 // creation instead; this is the fallback for a site that missed both.
 add_action( 'admin_init', 'wp_maybe_create_presence_table' );
 add_action( 'cli_init', 'wp_maybe_create_presence_table' );
+
+add_action( 'admin_init', 'wp_presence_register_settings' );
 if ( is_multisite() ) {
 	// Global so the keys are not prefixed with a blog ID. The push runs inside
 	// switch_to_blog(), and a per-site group would file the invalidation under
@@ -327,6 +330,8 @@ if ( is_multisite() ) {
 	add_action( 'wp_presence_admin_room_changed', 'wp_presence_flush_network_summary_cache' );
 	add_action( 'wp_delete_site', 'wp_presence_on_delete_site' );
 	add_action( 'wp_delete_expired_presence_data', 'wp_presence_delete_expired_network_summary_rows' );
+	add_action( 'wpmu_options', 'wp_presence_render_network_settings' );
+	add_action( 'update_wpmu_options', 'wp_presence_save_network_settings' );
 }
 // Priority 99 to run after core's wp_initialize_site() at 10.
 add_action( 'wp_initialize_site', 'wp_presence_on_initialize_site', 99 );

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,9 @@ Anyone with the `manage_network` capability, which on a default network means su
 
 = Can a site stop recording presence? =
 
-Yes. The `wp_presence_recording_enabled` filter switches the write off, and every screen empties within one TTL as the rows already stored expire. On multisite, `wp_presence_network_recording_enabled` does the same for every site at once; whichever switch is off decides.
+Yes. Clear the **Presence** checkbox on Settings > General, or run `wp presence recording set off`. Every screen empties within one TTL as the rows already stored expire. On multisite, Network Admin > Settings has the same checkbox for every site at once; whichever switch is off decides.
+
+For code, the `wp_presence_recording_enabled` and `wp_presence_network_recording_enabled` filters take the checkboxes as their defaults, so a filter always has the last word.
 
 == Changelog ==
 

--- a/tests/class-wp-presence-unittestcase.php
+++ b/tests/class-wp-presence-unittestcase.php
@@ -12,6 +12,12 @@ abstract class WP_Presence_UnitTestCase extends WP_UnitTestCase {
 
 	public function tear_down() {
 		global $wpdb;
+		// The TRUNCATE below commits, so an option a test wrote outlives the
+		// rollback. Cleared first, where the same commit carries the delete;
+		// after it the statement lands in a fresh transaction and is rolled back.
+		delete_option( 'wp_presence_recording' );
+		delete_site_option( 'wp_presence_network_recording' );
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->presence}" );
 

--- a/tests/test-cli-command.php
+++ b/tests/test-cli-command.php
@@ -395,4 +395,56 @@ class WP_Test_Presence_CLI_Command extends WP_Presence_UnitTestCase {
 			'This is not a multisite installation.'
 		);
 	}
+
+	/**
+	 * @covers WP_Presence_CLI_Command::recording
+	 */
+	public function test_recording_get_reports_the_stored_state() {
+		update_option( 'wp_presence_recording', '0' );
+
+		$this->command->recording( array( 'get' ), array() );
+
+		$this->assertSame( array( 'off' ), WP_CLI::messages( 'log' ) );
+	}
+
+	/**
+	 * Asserted at the option rather than only on the message: a command that
+	 * reports success while storing nothing is the failure that matters.
+	 *
+	 * @covers WP_Presence_CLI_Command::recording
+	 */
+	public function test_recording_set_stores_the_state() {
+		$this->command->recording( array( 'set', 'off' ), array() );
+
+		$this->assertFalse( (bool) get_option( 'wp_presence_recording' ) );
+		$this->assertFalse( wp_presence_recording_enabled() );
+	}
+
+	/**
+	 * @covers WP_Presence_CLI_Command::recording
+	 */
+	public function test_recording_set_requires_a_state() {
+		$this->assert_halts_with(
+			function () {
+				$this->command->recording( array( 'set' ), array() );
+			},
+			'Specify on or off.'
+		);
+	}
+
+	/**
+	 * @covers WP_Presence_CLI_Command::recording
+	 */
+	public function test_recording_refuses_the_network_switch_on_a_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Requires single site.' );
+		}
+
+		$this->assert_halts_with(
+			function () {
+				$this->command->recording( array( 'get' ), array( 'network' => true ) );
+			},
+			'This is not a multisite installation.'
+		);
+	}
 }

--- a/tests/test-cli-network-command.php
+++ b/tests/test-cli-network-command.php
@@ -169,4 +169,19 @@ class WP_Test_Presence_CLI_Network_Command extends WP_Presence_Network_UnitTestC
 
 		$this->assertSame( array(), WP_CLI::messages( 'error' ) );
 	}
+
+	/**
+	 * The network switch writes a site option, so a site that allows recording
+	 * still stops. Strictest wins, as with the filters.
+	 *
+	 * @covers WP_Presence_CLI_Command::recording
+	 */
+	public function test_recording_set_network_stops_a_site_that_allows_recording() {
+		update_option( 'wp_presence_recording', '1' );
+
+		$this->command->recording( array( 'set', 'off' ), array( 'network' => true ) );
+
+		$this->assertFalse( (bool) get_site_option( 'wp_presence_network_recording' ) );
+		$this->assertFalse( wp_presence_recording_enabled() );
+	}
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -879,4 +879,42 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 		$this->assertFalse( wp_presence_recording_enabled() );
 	}
+
+	/**
+	 * The switch an owner reaches without writing PHP.
+	 *
+	 * @covers ::wp_presence_recording_enabled
+	 */
+	public function test_the_stored_option_switches_recording_off() {
+		update_option( 'wp_presence_recording', '0' );
+
+		$this->assertFalse( wp_presence_recording_enabled() );
+	}
+
+	/**
+	 * The option is the filter's default, not a second opinion, so code still
+	 * has the last word over whatever the checkbox says.
+	 *
+	 * @covers ::wp_presence_recording_enabled
+	 */
+	public function test_a_filter_overrides_the_stored_option() {
+		update_option( 'wp_presence_recording', '0' );
+		add_filter( 'wp_presence_recording_enabled', '__return_true' );
+
+		$this->assertTrue( wp_presence_recording_enabled() );
+	}
+
+	/**
+	 * @covers ::wp_presence_recording_enabled
+	 */
+	public function test_the_network_option_switches_off_a_site_that_allows_recording() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_option( 'wp_presence_recording', '1' );
+		update_site_option( 'wp_presence_network_recording', '0' );
+
+		$this->assertFalse( wp_presence_recording_enabled() );
+	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Tests for the recording settings screens.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ */
+
+class WP_Test_Presence_Settings extends WP_Presence_UnitTestCase {
+
+	public function tear_down() {
+		unset( $_POST['wp_presence_network_recording'] );
+		parent::tear_down();
+	}
+
+	private function render( $callback ) {
+		ob_start();
+		$callback();
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * A field registered against any other page would never appear on the
+	 * screen the switch is meant to live on.
+	 *
+	 * @covers ::wp_presence_register_settings
+	 */
+	public function test_the_checkbox_is_registered_on_settings_general() {
+		global $wp_settings_fields;
+
+		wp_presence_register_settings();
+
+		$this->assertArrayHasKey( 'wp_presence_recording', $wp_settings_fields['general']['default'] );
+	}
+
+	/**
+	 * register_setting() is what lets options.php accept the field at all.
+	 * Without it the checkbox would post and be discarded.
+	 *
+	 * @covers ::wp_presence_register_settings
+	 */
+	public function test_the_option_is_allowed_through_options_php() {
+		wp_presence_register_settings();
+
+		$this->assertArrayHasKey( 'wp_presence_recording', get_registered_settings() );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_recording_field
+	 */
+	public function test_the_checkbox_follows_the_stored_option() {
+		update_option( 'wp_presence_recording', '1' );
+		$this->assertStringContainsString( 'checked', $this->render( 'wp_presence_render_recording_field' ) );
+
+		update_option( 'wp_presence_recording', '0' );
+		$off = $this->render( 'wp_presence_render_recording_field' );
+
+		$this->assertStringNotContainsString( 'checked', $off );
+		// An unchecked box posts nothing, so the hidden field is what carries the off.
+		$this->assertStringContainsString( 'name="wp_presence_recording" value="0"', $off );
+	}
+
+	/**
+	 * @covers ::wp_presence_render_network_settings
+	 */
+	public function test_the_network_checkbox_follows_the_stored_option() {
+		update_site_option( 'wp_presence_network_recording', '0' );
+
+		$this->assertStringNotContainsString( 'checked', $this->render( 'wp_presence_render_network_settings' ) );
+	}
+
+	/**
+	 * @covers ::wp_presence_save_network_settings
+	 */
+	public function test_the_network_box_saves_both_ways() {
+		// Not seeded first: an install that has never touched the switch is
+		// where storing a boolean false would read back as unchanged.
+		wp_presence_save_network_settings();
+
+		$this->assertSame( '0', get_site_option( 'wp_presence_network_recording' ), 'An unchecked box posts nothing and should switch recording off.' );
+
+		$_POST['wp_presence_network_recording'] = '1';
+
+		wp_presence_save_network_settings();
+
+		$this->assertTrue( (bool) get_site_option( 'wp_presence_network_recording' ) );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,6 +27,7 @@ function wp_presence_uninstall_site() {
 	$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 
 	delete_option( 'wp_presence_db_version' );
+	delete_option( 'wp_presence_recording' );
 	delete_option( 'wp_presence_screen_revisions' );
 	delete_option( 'wp_presence_network_pushed' );
 
@@ -68,6 +69,7 @@ if ( is_multisite() ) {
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a controlled value from $wpdb->base_prefix.
 	$wpdb->query( "DROP TABLE IF EXISTS {$summary_table}" );
 
+	delete_site_option( 'wp_presence_network_recording' );
 	delete_site_option( 'wp_presence_network_summary_db_version' );
 	delete_site_option( 'wp_presence_network_summary_table.lock' );
 } else {


### PR DESCRIPTION
The recording filters shipped in #429 with no way to reach them without writing PHP.

Fixes #441

| Where | Control |
| --- | --- |
| Settings > General | **Presence** checkbox |
| Network Admin > Settings | **Presence** checkbox, network-wide |
| WP-CLI | `wp presence recording get\|set on\|off [--network]` |

The stored options are passed as the two filters' defaults, so a filter still has the last word over whatever an administrator has chosen, and strictest-wins precedence between the site and network switches is unchanged.

`wp_presence_network_aggregation_enabled` stays code-only. It answers write concentration rather than policy, so it has no checkbox.

Notes:

- Options store `'1'` or `'0'` rather than booleans. A boolean `false` is indistinguishable from an absent option, so `update_option()` discards it as unchanged and recording stays on.
- Test cleanup moved above the `TRUNCATE` in the base test case. `TRUNCATE` commits and `autocommit` is off, so a statement after it lands in a fresh transaction and is rolled back.

Testing:

- `npm test` — 426 tests, 713 assertions, 106 skipped
- `npm run test:multisite` — 426 tests, 920 assertions, 3 expected skips
- `npm run test:scripts` — 79 passed
- `composer validate --no-check-publish --no-interaction` — passed
- `./vendor/bin/phpcs --standard=phpcs.xml.dist --report=summary` — passed
- `./vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=2G --no-progress` — passed

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes  
Tool(s): Claude Code  
Model(s): Claude Opus 5  
Used for: Assisting with the implementation, tests, and documentation. The final change and results were reviewed by me before submission.

</details>
