### PR TITLE
feat: add policy content, exporter and eraser for presence data

### DIFF
--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Privacy: suggested privacy policy content for presence data.
+ *
+ * @package Presence_API
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds the suggested privacy policy text for presence data.
+ *
+ * The retention window is read through wp_presence_get_timeout() rather than
+ * printed from the constant, so a site filtering wp_presence_default_ttl gets
+ * a suggestion that matches what it actually stores.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ *
+ * @return string Policy content, ready for wp_add_privacy_policy_content().
+ */
+function wp_presence_get_privacy_policy_content() {
+	$timeout = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
+
+	$content =
+		'<p class="privacy-policy-tutorial">' .
+		__( 'This site records which signed-in users are currently active, so that people working on the same content can see each other. Rows expire on their own and a scheduled task deletes them, so there is no archive to disclose.', 'presence-api' ) .
+		'</p>' .
+		'<strong class="privacy-policy-tutorial">' .
+		__( 'Suggested text:', 'presence-api' ) .
+		'</strong> ' .
+		sprintf(
+			/* translators: %s: Number of seconds presence data is retained. */
+			__( 'While you are signed in, this site records that you are active, which screen you are viewing, and which post you are editing. Other signed-in users who can edit content are able to see this. It is kept for at most %s seconds after your last activity and is then deleted automatically. Nothing is retained beyond that.', 'presence-api' ),
+			number_format_i18n( $timeout )
+		) .
+		'<p class="privacy-policy-tutorial">' .
+		__( 'Recording can be switched off for the whole site under Settings &gt; General, or in code with the wp_presence_recording_enabled filter. Remove the paragraph above if you switch it off.', 'presence-api' ) .
+		'</p>';
+
+	return wp_kses_post( wpautop( $content, false ) );
+}
+
+/**
+ * Adds presence to the Privacy Policy Guide.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ */
+function wp_presence_add_privacy_policy_content() {
+	wp_add_privacy_policy_content(
+		__( 'Presence API', 'presence-api' ),
+		wp_presence_get_privacy_policy_content()
+	);
+}

--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Privacy: suggested privacy policy content for presence data.
+ * Privacy: policy content, personal data exporter and eraser for presence data.
  *
  * @package Presence_API
  */
@@ -56,4 +56,192 @@ function wp_presence_add_privacy_policy_content() {
 		__( 'Presence API', 'presence-api' ),
 		wp_presence_get_privacy_policy_content()
 	);
