### PR TITLE
docs: point post-lock-bridge at the block-editor sync split 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ wp presence recording set off --network   # Multisite only
 
 ## Relationship to the block editor
 
-Real-time awareness inside the editor — cursors, selections, who's editing which block — is not this plugin's job. The block editor gets that from [`WP_Sync_Storage`](https://github.com/WordPress/sync-storage), consumed through Gutenberg's `__unstable_wp_sync_storage` ([WordPress/gutenberg#81697](https://github.com/WordPress/gutenberg/pull/81697)). Its [HTTP-polling provider](https://github.com/WordPress/sync-storage/blob/main/lib/rtc/class-sync-storage-provider.php) delegates `get_awareness_state()` and `set_awareness_state()` straight to `wp_get_presence()` and `wp_set_presence()`, while keeping CRDT document updates in its own `wp_collaboration` table.
+Real-time awareness inside the editor — cursors, selections, who's editing which block — is not this plugin's job. The block editor gets that from the [sync-storage](https://github.com/WordPress/sync-storage) plugin, registered through Gutenberg's [`__unstable_wp_sync_storage`](https://github.com/WordPress/gutenberg/pull/81697) filter as an implementation of Gutenberg's `WP_Sync_Storage` interface. Its [storage provider](https://github.com/WordPress/sync-storage/blob/main/lib/rtc/class-sync-storage-provider.php) backs `get_awareness_state()` and `set_awareness_state()` with `wp_get_presence()` and `wp_set_presence()`, while keeping CRDT document updates in its own `wp_collaboration` table.
 
 No room mapping sits between the two: sync-storage's room string (`{objectType}:{objectId}`) and this plugin's `postType/{type}:{id}` room ([`wp_presence_post_room()`](#php-api)) already agree, since `objectType` there is `postType/{type}`.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ wp presence recording set off --network   # Multisite only
 
 Real-time awareness inside the editor — cursors, selections, who's editing which block — is not this plugin's job. The block editor gets that from the [sync-storage](https://github.com/WordPress/sync-storage) plugin, registered through Gutenberg's [`__unstable_wp_sync_storage`](https://github.com/WordPress/gutenberg/pull/81697) filter as an implementation of Gutenberg's `WP_Sync_Storage` interface. Its [storage provider](https://github.com/WordPress/sync-storage/blob/main/lib/rtc/class-sync-storage-provider.php) backs `get_awareness_state()` and `set_awareness_state()` with `wp_get_presence()` and `wp_set_presence()`, while keeping CRDT document updates in its own `wp_collaboration` table.
 
-No room mapping sits between the two: sync-storage's room string (`{objectType}:{objectId}`) and this plugin's `postType/{type}:{id}` room ([`wp_presence_post_room()`](#php-api)) already agree, since `objectType` there is `postType/{type}`.
+No room mapping sits between the two: both use `postType/{type}:{id}`, the grammar Gutenberg's `WP_Sync_Config::parse_room()` defines and [`wp_presence_post_room()`](#php-api) already returns. What keeps the two sets of rows apart inside that shared room is the `client_id` prefix: sync-storage writes `sync-{id}` and reads nothing else back, leaving this plugin's `editor-{user_id}` rows untouched.
 
 That leaves the split: awareness and cursors inside the editor go through sync-storage; room membership everywhere else in wp-admin — plus the post-lock bridge below — stays this plugin's.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ wp presence recording set off
 wp presence recording set off --network   # Multisite only
 ```
 
+## Relationship to the block editor
+
+Real-time awareness inside the editor — cursors, selections, who's editing which block — is not this plugin's job. The block editor gets that from [`WP_Sync_Storage`](https://github.com/WordPress/sync-storage), consumed through Gutenberg's `__unstable_wp_sync_storage` ([WordPress/gutenberg#81697](https://github.com/WordPress/gutenberg/pull/81697)). Its [HTTP-polling provider](https://github.com/WordPress/sync-storage/blob/main/lib/rtc/class-sync-storage-provider.php) delegates `get_awareness_state()` and `set_awareness_state()` straight to `wp_get_presence()` and `wp_set_presence()`, while keeping CRDT document updates in its own `wp_collaboration` table.
+
+No room mapping sits between the two: sync-storage's room string (`{objectType}:{objectId}`) and this plugin's `postType/{type}:{id}` room ([`wp_presence_post_room()`](#php-api)) already agree, since `objectType` there is `postType/{type}`.
+
+That leaves the split: awareness and cursors inside the editor go through sync-storage; room membership everywhere else in wp-admin — plus the post-lock bridge below — stays this plugin's.
+
 ## Post-lock bridge
 
 Creates presence entries alongside `_edit_lock` postmeta when a post lock is refreshed via Heartbeat. Both systems coexist.

--- a/includes/post-lock-bridge.php
+++ b/includes/post-lock-bridge.php
@@ -4,10 +4,10 @@
  *
  * This bridge is transitional. It records the lock on the editing user's
  * presence entry alongside the existing _edit_lock postmeta so both systems
- * coexist. The intent is for the block editor (Gutenberg) to consume presence
- * data directly in the future — enabling real-time awareness (cursors,
- * selections, who's editing which block) rather than the current blunt
- * lock/takeover model.
+ * coexist. See "Relationship to the block editor" in README.md for how this
+ * relates to the block editor's own awareness data (cursors, selections,
+ * who's editing which block), which flows through WP_Sync_Storage rather
+ * than through this bridge.
  *
  * @package Presence_API
  */

--- a/includes/post-lock-bridge.php
+++ b/includes/post-lock-bridge.php
@@ -6,8 +6,8 @@
  * presence entry alongside the existing _edit_lock postmeta so both systems
  * coexist. See "Relationship to the block editor" in README.md for how this
  * relates to the block editor's own awareness data (cursors, selections,
- * who's editing which block), which flows through WP_Sync_Storage rather
- * than through this bridge.
+ * who's editing which block), which flows through the sync-storage plugin
+ * rather than through this bridge.
  *
  * @package Presence_API
  */


### PR DESCRIPTION
### Why
[#414](https://github.com/WordPress/presence-api/issues/414) flagged that `post-lock-bridge.php`'s header describes the block editor consuming presence data directly as a *future* intent. That's no longer true — it's settled now. The block editor already consumes presence through `WP_Sync_Storage` behind `__unstable_wp_sync_storage` ([WordPress/gutenberg#81697](https://github.com/WordPress/gutenberg/pull/81697)), and [WordPress/sync-storage](https://github.com/WordPress/sync-storage/blob/main/lib/rtc/class-sync-storage-provider.php) delegates `get_awareness_state()`/`set_awareness_state()` straight to `wp_get_presence()`/`wp_set_presence()`. Nothing in this repo documented that split, leaving the header as the only (and outdated) explanation a reader would find.

### What
- Added a "Relationship to the block editor" section to `README.md` explaining the split: editor awareness/cursors flow through sync-storage (CRDT content kept separately in `wp_collaboration`), while room membership across the rest of wp-admin — plus the post-lock bridge — stays this plugin's responsibility. Notes that no room-string mapping is needed since sync-storage's `{objectType}:{objectId}` and this plugin's `postType/{type}:{id}` already agree.
- Replaced the stale "intent is for the future" paragraph in `post-lock-bridge.php`'s file header with a pointer to that new README section.

### How
Doc-only change — no PHP logic, hooks, or public API touched. `wp_presence_bridge_post_lock()` behavior is unchanged.

### Test instructions
1. `git diff` confirms only `README.md` and `includes/post-lock-bridge.php` changed, both comments/docs.
2. Read through the new README section and the updated file header for accuracy against the linked sync-storage source (`class-sync-storage-provider.php`) and gutenberg#81697.
3. Run the existing test suite to confirm no regressions (should be a no-op since no code changed):
  ```
   npm install
   composer install
   composer test
  ```
4. No manual/browser testing needed since this doesn't touch runtime behavior.

**Fixes**: #414