### PR TITLE
fix: distinguish a non-aggregating network from a quiet one

### DIFF
--- a/includes/class-wp-rest-presence-network-controller.php
+++ b/includes/class-wp-rest-presence-network-controller.php
@@ -162,6 +162,9 @@ class WP_REST_Presence_Network_Controller extends WP_REST_Controller {
 		$response->header( 'X-WP-Total', $summary['total_sites_online'] );
 		$response->header( 'X-WP-TotalPages', (int) ceil( $summary['total_sites_online'] / $per_page ) );
 		$response->header( 'X-WP-Presence-Users-Online', $summary['total_users_online'] );
+		// An empty collection is two answers, and the body and status are the
+		// same for both.
+		$response->header( 'X-WP-Presence-Aggregating', $summary['aggregating'] ? '1' : '0' );
 		$response->header( 'Cache-Control', 'no-store' );
 
 		return $response;
@@ -199,6 +202,7 @@ class WP_REST_Presence_Network_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $this->prepare_item_for_response( $item, $request )->get_data() );
 
+		$response->header( 'X-WP-Presence-Aggregating', $summary['aggregating'] ? '1' : '0' );
 		$response->header( 'Cache-Control', 'no-store' );
 
 		return $response;

--- a/includes/cli/class-wp-presence-cli-command.php
+++ b/includes/cli/class-wp-presence-cli-command.php
@@ -255,6 +255,13 @@ class WP_Presence_CLI_Command extends WP_CLI_Command {
 			return;
 		}
 