+}
+
+/**
+ * Reads every stored presence row for one user on the current site.
+ *
+ * Unfiltered by TTL, so the export reports exactly what the eraser would
+ * delete. A row past the timeout is no longer presence, but it is still held
+ * until the next cleanup run.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param int $user_id The user whose rows to read.
+ * @return object[] Rows with room, data and date_gmt.
+ */
+function wp_presence_get_rows_for_user( $user_id ) {
+	global $wpdb;
+
+	if ( ! wp_presence_has_table() ) {
+		return array();
+	}
+
+	// Presence changes on every heartbeat, so a cached read would be stale.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	return $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT room, data, date_gmt FROM {$wpdb->presence} WHERE user_id = %d ORDER BY date_gmt DESC",
+			$user_id
+		)
+	);
+}
+
+/**
+ * Registers presence with Tools > Export Personal Data.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ *
+ * @param array $exporters Registered exporters, keyed by slug.
+ * @return array Exporters with presence added.
+ */
+function wp_presence_register_personal_data_exporter( $exporters ) {
+	$exporters['presence-api'] = array(
+		'exporter_friendly_name' => __( 'Presence API', 'presence-api' ),
+		'callback'               => 'wp_presence_personal_data_exporter',
+	);
+
+	return $exporters;
+}
+
+/**
+ * Exports the presence held for one user.
+ *
+ * Always returns an item, even with nothing stored. An exporter returning an
+ * empty data array renders as nothing at all, which reads the same as never
+ * having registered, and the statement that nothing is kept is the point.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ *
+ * @param string $email_address Email address of the user being exported.
+ * @return array Export response.
+ */
+function wp_presence_personal_data_exporter( $email_address ) {
+	$user = get_user_by( 'email', $email_address );
+
+	// Presence is only recorded for signed-in users, so an address with no
+	// account has none by definition.
+	if ( ! $user ) {
+		return array(
+			'data' => array(),
+			'done' => true,
+		);
+	}
+
+	$data = array();
+
+	foreach ( wp_presence_get_rows_for_user( $user->ID ) as $row ) {
+		$state  = json_decode( $row->data, true );
+		$state  = is_array( $state ) ? $state : array();
+		$parsed = wp_presence_parse_room( $row->room );
+
+		$data[] = array(
+			'name'  => __( 'Screen', 'presence-api' ),
+			'value' => isset( $state['screen'] ) ? $state['screen'] : $row->room,
+		);
+
+		if ( $parsed ) {
+			$data[] = array(
+				'name'  => __( 'Post being edited', 'presence-api' ),
+				'value' => get_the_title( $parsed['post_id'] ),
+			);
+		}
+
+		$data[] = array(
+			'name'  => __( 'Last active', 'presence-api' ),
+			'value' => $row->date_gmt . ' GMT',
+		);
+	}
+
+	if ( ! $data ) {
+		$data[] = array(
+			'name'  => __( 'Presence', 'presence-api' ),
+			'value' => __( 'No presence is recorded for this account.', 'presence-api' ),
+		);
+	}
+
+	$data[] = array(
+		'name'  => __( 'Retention', 'presence-api' ),
+		'value' => sprintf(
+			/* translators: %s: Number of seconds presence data is retained. */
+			__( 'Presence is deleted at most %s seconds after the last activity. Nothing is kept beyond that, so there is no history to export.', 'presence-api' ),
+			number_format_i18n( wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL ) )
+		),
+	);
+
+	return array(
+		'data' => array(
+			array(
+				'group_id'          => 'presence',
+				'group_label'       => __( 'Presence', 'presence-api' ),
+				'group_description' => __( 'Which screen you are viewing and which post you are editing, while you are signed in.', 'presence-api' ),
+				'item_id'           => 'presence-' . $user->ID,
+				'data'              => $data,
+			),
+		),
+		'done' => true,
+	);
+}
+
+/**
+ * Registers presence with Tools > Erase Personal Data.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ *
+ * @param array $erasers Registered erasers, keyed by slug.
+ * @return array Erasers with presence added.
+ */
+function wp_presence_register_personal_data_eraser( $erasers ) {
+	$erasers['presence-api'] = array(
+		'eraser_friendly_name' => __( 'Presence API', 'presence-api' ),
+		'callback'             => 'wp_presence_personal_data_eraser',
+	);
+
+	return $erasers;
+}
+
+/**
+ * Erases the presence held for one user on the current site.
+ *
+ * @since 0.3.0
+ *
+ * @access private
+ *
+ * @param string $email_address Email address of the user being erased.
+ * @return array Erasure response.
+ */
+function wp_presence_personal_data_eraser( $email_address ) {
+	$response = array(
+		'items_removed'  => false,
+		'items_retained' => false,
+		'messages'       => array(),
+		'done'           => true,
+	);
+
+	$user = get_user_by( 'email', $email_address );
+
+	// Reported as removed only when there was something to remove, so a request
+	// against an account with nothing stored does not claim otherwise.
+	if ( ! $user || ! wp_presence_get_rows_for_user( $user->ID ) ) {
+		return $response;
+	}
+
+	if ( wp_remove_user_presence( $user->ID ) ) {
+		$response['items_removed'] = true;
+	} else {
+		$response['items_retained'] = true;
+		$response['messages'][]     = __( 'Presence could not be deleted.', 'presence-api' );
+	}
+
+	return $response;
 }

--- a/presence-api.php
+++ b/presence-api.php
@@ -341,6 +341,8 @@ add_action( 'rest_api_init', 'wp_presence_register_rest_routes' );
 add_action( 'wp_delete_expired_presence_data', 'wp_delete_expired_presence_data' );
 add_action( 'admin_init', 'wp_presence_schedule_cleanup' );
 add_action( 'admin_init', 'wp_presence_add_privacy_policy_content' );
