### PR TITLE
docs: document client_id prefix convention and wp_get_presence() entry shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Post types opt in via `add_post_type_support( 'post', 'presence' )`.
 
 Rooms carry no producer namespace of their own — this plugin's own writers are told apart from anyone else's entries in the same room by a `client_id` prefix instead. `user-{user_id}` (admin/online room, from `includes/heartbeat.php` and `includes/lifecycle.php`) and `editor-{user_id}` (post rooms, from `includes/heartbeat.php` and `includes/post-lock-bridge.php`) are reserved this way; a row using either belongs to this plugin and has the state shape its writer expects.
 
-Anything else sharing a room — another plugin relaying awareness from an external source, a REST client, a WP-CLI entry — must prefix its own `client_id` (e.g. `sync-{id}`) so it can't collide with those rows or be mistaken for one.
+Anything else sharing a room — another plugin relaying awareness from an external source, a REST client — must prefix its own `client_id` so it can't collide with those rows or be mistaken for one. `sync-` is already spoken for: the [sync-storage](https://github.com/WordPress/sync-storage) plugin writes Gutenberg awareness into the same post rooms under that prefix.
 
 The `editor-` prefix is load-bearing rather than cosmetic: `includes/heartbeat.php` counts the editors in a post room with `str_starts_with( $entry->client_id, 'editor-' )`, so a colliding prefix inflates that count.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Then open [localhost:8888/wp-admin/](http://localhost:8888/wp-admin/) (admin / p
 
 Post types opt in via `add_post_type_support( 'post', 'presence' )`.
 
+### Client IDs
+
+Rooms carry no producer namespace of their own — this plugin's own writers are told apart from anyone else's entries in the same room by a `client_id` prefix instead. `user-{user_id}` (admin/online room, from `includes/heartbeat.php` and `includes/lifecycle.php`) and `editor-{user_id}` (post rooms, from `includes/heartbeat.php` and `includes/post-lock-bridge.php`) are reserved this way; a row using either belongs to this plugin and has the state shape its writer expects.
+
+Anything else sharing a room — another plugin relaying awareness from an external source, a REST client, a WP-CLI entry — must prefix its own `client_id` (e.g. `sync-{id}`) so it can't collide with those rows or be mistaken for one.
+
 ## PHP API
 
 The following public functions are part of the stable public API contract. All other helper functions in `includes/functions.php` and `includes/network-functions.php` (such as `wp_get_active_rooms()`, `wp_get_presence_summary()`, etc.) are marked `@access private`, are intended for internal plugin use only, and may change or be removed without notice.
@@ -67,7 +73,15 @@ $room = wp_presence_post_room( $post );
 wp_presence_recording_enabled();
 ```
 
-Each entry object returned by `wp_get_presence()` has: `room`, `client_id`, `user_id`, `data` (array), `date_gmt`.
+Each entry object returned by `wp_get_presence()` has:
+
+| Field       | Type     | Notes                                                                                                                      |
+| ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `room`      | `string` | The room the entry belongs to.                                                                                              |
+| `client_id` | `string` | A `varchar` column — opaque, and not guaranteed numeric even when it looks like one. See [Client IDs](#client-ids).         |
+| `user_id`   | `int`    | `0` for an entry with no signed-in user.                                                                                    |
+| `data`      | `array`  | Decoded from the stored JSON; an empty array if that JSON failed to decode.                                                 |
+| `date_gmt`  | `string` | A MySQL `datetime` string in UTC (e.g. `2024-01-01 12:00:00`), not a Unix timestamp. Convert with `strtotime( $entry->date_gmt . ' UTC' )`. |
 
 ### Network
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each entry object returned by `wp_get_presence()` has:
 | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `room`      | `string` | The room the entry belongs to.                                                                                              |
 | `client_id` | `string` | A `varchar` column — opaque, and not guaranteed numeric even when it looks like one. See [Client IDs](#client-ids).         |
-| `user_id`   | `int`    | `0` for an entry with no signed-in user.                                                                                    |
+| `user_id`   | `string` | `"0"` for an entry with no signed-in user. Every column comes back as a string, so cast before a strict comparison. |
 | `data`      | `array`  | Decoded from the stored JSON; an empty array if that JSON failed to decode.                                                 |
 | `date_gmt`  | `string` | A MySQL `datetime` string in UTC (e.g. `2024-01-01 12:00:00`), not a Unix timestamp. Convert with `strtotime( $entry->date_gmt . ' UTC' )`. |
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Post types opt in via `add_post_type_support( 'post', 'presence' )`.
 
 ### Client IDs
 
-Rooms carry no producer namespace of their own — this plugin's own writers are told apart from anyone else's entries in the same room by a `client_id` prefix instead. `user-{user_id}` (admin/online room, from `includes/heartbeat.php` and `includes/lifecycle.php`) and `editor-{user_id}` (post rooms, from `includes/heartbeat.php` and `includes/post-lock-bridge.php`) are reserved this way; a row using either belongs to this plugin and has the state shape its writer expects.
+Rooms carry no producer namespace of their own — this plugin's own writers are told apart from anyone else's entries in the same room by a `client_id` prefix instead. `user-{user_id}` (admin/online room, from `includes/heartbeat.php` and `includes/lifecycle.php`), `editor-{user_id}` (post rooms, from `includes/heartbeat.php` and `includes/post-lock-bridge.php`) and `cli-{user_id}` (any room, from `includes/cli/class-wp-presence-cli-command.php`, the default when `wp presence set` is given no client ID) are reserved this way; a row using any of them belongs to this plugin and has the state shape its writer expects.
 
 Anything else sharing a room — another plugin relaying awareness from an external source, a REST client — must prefix its own `client_id` so it can't collide with those rows or be mistaken for one. `sync-` is already spoken for: the [sync-storage](https://github.com/WordPress/sync-storage) plugin writes Gutenberg awareness into the same post rooms under that prefix.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Rooms carry no producer namespace of their own — this plugin's own writers are
 
 Anything else sharing a room — another plugin relaying awareness from an external source, a REST client, a WP-CLI entry — must prefix its own `client_id` (e.g. `sync-{id}`) so it can't collide with those rows or be mistaken for one.
 
+The `editor-` prefix is load-bearing rather than cosmetic: `includes/heartbeat.php` counts the editors in a post room with `str_starts_with( $entry->client_id, 'editor-' )`, so a colliding prefix inflates that count.
+
 ## PHP API
 
 The following public functions are part of the stable public API contract. All other helper functions in `includes/functions.php` and `includes/network-functions.php` (such as `wp_get_active_rooms()`, `wp_get_presence_summary()`, etc.) are marked `@access private`, are intended for internal plugin use only, and may change or be removed without notice.


### PR DESCRIPTION
### Why

sync-storage's `Sync_Storage_Provider` has to run a translation layer before it can hand `wp_get_presence()` rows to Gutenberg as awareness: rooms carry no producer namespace, so Heartbeat's `editor-{user_id}` rows land in the same room and crash `PostEditorAwareness`; `date_gmt` is a GMT datetime string, not the Unix timestamp awareness expiry expects; and `client_id` is a `varchar`, not the int the sync server compares against. Two of these already caused real incidents (WordPress/sync-storage#88, fixed in WordPress/sync-storage#89). Nothing in this repo said any of it, so the next consumer would rediscover it the same way.

### What

- Added a "Client IDs" section under **Rooms** in `README.md`: documents `user-` (admin/online room) and `editor-` (post rooms) as reserved prefixes owned by Heartbeat, the login/logout lifecycle hooks, and the post-lock bridge. Any other writer sharing a room must prefix its own `client_id`.
- Replaced the one-line entry-shape summary under **PHP API** with a table spelling out each field's type — specifically that `date_gmt` is a MySQL UTC datetime string (convert with `strtotime( $entry->date_gmt . ' UTC' )`, not a raw cast) and `client_id` is not guaranteed numeric.

### How

Decided against giving rooms a producer namespace — that would mean reworking `wp_presence_post_room()` and every Heartbeat/lifecycle/post-lock-bridge call site for a scheme change with no consumer asking for it. Documenting `editor-`/`user-` as reserved costs nothing and matches the convention sync-storage already had to invent on its own (`CLIENT_PREFIX = 'sync-'`). Field descriptions were checked against `wp_get_presence()`'s actual query and decode logic in `includes/functions.php` and the `wp_presence` table schema, not just the issue's own summary.

### Test instructions

Documentation only — no PHP changed.

1. Open `README.md` and confirm the new "Client IDs" section renders under **Rooms**, and the entry-shape table renders under **PHP API**.
2. Click the `Client IDs` link in the table and confirm it jumps to the new section.
3. `./vendor/bin/phpcs --standard=phpcs.xml.dist` and `./vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=2G` still pass (nothing to check here, included for completeness since CI runs them unconditionally).

Fixes #417
