### PR TITLE
docs: correct overflow threshold docblock

### DIFF
--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -47,7 +47,7 @@ class WP_Presence_Widget_Whos_Online {
 	const AVATAR_STACK_MAX = 4;
 
 	/**
-	 * Returns the overflow threshold, filtered for customization.
+	 * Returns the fixed overflow threshold.
 	 *
 	 * When the number of overflow users exceeds this value, the widget
 	 * switches from an expandable list to a compact summary linking to


### PR DESCRIPTION
Correct the overflow threshold getter docblock to describe the threshold as fixed, matching the current implementation and the maintainer decision.

Fixes #437

### Testing

- `php -l includes/widgets/class-wp-presence-widget-whos-online.php`
- `php vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist includes/widgets/class-wp-presence-widget-whos-online.php`
- `git diff --check`

I used the AI tool "Codex" to understand the issue and get help with the code.