+add_filter( 'wp_privacy_personal_data_exporters', 'wp_presence_register_personal_data_exporter' );
+add_filter( 'wp_privacy_personal_data_erasers', 'wp_presence_register_personal_data_eraser' );
 // phpcs:ignore WordPress.WP.CronInterval -- 60-second interval is intentional for presence cleanup.
 add_filter( 'cron_schedules', 'wp_presence_cron_schedules' );
 

--- a/presence-api.php
+++ b/presence-api.php
@@ -104,6 +104,7 @@ require_once WP_PRESENCE_PLUGIN_DIR . 'includes/cron.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/post-lock-bridge.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/screen-revisions.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/lifecycle.php';
+require_once WP_PRESENCE_PLUGIN_DIR . 'includes/privacy.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/settings.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/admin-bar.php';
 require_once WP_PRESENCE_PLUGIN_DIR . 'includes/user-list.php';
@@ -339,6 +340,7 @@ add_action( 'rest_api_init', 'wp_presence_register_rest_routes' );
 
 add_action( 'wp_delete_expired_presence_data', 'wp_delete_expired_presence_data' );
 add_action( 'admin_init', 'wp_presence_schedule_cleanup' );
+add_action( 'admin_init', 'wp_presence_add_privacy_policy_content' );
 // phpcs:ignore WordPress.WP.CronInterval -- 60-second interval is intentional for presence cleanup.
 add_filter( 'cron_schedules', 'wp_presence_cron_schedules' );
 

--- a/tests/class-wp-presence-unittestcase.php
+++ b/tests/class-wp-presence-unittestcase.php
@@ -33,9 +33,9 @@ abstract class WP_Presence_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * Returns every live presence entry for one user, across all rooms.
 	 *
-	 * Reads the table directly. Nothing in the plugin needs a per-user view, so
-	 * this stays a test affordance rather than an API function kept alive only
-	 * by the assertions below it.
+	 * Reads the table directly. The privacy exporter reads every stored row,
+	 * expired ones included, so nothing in the plugin needs this TTL-filtered
+	 * view and it stays a test affordance rather than an API function.
 	 *
 	 * @param int $user_id The user whose entries to read.
 	 * @param int $timeout Optional. TTL in seconds. Default WP_PRESENCE_DEFAULT_TTL.

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the suggested privacy policy content.
+ * Tests for the privacy policy content, exporter and eraser.
  *
  * @package Presence_API
  *