+		// Reported instead of the totals, not alongside them: zero sites and
+		// zero users is the answer this network cannot give.
+		if ( ! $summary['aggregating'] ) {
+			WP_CLI::warning( __( 'Presence is not aggregated across this network, so who is online cannot be reported.', 'presence-api' ) );
+			return;
+		}
+
 		/* translators: %d: Number of sites with someone online. */
 		WP_CLI::log( sprintf( __( 'Sites online: %d', 'presence-api' ), $summary['total_sites_online'] ) );
 		/* translators: %d: Number of users online, summed per site. */

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -600,6 +600,9 @@ function wp_presence_get_network_sites_for_user( $user_id ) {
  *                                       pushed from that site's own request.
  *                                       Absent when the summary is empty. Read
  *                                       only by wp_presence_hydrate_network_snapshot().
+ *     @type bool  $aggregating         Whether the network aggregates at all.
+ *                                       False means nothing is pushing, so the
+ *                                       empty read is not a headcount.
  *     @type int   $total_sites_online
  *     @type int   $total_users_online  Summed per site, so a user online on two
  *                                       sites counts twice.
@@ -640,6 +643,9 @@ function wp_presence_get_network_snapshot( array $args = array() ) {
  *                                       descending, then by blog_id.
  *                                       user_count is the site's real total,
  *                                       which users is capped below.
+ *     @type bool  $aggregating         Whether the network aggregates at all.
+ *                                       False means nothing is pushing, so the
+ *                                       empty read is not a headcount.
  *     @type int   $total_sites_online  Network-wide, not the resolved count.
  *     @type int   $total_users_online  Network-wide, not the resolved count.
  * }
@@ -813,7 +819,8 @@ function wp_presence_filter_network_snapshot_users( array $by_site ) {
  * still a list of IDs, so a stale row is dropped before anything gets loaded.
  *
  * A network that does not aggregate reads as empty rather than as whatever its
- * rows last said, since nothing is keeping them current.
+ * rows last said, since nothing is keeping them current. That read carries
+ * aggregating => false, so callers do not report it as a quiet network.
  *
  * @access private
  * @param int $timeout TTL in seconds; rows untouched longer than this are skipped.
@@ -823,7 +830,9 @@ function wp_presence_compute_network_snapshot( $timeout ) {
 	global $wpdb;
 
 	if ( ! wp_presence_network_aggregation_enabled() || ! wp_presence_has_network_summary_table() ) {
-		return wp_presence_empty_network_summary();
+		// Only the switch means "not aggregating". A network still waiting on
+		// its table aggregates and has nothing yet.
+		return wp_presence_empty_network_summary( wp_presence_network_aggregation_enabled() );
 	}
 
 	$cutoff = gmdate( 'Y-m-d H:i:s', time() - $timeout );
@@ -908,6 +917,7 @@ function wp_presence_compute_network_snapshot( $timeout ) {
 	return array(
 		'sites'              => $by_site,
 		'schemes'            => array_intersect_key( $schemes, $by_site ),
+		'aggregating'        => true,
 		'total_sites_online' => count( $by_site ),
 		'total_users_online' => $total_users,
 	);
@@ -940,6 +950,7 @@ function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $use
 	if ( ! $by_site ) {
 		return array(
 			'sites'              => array(),
+			'aggregating'        => $snapshot['aggregating'],
 			'total_sites_online' => $snapshot['total_sites_online'],
 			'total_users_online' => $snapshot['total_users_online'],
 		);
@@ -1036,6 +1047,7 @@ function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $use
 
 	return array(
 		'sites'              => $sites,
+		'aggregating'        => $snapshot['aggregating'],
 		'total_sites_online' => $snapshot['total_sites_online'],
 		'total_users_online' => $snapshot['total_users_online'],
 	);
@@ -1045,11 +1057,14 @@ function wp_presence_hydrate_network_snapshot( array $snapshot, $max_sites, $use
  * Returns the shape wp_presence_get_network_summary() returns when nobody is online.
  *
  * @access private
+ * @param bool $aggregating Optional. Default true, a network that aggregates
+ *                          and is simply quiet.
  * @return array See wp_presence_get_network_summary().
  */
-function wp_presence_empty_network_summary() {
+function wp_presence_empty_network_summary( $aggregating = true ) {
 	return array(
 		'sites'              => array(),
+		'aggregating'        => (bool) $aggregating,
 		'total_sites_online' => 0,
 		'total_users_online' => 0,
 	);

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -45,6 +45,32 @@ function wp_presence_enqueue_network_sites_assets( $hook_suffix ) {
 }
 
 /**
+ * Warns above the Sites list when the network does not aggregate presence.
+ *
+ * The column reads the same em dash either way, so the reason is said once
+ * above the table rather than repeated down every row of it.
+ */
+function wp_presence_network_sites_aggregation_notice() {
+	$screen = get_current_screen();
+
+	if ( ! $screen || 'sites-network' !== $screen->id ) {
+		return;
+	}
+
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
+		return;
+	}
+
+	if ( wp_presence_network_aggregation_enabled() ) {
+		return;
+	}
+
+	echo '<div class="notice notice-warning"><p>';
+	echo esc_html__( 'Presence is not aggregated across this network, so the Online column has no data.', 'presence-api' );
+	echo '</p></div>';
+}
+
+/**
  * Renders the "Online" column for a single row of the Sites list table.
  *
  * Rendered once per page load, the same as every other column on this table

--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -127,6 +127,11 @@ class WP_Presence_Network_Widget_Whos_Online {
 	 * @param array $summary Return value of self::get_summary().
 	 */
 	private static function render_summary( $summary ) {
+		if ( ! $summary['aggregating'] ) {
+			echo '<p>' . esc_html__( 'Presence is not aggregated across this network, so who is online cannot be shown.', 'presence-api' ) . '</p>';
+			return;
+		}
+
 		if ( empty( $summary['sites'] ) ) {
 			echo '<p>' . esc_html__( 'No users are currently online anywhere on the network.', 'presence-api' ) . '</p>';
 			return;
@@ -195,9 +200,10 @@ class WP_Presence_Network_Widget_Whos_Online {
 			return $response;
 		}
 
-		$response['presence-network-widget']          = $summary['sites'];
-		$response['presence-network-widget-overflow'] = $overflow;
-		$response['presence-network-widget-hash']     = $hash;
+		$response['presence-network-widget']             = $summary['sites'];
+		$response['presence-network-widget-overflow']    = $overflow;
+		$response['presence-network-widget-aggregating'] = $summary['aggregating'];
+		$response['presence-network-widget-hash']        = $hash;
 
 		return $response;
 	}
@@ -214,12 +220,16 @@ class WP_Presence_Network_Widget_Whos_Online {
 	 * The read path already returns sites busiest-first and users by name, so
 	 * there is nothing left to normalize here.
 	 *
+	 * The aggregation flag is in the payload because a network that stops
+	 * aggregating sends the same empty list as a quiet one, and the widget has
+	 * to repaint to start saying so.
+	 *
 	 * @param array $summary  Return value of self::get_summary().
 	 * @param int   $overflow Sites online beyond the ones being sent.
 	 * @return string The state hash.
 	 */
 	private static function hash_summary( $summary, $overflow ) {
-		return md5( (string) wp_json_encode( array( $summary['sites'], $overflow ) ) );
+		return md5( (string) wp_json_encode( array( $summary['sites'], $overflow, $summary['aggregating'] ) ) );
 	}
 
 	/**
@@ -231,6 +241,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 		$i18n_json = wp_json_encode(
 			array(
 				'noUsersOnline' => __( 'No users are currently online anywhere on the network.', 'presence-api' ),
+				'notAggregated' => __( 'Presence is not aggregated across this network, so who is online cannot be shown.', 'presence-api' ),
 				'sitesOnline'   => __( 'Sites with online users', 'presence-api' ),
 				/* translators: %d: Number of additional sites with online users. */
 				'moreSite'      => __( '+%d more site — view all', 'presence-api' ),
@@ -294,7 +305,11 @@ class WP_Presence_Network_Widget_Whos_Online {
 
 	// Already cut to the sites and avatars this widget shows, so nothing is
 	// sliced here; overflow is a count the server sends, not what is left over.
-	function buildListHtml(sites, overflow) {
+	function buildListHtml(sites, overflow, aggregating) {
+		if (!aggregating) {
+			return '<p>' + esc(i18n.notAggregated) + '</p>';
+		}
+
 		if (!sites.length) {
 			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
 		}
@@ -342,15 +357,16 @@ class WP_Presence_Network_Widget_Whos_Online {
 
 		var sites = data['presence-network-widget'];
 		var overflow = data['presence-network-widget-overflow'] || 0;
+		var aggregating = data['presence-network-widget-aggregating'] !== false;
 
 		// Signature over what gets drawn, matching the server-side hash: a
 		// rename or a new avatar has to repaint, and the order is already the
 		// order it renders in.
-		var sig = JSON.stringify([sites, overflow]);
+		var sig = JSON.stringify([sites, overflow, aggregating]);
 
 		if (sig !== lastSignature) {
 			var focusInfo = captureFocus(container);
-			container.html(buildListHtml(sites, overflow));
+			container.html(buildListHtml(sites, overflow, aggregating));
 			restoreFocus(container, focusInfo);
 			lastSignature = sig;
 		}

--- a/presence-api.php
+++ b/presence-api.php
@@ -381,6 +381,7 @@ if ( is_multisite() ) {
 	add_filter( 'wpmu_blogs_columns', 'wp_presence_register_network_sites_column' );
 	add_action( 'manage_sites_custom_column', 'wp_presence_render_network_sites_column', 10, 2 );
 	add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_network_sites_assets' );
+	add_action( 'network_admin_notices', 'wp_presence_network_sites_aggregation_notice' );
 
 	add_filter( 'views_users-network', 'wp_presence_network_users_views' );
 	add_filter( 'users_list_table_query_args', 'wp_presence_filter_network_online_users' );

--- a/tests/stubs/wp-cli.php
+++ b/tests/stubs/wp-cli.php
@@ -41,6 +41,10 @@ namespace {
 			self::record( 'log', $message );
 		}
 
+		public static function warning( $message ) {
+			self::record( 'warning', $message );
+		}
+
 		/**
 		 * @throws WP_Presence_CLI_Halt Standing in for the process exit, when $confirm_declines is set.
 		 */

--- a/tests/test-cli-network-command.php
+++ b/tests/test-cli-network-command.php
@@ -87,6 +87,35 @@ class WP_Test_Presence_CLI_Network_Command extends WP_Presence_Network_UnitTestC
 		$this->assertSame( array(), WP_CLI::$formatted );
 	}
 
+	/**
+	 * Zero sites and zero users is the answer a network that has stopped
+	 * aggregating cannot give, so it says what it does not know instead.
+	 */
+	public function test_a_network_that_does_not_aggregate_says_so_instead_of_reporting_zero() {
+		$this->set_network_summary_row( $this->create_blog(), array( self::$editor_id ) );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$this->command->network( array(), array() );
+
+		$this->assertSame( array(), WP_CLI::messages( 'log' ) );
+		$this->assertStringContainsString( 'not aggregated across this network', WP_CLI::messages( 'warning' )[0] );
+	}
+
+	/**
+	 * A script reading the JSON gets the flag rather than the warning, which
+	 * only ever reaches STDERR.
+	 */
+	public function test_json_carries_the_aggregation_state() {
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$this->command->network( array(), array( 'format' => 'json' ) );
+
+		$this->assertFalse( json_decode( WP_CLI::messages( 'log' )[0], true )['aggregating'] );
+	}
+
 	public function test_json_emits_the_whole_summary() {
 		$blog_id = $this->create_blog();
 

--- a/tests/test-network-presence.php
+++ b/tests/test-network-presence.php
@@ -302,9 +302,66 @@ class WP_Test_Network_Presence extends WP_Presence_Network_UnitTestCase {
 		add_filter( 'wp_is_large_network', '__return_true' );
 		wp_presence_flush_network_summary_cache();
 
-		$this->assertSame( wp_presence_empty_network_summary(), wp_presence_get_network_summary() );
+		$this->assertSame( wp_presence_empty_network_summary( false ), wp_presence_get_network_summary() );
 		$this->assertSame( array(), wp_presence_get_network_online_user_ids() );
 		$this->assertSame( array(), wp_presence_get_network_sites_for_user( self::$editor_id ) );
+	}
+
+	/**
+	 * A network crosses wp_is_large_network() on its own, so unless the read
+	 * itself tells the two apart, the screens go quietly from correct to wrong.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_empty_network_summary
+	 */
+	public function test_summary_reports_that_a_gated_network_does_not_aggregate() {
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$this->assertFalse( wp_presence_get_network_summary()['aggregating'] );
+		$this->assertFalse( wp_presence_get_network_snapshot()['aggregating'] );
+	}
+
+	/**
+	 * The quiet network the gated one has to be told apart from.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_empty_network_summary
+	 */
+	public function test_summary_reports_an_aggregating_network_with_nobody_online() {
+		$this->assertSame( array(), wp_presence_get_network_summary()['sites'] );
+		$this->assertTrue( wp_presence_get_network_summary()['aggregating'] );
+	}
+
+	/**
+	 * Only one half of the gate is a policy: a network activated one request
+	 * before its table exists aggregates, and answers quiet rather than gated.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 * @covers ::wp_presence_empty_network_summary
+	 */
+	public function test_summary_still_reports_aggregating_before_the_table_is_provisioned() {
+		$version = get_site_option( 'wp_presence_network_summary_db_version' );
+		delete_site_option( 'wp_presence_network_summary_db_version' );
+
+		$aggregating = wp_presence_get_network_summary()['aggregating'];
+
+		update_site_option( 'wp_presence_network_summary_db_version', $version );
+
+		$this->assertTrue( $aggregating );
+	}
+
+	/**
+	 * The flag tracks the feed, not whether the read came back empty.
+	 *
+	 * @covers ::wp_presence_compute_network_snapshot
+	 */
+	public function test_summary_reports_aggregating_on_a_populated_network() {
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+		wp_presence_flush_network_summary_cache();
+
+		$this->assertTrue( wp_presence_get_network_summary()['aggregating'] );
 	}
 
 	/**

--- a/tests/test-network-rest-controller.php
+++ b/tests/test-network-rest-controller.php
@@ -47,7 +47,46 @@ class WP_Test_Network_Presence_REST_Controller extends WP_Presence_Network_UnitT
 		$this->assertArrayHasKey( 'avatar_url', $data[0]['users'][0] );
 		$this->assertSame( 2, $headers['X-WP-Total'] );
 		$this->assertSame( 3, $headers['X-WP-Presence-Users-Online'] );
+		$this->assertSame( '1', $headers['X-WP-Presence-Aggregating'] );
 		$this->assertSame( 'no-store', $headers['Cache-Control'] );
+	}
+
+	/**
+	 * An empty collection is two answers with the same body and the same 200,
+	 * so a client polling this route has only the header to tell them apart.
+	 */
+	public function test_the_collection_reports_that_the_network_does_not_aggregate() {
+		$this->become_network_admin();
+
+		$this->set_network_summary_row( $this->create_blog(), array( self::$editor_id ) );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$response = $this->get( '/wp-presence/v1/presence/network' );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data() );
+		$this->assertSame( '0', $response->get_headers()['X-WP-Presence-Aggregating'] );
+	}
+
+	/**
+	 * The single-site route answers with an empty user list either way, so it
+	 * needs the same header as the collection.
+	 */
+	public function test_a_single_site_reports_that_the_network_does_not_aggregate() {
+		$this->become_network_admin();
+
+		$blog_id = $this->create_blog();
+		$this->set_network_summary_row( $blog_id, array( self::$editor_id ) );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$response = $this->get( '/wp-presence/v1/presence/network/' . $blog_id );
+
+		$this->assertSame( array(), $response->get_data()['users'] );
+		$this->assertSame( '0', $response->get_headers()['X-WP-Presence-Aggregating'] );
 	}
 
 	public function test_the_collection_paginates_over_sites() {

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -118,4 +118,71 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 
 		$this->assertSame( '&#8212;', $output, 'An archived site must show a dash in the Online column.' );
 	}
+
+	/**
+	 * The column reads the same em dash either way, so the screen has to say
+	 * which it is.
+	 *
+	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 */
+	public function test_sites_list_warns_when_the_network_does_not_aggregate() {
+		$this->become_network_admin();
+		set_current_screen( 'sites-network' );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+
+		ob_start();
+		wp_presence_network_sites_aggregation_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'not aggregated across this network', $output );
+	}
+
+	/**
+	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 */
+	public function test_sites_list_is_silent_while_the_network_aggregates() {
+		$this->become_network_admin();
+		set_current_screen( 'sites-network' );
+
+		ob_start();
+		wp_presence_network_sites_aggregation_notice();
+
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * network_admin_notices fires on every Network Admin screen, so the notice
+	 * has to place itself.
+	 *
+	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 */
+	public function test_the_notice_stays_on_the_sites_list() {
+		$this->become_network_admin();
+		set_current_screen( 'dashboard-network' );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+
+		ob_start();
+		wp_presence_network_sites_aggregation_notice();
+
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * The notice names a column only a network administrator is shown.
+	 *
+	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 */
+	public function test_the_notice_requires_capability() {
+		wp_set_current_user( self::$editor_id );
+		set_current_screen( 'sites-network' );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+
+		ob_start();
+		wp_presence_network_sites_aggregation_notice();
+
+		$this->assertSame( '', ob_get_clean() );
+	}
 }

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -241,4 +241,56 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 
 		$this->assertStringContainsString( 'No users are currently online', $output );
 	}
+
+	/**
+	 * A network that has stopped aggregating knows nothing about who is online,
+	 * so reporting that nobody is would be an answer it cannot give.
+	 */
+	public function test_render_reports_that_the_network_does_not_aggregate() {
+		$this->set_presence_on_site( $this->create_blog(), self::$editor_id );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		ob_start();
+		WP_Presence_Network_Widget_Whos_Online::render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'not aggregated across this network', $output );
+		$this->assertStringNotContainsString( 'No users are currently online', $output );
+	}
+
+	/**
+	 * Both states send an empty site list and no overflow, so on a quiet network
+	 * the flag is the only thing the hash has to go on: without it the switch
+	 * going off reports unchanged and the widget never starts saying so.
+	 */
+	public function test_heartbeat_repaints_when_a_quiet_network_stops_aggregating() {
+		$this->become_network_admin();
+
+		$first = $this->tick();
+
+		$this->assertTrue( $first['presence-network-widget-aggregating'] );
+		$this->assertSame( array(), $first['presence-network-widget'] );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$second = $this->tick( array( 'presence-network-widget-hash' => $first['presence-network-widget-hash'] ) );
+
+		$this->assertArrayHasKey( 'presence-network-widget', $second, 'The switch going off reported unchanged.' );
+		$this->assertFalse( $second['presence-network-widget-aggregating'] );
+	}
+
+	/**
+	 * The tick replaces the whole list, so a network that stops aggregating
+	 * mid-session has to be told about by the script too, not just the render.
+	 */
+	public function test_inline_script_carries_the_not_aggregated_message() {
+		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'index.php' );
+
+		$script = implode( '', (array) wp_scripts()->get_data( 'presence-network-widget', 'after' ) );
+
+		$this->assertStringContainsString( 'not aggregated across this network', $script );
+	}
 }


### PR DESCRIPTION
Fixes #411

The network read now returns an `aggregating` flag, so an empty result can say which kind of empty it is. Only the switch sets it false - a network still waiting on its summary table aggregates and has nothing yet.

- **Dashboard widget** - says so instead of "No users are currently online anywhere on the network." The flag is in the Heartbeat hash, or a quiet network and a gated one send an identical payload and the tick reports `unchanged` forever.
- **Sites list** - one `notice-warning` above the table rather than a sentence down every row; cells keep their em dash.
- **REST** - `X-WP-Presence-Aggregating` on both routes.
- **WP-CLI** - `wp presence network` warns instead of printing `Sites online: 0`. `--format=json` already carries the flag.

### Screenshots

| Aggregating | Not aggregating |
| --- | --- |
| <img width="526" height="148" alt="widget-aggregating" src="https://github.com/user-attachments/assets/85112335-6283-438d-a930-386293bfc9ef" /> | <img width="526" height="122" alt="widget-not-aggregating" src="https://github.com/user-attachments/assets/5d9489dd-a4b7-4ec3-b0f6-d3f3496f7d4e" /> |

<img width="1280" height="720" alt="sites-list-not-aggregating" src="https://github.com/user-attachments/assets/9feb201a-8d8e-4aab-a17d-ad23509665e6" />

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Auditing the network read path, then implementing the change and its tests.

</details>