@@ -8,6 +8,22 @@
  */
 
 class WP_Test_Presence_Privacy extends WP_Presence_UnitTestCase {
+
+	/**
+	 * Editor whose presence is exported and erased.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$editor_id = $factory->user->create(
+			array(
+				'role'       => 'editor',
+				'user_email' => 'editor@presence.test',
+			)
+		);
+	}
 
 	/**
 	 * A site that widens the TTL keeps presence longer than the constant says,
@@ -49,5 +65,89 @@ class WP_Test_Presence_Privacy extends WP_Presence_UnitTestCase {
 		$this->assertNotFalse(
 			has_action( 'admin_init', 'wp_presence_add_privacy_policy_content' )
 		);
+	}
+
+	/**
+	 * Without a registration on both filters, neither tool knows presence
+	 * exists and the Tools screens are silent about it.
+	 *
+	 * @covers ::wp_presence_register_personal_data_exporter
+	 * @covers ::wp_presence_register_personal_data_eraser
+	 */
+	public function test_presence_appears_on_both_tools_screens() {
+		$exporters = apply_filters( 'wp_privacy_personal_data_exporters', array() );
+		$erasers   = apply_filters( 'wp_privacy_personal_data_erasers', array() );
+
+		$this->assertArrayHasKey( 'presence-api', $exporters );
+		$this->assertArrayHasKey( 'presence-api', $erasers );
+	}
+
+	/**
+	 * An exporter returning no items renders as nothing at all, which reads the
+	 * same as never registering. The statement that nothing is kept is the
+	 * useful output, so it has to survive an account with no rows.
+	 *
+	 * @covers ::wp_presence_personal_data_exporter
+	 */
+	public function test_the_export_states_that_nothing_is_kept_when_no_presence_is_stored() {
+		$export = wp_presence_personal_data_exporter( 'editor@presence.test' );
+
+		$this->assertCount( 1, $export['data'] );
+		$this->assertStringContainsString(
+			'no history to export',
+			implode( ' ', wp_list_pluck( $export['data'][0]['data'], 'value' ) )
+		);
+	}
+
+	/**
+	 * The export has to match what the eraser would delete, and the eraser
+	 * takes every row. A TTL filter here would hide rows the site still holds.
+	 *
+	 * @covers ::wp_presence_personal_data_exporter
+	 */
+	public function test_the_export_reports_every_stored_row_including_expired_ones() {
+		global $wpdb;
+
+		wp_set_presence( 'admin', 'client-1', array( 'screen' => 'dashboard' ), self::$editor_id );
+		wp_set_presence( 'admin', 'client-2', array( 'screen' => 'edit-post' ), self::$editor_id );
+
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - ( WP_PRESENCE_DEFAULT_TTL * 2 ) ) ),
+			array( 'client_id' => 'client-1' ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$export = wp_presence_personal_data_exporter( 'editor@presence.test' );
+		$values = wp_list_pluck( $export['data'][0]['data'], 'value' );
+
+		$this->assertContains( 'dashboard', $values, 'The expired row is still stored, so it is still exported.' );
+		$this->assertContains( 'edit-post', $values );
+	}
+
+	/**
+	 * @covers ::wp_presence_personal_data_eraser
+	 */
+	public function test_the_eraser_clears_the_users_rows() {
+		wp_set_presence( 'admin', 'client-1', array( 'screen' => 'dashboard' ), self::$editor_id );
+
+		$response = wp_presence_personal_data_eraser( 'editor@presence.test' );
+
+		$this->assertTrue( $response['items_removed'] );
+		$this->assertEmpty( $this->presence_for_user( self::$editor_id ) );
+	}
+
+	/**
+	 * Reporting a removal that never happened tells a data subject their data
+	 * was deleted on a site that never held any.
+	 *
+	 * @covers ::wp_presence_personal_data_eraser
+	 */
+	public function test_the_eraser_reports_no_removal_when_nothing_is_stored() {
+		$response = wp_presence_personal_data_eraser( 'editor@presence.test' );
+
+		$this->assertFalse( $response['items_removed'] );
+		$this->assertFalse( $response['items_retained'] );
 	}
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for the suggested privacy policy content.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ */
+
+class WP_Test_Presence_Privacy extends WP_Presence_UnitTestCase {
+
+	/**
+	 * A site that widens the TTL keeps presence longer than the constant says,
+	 * so a hard-coded number would understate its own retention.
+	 *
+	 * @covers ::wp_presence_get_privacy_policy_content
+	 */
+	public function test_the_retention_window_follows_the_ttl_filter() {
+		add_filter(
+			'wp_presence_default_ttl',
+			static function () {
+				return 900;
+			}
+		);
+
+		$this->assertStringContainsString( '900 seconds', wp_presence_get_privacy_policy_content() );
+	}
+
+	/**
+	 * Naming the switch is the acceptance criterion #400 waits on, so the
+	 * mention is the deliverable rather than incidental wording.
+	 *
+	 * @covers ::wp_presence_get_privacy_policy_content
+	 */
+	public function test_the_content_names_the_recording_switch() {
+		$this->assertStringContainsString(
+			'wp_presence_recording_enabled',
+			wp_presence_get_privacy_policy_content()
+		);
+	}
+
+	/**
+	 * Core only collects suggestions during admin_init. Unhooked, the guide
+	 * stays empty and nothing else in the plugin would notice.
+	 *
+	 * @covers ::wp_presence_add_privacy_policy_content
+	 */
+	public function test_the_content_is_registered_on_admin_init() {
+		$this->assertNotFalse(
+			has_action( 'admin_init', 'wp_presence_add_privacy_policy_content' )
+		);
+	}
+}


### PR DESCRIPTION
Presence is personal data, and core's privacy tools were wired to none of it.

Fixes #393
Related: #400

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the implementation and tests

</details>
