### PR TITLE
perf: skip presence writes that would only move the timestamp

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -187,7 +187,7 @@ function wp_presence_recording_enabled() {
  *
  * @access private
  *
- * @since 0.3.0
+ * @since 0.4.0
  *
  * @return int Seconds.
  */
@@ -221,7 +221,7 @@ function wp_presence_next_tick_gap() {
  *
  * @access private
  *
- * @since 0.3.0
+ * @since 0.4.0
  *
  * @return int Age in seconds. 0 means never skip.
  */
@@ -240,7 +240,7 @@ function wp_presence_refresh_threshold() {
  *
  * @access private
  *
- * @since 0.3.0
+ * @since 0.4.0
  *
  * @param string $room      The room identifier.
  * @param string $client_id The client identifier.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -183,6 +183,106 @@ function wp_presence_recording_enabled() {
 }
 
 /**
+ * Returns how long until the client is expected to send its next Heartbeat.
+ *
+ * @access private
+ *
+ * @since 0.3.0
+ *
+ * @return int Seconds.
+ */
+function wp_presence_next_tick_gap() {
+	// Core's scheduleNextTick() overrides the interval to 120s whenever the
+	// window is blurred, and never reflects that back into the interval it
+	// reports in the same request, so the reported value understates the real
+	// gap on an unfocused tab. That is the worst case, and the assumption to
+	// make whenever the request does not say otherwise.
+	$blurred = 120;
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled by WordPress in wp_ajax_heartbeat() before any of this runs.
+	if ( ! isset( $_POST['interval'], $_POST['has_focus'] ) || 'true' !== $_POST['has_focus'] ) {
+		return $blurred;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- As above.
+	$interval = absint( $_POST['interval'] );
+
+	return $interval > 0 ? $interval : $blurred;
+}
+
+/**
+ * Returns the age at which an unchanged presence row still has to be rewritten.
+ *
+ * Skipping a write leaves the row's existing date_gmt in place, so it is only
+ * safe while the row will still be inside wp_get_presence()'s cutoff when the
+ * next tick arrives. Deriving this from wp_presence_get_timeout() rather than
+ * WP_PRESENCE_DEFAULT_TTL matters: a site filtering the TTL below the tick
+ * interval would otherwise make its users blink offline.
+ *
+ * @access private
+ *
+ * @since 0.3.0
+ *
+ * @return int Age in seconds. 0 means never skip.
+ */
+function wp_presence_refresh_threshold() {
+	// Mirrors TTL_SAFETY_MARGIN in assets/js/presence-ping.js, which caps the
+	// client's own idle backoff against the same TTL. The two have to agree.
+	$margin = 15;
+
+	$timeout = wp_presence_get_timeout( WP_PRESENCE_DEFAULT_TTL );
+
+	return max( 0, $timeout - $margin - wp_presence_next_tick_gap() );
+}
+
+/**
+ * Reports whether a write would leave the stored row exactly as it already is.
+ *
+ * @access private
+ *
+ * @since 0.3.0
+ *
+ * @param string $room      The room identifier.
+ * @param string $client_id The client identifier.
+ * @param string $data_json The encoded state about to be written.
+ * @return bool True when the row can be left alone.
+ */
+function wp_presence_write_is_redundant( $room, $client_id, $data_json ) {
+	global $wpdb;
+
+	$threshold = wp_presence_refresh_threshold();
+
+	if ( $threshold <= 0 ) {
+		return false;
+	}
+
+	// The network summary push hangs off wp_presence_admin_room_changed, so an
+	// admin-room write that is skipped also skips the push. Loaded on multisite
+	// only, hence the guard.
+	if ( wp_presence_admin_room() === $room
+		&& function_exists( 'wp_presence_network_summary_push_is_due' )
+		&& wp_presence_network_summary_push_is_due()
+	) {
+		return false;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$current = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT data, date_gmt FROM {$wpdb->presence} WHERE room = %s AND client_id = %s",
+			$room,
+			$client_id
+		)
+	);
+
+	if ( ! $current || $current->data !== $data_json ) {
+		return false;
+	}
+
+	return ( time() - (int) strtotime( $current->date_gmt . ' UTC' ) ) <= $threshold;
+}
+
+/**
  * Upserts a client's presence state in a room.
  *
  * Uses INSERT ... ON DUPLICATE KEY UPDATE for atomic upserts
@@ -207,6 +307,10 @@ function wp_set_presence( $room, $client_id, $state, $user_id = 0 ) {
 
 	$data_json = wp_json_encode( $state );
 	$now       = gmdate( 'Y-m-d H:i:s' );
+
+	if ( wp_presence_write_is_redundant( $room, $client_id, $data_json ) ) {
+		return true;
+	}
 
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$result = $wpdb->query(

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -274,7 +274,7 @@ function wp_presence_push_network_summary() {
  *
  * @access private
  *
- * @since 0.3.0
+ * @since 0.4.0
  *
  * @return bool True when a push is owed.
  */

--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -261,6 +261,38 @@ function wp_presence_push_network_summary() {
 }
 
 /**
+ * Reports whether this site's network summary row is due to be rewritten.
+ *
+ * The push runs off wp_presence_admin_room_changed, which only fires on a real
+ * write. A presence write skipped as redundant therefore has to keep firing the
+ * push on schedule, or the summary row decays past the read cutoff and every
+ * network surface reports nobody online.
+ *
+ * Only the staleness half of wp_presence_network_summary_needs_push() applies
+ * here: a membership change is somebody else's state changing, and their own
+ * write announces it.
+ *
+ * @access private
+ *
+ * @since 0.3.0
+ *
+ * @return bool True when a push is owed.
+ */
+function wp_presence_network_summary_push_is_due() {
+	if ( ! wp_presence_network_aggregation_enabled() || ! wp_presence_has_network_summary_table() ) {
+		return false;
+	}
+
+	$last = get_option( 'wp_presence_network_pushed' );
+
+	if ( ! is_array( $last ) || ! isset( $last['time'] ) ) {
+		return true;
+	}
+
+	return (int) $last['time'] <= time() - wp_presence_network_summary_refresh_interval();
+}
+
+/**
  * Decides whether this site has anything to write into the summary table.
  *
  * True when the online set differs from the one this site last pushed, or when

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -917,4 +917,114 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 		$this->assertFalse( wp_presence_recording_enabled() );
 	}
+
+	/**
+	 * Reads the stored timestamp for a row, as the raw string the column holds.
+	 */
+	private function stored_date_gmt( $room, $client_id ) {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT date_gmt FROM {$wpdb->presence} WHERE room = %s AND client_id = %s",
+				$room,
+				$client_id
+			)
+		);
+	}
+
+	/**
+	 * Backdates a row so the refresh window can be crossed without waiting.
+	 */
+	private function backdate( $room, $client_id, $seconds ) {
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - $seconds ) ),
+			array(
+				'room'      => $room,
+				'client_id' => $client_id,
+			),
+			array( '%s' ),
+			array( '%s', '%s' )
+		);
+	}
+
+	/**
+	 * @covers ::wp_set_presence
+	 */
+	public function test_unchanged_state_within_the_refresh_window_skips_the_write() {
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+		$this->backdate( 'test/room', 'client-1', 5 );
+
+		$before = $this->stored_date_gmt( 'test/room', 'client-1' );
+		$result = wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+
+		$this->assertTrue( $result, 'Presence is still recorded, so a skipped write reports success.' );
+		$this->assertSame(
+			$before,
+			$this->stored_date_gmt( 'test/room', 'client-1' ),
+			'An unchanged state inside the refresh window must not touch the row.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_set_presence
+	 */
+	public function test_unchanged_state_past_the_refresh_window_writes() {
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+		$this->backdate( 'test/room', 'client-1', WP_PRESENCE_DEFAULT_TTL - 5 );
+
+		$before = $this->stored_date_gmt( 'test/room', 'client-1' );
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+
+		$this->assertNotSame(
+			$before,
+			$this->stored_date_gmt( 'test/room', 'client-1' ),
+			'A row close to the cutoff must be refreshed even when the state is identical.'
+		);
+	}
+
+	/**
+	 * @covers ::wp_set_presence
+	 */
+	public function test_changed_state_writes_inside_the_refresh_window() {
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+		$this->backdate( 'test/room', 'client-1', 5 );
+
+		$before = $this->stored_date_gmt( 'test/room', 'client-1' );
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'idle' ), self::$editor_id );
+
+		$this->assertNotSame(
+			$before,
+			$this->stored_date_gmt( 'test/room', 'client-1' ),
+			'A state change is the thing the guard must never swallow.'
+		);
+
+		$entries = wp_get_presence( 'test/room' );
+		$this->assertSame( 'idle', $entries[0]->data['action'] );
+	}
+
+	/**
+	 * @covers ::wp_set_presence
+	 */
+	public function test_skipped_write_does_not_announce_an_admin_room_change() {
+		$room = wp_presence_admin_room();
+
+		wp_set_presence( $room, 'user-' . self::$editor_id, array( 'screen' => 'dashboard' ), self::$editor_id );
+		$this->backdate( $room, 'user-' . self::$editor_id, 5 );
+
+		$fired = 0;
+		add_action(
+			'wp_presence_admin_room_changed',
+			static function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		wp_set_presence( $room, 'user-' . self::$editor_id, array( 'screen' => 'dashboard' ), self::$editor_id );
+
+		$this->assertSame( 0, $fired, 'Nobody arrived or left, so no surface needs to re-render.' );
+	}
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -1015,6 +1015,13 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 		wp_set_presence( $room, 'user-' . self::$editor_id, array( 'screen' => 'dashboard' ), self::$editor_id );
 		$this->backdate( $room, 'user-' . self::$editor_id, 5 );
 
+		// Under WP_MULTISITE=1 this class does not provision the summary table, so
+		// wp_presence_network_summary_push_is_due() is false and the guard is free
+		// to skip. The network suite covers the case where a push is owed.
+		if ( function_exists( 'wp_presence_network_summary_push_is_due' ) ) {
+			$this->assertFalse( wp_presence_network_summary_push_is_due(), 'Precondition: no push is owed here.' );
+		}
+
 		$fired = 0;
 		add_action(
 			'wp_presence_admin_room_changed',

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -953,6 +953,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 	/**
 	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_unchanged_state_within_the_refresh_window_skips_the_write() {
 		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
@@ -971,6 +972,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 	/**
 	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_unchanged_state_past_the_refresh_window_writes() {
 		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
@@ -988,6 +990,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 	/**
 	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_changed_state_writes_inside_the_refresh_window() {
 		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
@@ -1008,6 +1011,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 	/**
 	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_skipped_write_does_not_announce_an_admin_room_change() {
 		$room = wp_presence_admin_room();
@@ -1062,6 +1066,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 	/**
 	 * @covers ::wp_presence_refresh_threshold
 	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_a_ttl_below_the_tick_gap_leaves_no_room_to_skip() {
 		add_filter(
@@ -1087,6 +1092,7 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 	 * at any age above zero the comparison already refuses to skip.
 	 *
 	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_a_zero_threshold_writes_again_inside_the_same_second() {
 		add_filter(

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -1027,4 +1027,98 @@ class WP_Test_Presence_Functions extends WP_Presence_UnitTestCase {
 
 		$this->assertSame( 0, $fired, 'Nobody arrived or left, so no surface needs to re-render.' );
 	}
+
+	/**
+	 * Counts INSERT statements against the presence table during a callback.
+	 */
+	private function count_presence_inserts( callable $during ) {
+		global $wpdb;
+
+		$count = 0;
+		$table = $wpdb->presence;
+
+		$counter = static function ( $query ) use ( &$count, $table ) {
+			if ( 0 === strpos( ltrim( $query ), 'INSERT' ) && false !== strpos( $query, $table ) ) {
+				++$count;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $counter );
+		$during();
+		remove_filter( 'query', $counter );
+
+		return $count;
+	}
+
+	/**
+	 * @covers ::wp_presence_refresh_threshold
+	 * @covers ::wp_set_presence
+	 */
+	public function test_a_ttl_below_the_tick_gap_leaves_no_room_to_skip() {
+		add_filter(
+			'wp_presence_default_ttl',
+			static function () {
+				return 60;
+			}
+		);
+
+		$this->assertSame( 0, wp_presence_refresh_threshold(), 'A 60s TTL against a 120s gap cannot afford to skip anything.' );
+
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+		$this->backdate( 'test/room', 'client-1', 1 );
+
+		$before = $this->stored_date_gmt( 'test/room', 'client-1' );
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+
+		$this->assertNotSame( $before, $this->stored_date_gmt( 'test/room', 'client-1' ) );
+	}
+
+	/**
+	 * The zero threshold is the only case the early return decides on its own:
+	 * at any age above zero the comparison already refuses to skip.
+	 *
+	 * @covers ::wp_set_presence
+	 */
+	public function test_a_zero_threshold_writes_again_inside_the_same_second() {
+		add_filter(
+			'wp_presence_default_ttl',
+			static function () {
+				return 60;
+			}
+		);
+
+		wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+
+		$inserts = $this->count_presence_inserts(
+			function () {
+				wp_set_presence( 'test/room', 'client-1', array( 'action' => 'editing' ), self::$editor_id );
+			}
+		);
+
+		$this->assertSame( 1, $inserts, 'A row written this same second is still owed its refresh.' );
+	}
+
+	/**
+	 * @covers ::wp_presence_next_tick_gap
+	 */
+	public function test_the_tick_gap_assumes_a_blurred_window_unless_the_request_says_otherwise() {
+		$this->assertSame( 120, wp_presence_next_tick_gap(), 'Nothing outside a Heartbeat request says how long the gap is.' );
+
+		$_POST['interval']  = '10';
+		$_POST['has_focus'] = 'false';
+
+		$this->assertSame( 120, wp_presence_next_tick_gap(), 'A blurred tab returns in 120s whatever interval it reports.' );
+
+		$_POST['has_focus'] = 'true';
+
+		$this->assertSame( 10, wp_presence_next_tick_gap() );
+
+		$_POST['interval'] = '0';
+
+		$this->assertSame( 120, wp_presence_next_tick_gap(), 'An unusable interval falls back rather than skipping forever.' );
+
+		unset( $_POST['interval'], $_POST['has_focus'] );
+	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -350,4 +350,25 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 
 		$this->assertArrayNotHasKey( $blog_id, $snapshot['sites'], 'A deleted site must not appear in the network snapshot.' );
 	}
+
+	/**
+	 * With aggregation switched off there is no summary row to keep alive, so
+	 * the redundant-write guard is free to skip admin-room writes as usual.
+	 *
+	 * @covers ::wp_presence_network_summary_push_is_due
+	 */
+	public function test_push_is_not_due_when_aggregation_is_off() {
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+
+		$this->assertFalse( wp_presence_network_summary_push_is_due() );
+	}
+
+	/**
+	 * @covers ::wp_presence_network_summary_push_is_due
+	 */
+	public function test_push_is_due_when_the_row_has_never_been_pushed() {
+		delete_option( 'wp_presence_network_pushed' );
+
+		$this->assertTrue( wp_presence_network_summary_push_is_due() );
+	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -371,4 +371,81 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 
 		$this->assertTrue( wp_presence_network_summary_push_is_due() );
 	}
+
+	/**
+	 * @covers ::wp_presence_network_summary_push_is_due
+	 */
+	public function test_push_is_not_due_when_the_row_was_pushed_recently() {
+		update_option(
+			'wp_presence_network_pushed',
+			array(
+				'users' => (string) self::$editor_id,
+				'time'  => time(),
+			)
+		);
+
+		$this->assertFalse( wp_presence_network_summary_push_is_due() );
+	}
+
+	/**
+	 * The redundant-write guard has to keep admin-room writes alive while a push
+	 * is owed, because the push only runs off wp_presence_admin_room_changed.
+	 *
+	 * @covers ::wp_set_presence
+	 * @covers ::wp_presence_network_summary_push_is_due
+	 */
+	public function test_an_overdue_push_keeps_an_unchanged_admin_room_write() {
+		global $wpdb;
+
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		switch_to_blog( $blog_id );
+
+		$client_id = 'user-' . self::$editor_id;
+
+		// Old enough that the guard would otherwise skip it.
+		$wpdb->update(
+			$wpdb->presence,
+			array( 'date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 5 ) ),
+			array(
+				'room'      => wp_presence_admin_room(),
+				'client_id' => $client_id,
+			),
+			array( '%s' ),
+			array( '%s', '%s' )
+		);
+
+		update_option(
+			'wp_presence_network_pushed',
+			array(
+				'users' => (string) self::$editor_id,
+				'time'  => time() - wp_presence_network_summary_refresh_interval() - 1,
+			)
+		);
+
+		$this->assertTrue( wp_presence_network_summary_push_is_due(), 'Precondition: the push has to be overdue for this to test anything.' );
+
+		$before = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT date_gmt FROM {$wpdb->presence} WHERE room = %s AND client_id = %s",
+				wp_presence_admin_room(),
+				$client_id
+			)
+		);
+
+		wp_set_presence( wp_presence_admin_room(), $client_id, array( 'screen' => 'dashboard' ), self::$editor_id );
+
+		$after = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT date_gmt FROM {$wpdb->presence} WHERE room = %s AND client_id = %s",
+				wp_presence_admin_room(),
+				$client_id
+			)
+		);
+
+		restore_current_blog();
+
+		$this->assertNotSame( $before, $after, 'An unchanged state still writes while the summary push is owed.' );
+	}
 }

--- a/tests/test-network-summary-push.php
+++ b/tests/test-network-summary-push.php
@@ -393,6 +393,7 @@ class WP_Test_Network_Summary_Push extends WP_Presence_Network_UnitTestCase {
 	 *
 	 * @covers ::wp_set_presence
 	 * @covers ::wp_presence_network_summary_push_is_due
+	 * @covers ::wp_presence_write_is_redundant
 	 */
 	public function test_an_overdue_push_keeps_an_unchanged_admin_room_write() {
 		global $wpdb;


### PR DESCRIPTION
Presence is upserted on every Heartbeat tick, so a user sitting on one screen rewrites the same row with byte-identical data until they leave. This compares the encoded state against the stored row first and leaves it alone when nothing changed and the row will still be inside the cutoff at the next tick.

Fixes #131

One live editor session, same steps on both branches:

| | Writes in 186s | Max row age while live |
| --- | --- | --- |
| `main` | one every ~10s, payload hash unchanged every time | n/a, refreshed constantly |
| This branch | 3, each a real state change | 95s against the 150s TTL |

The threshold is `wp_presence_get_timeout() - 15 - gap`. It derives from the filtered timeout rather than `WP_PRESENCE_DEFAULT_TTL`, or a site filtering the TTL below the tick interval blinks its users offline. The 15 mirrors `TTL_SAFETY_MARGIN` in `presence-ping.js`, which caps the client's own idle backoff against the same TTL.

`gap` comes from `has_focus`, not from the `interval` in the same request. `scheduleNextTick()` hard-codes `120000` on a blurred window and never writes that back into the reported field, so the reported value understates the real gap on exactly the case with the least headroom: a 150s TTL against a 120s gap.

**The multisite coupling is the part worth reviewing.** The network summary push runs off `wp_presence_admin_room_changed` (`presence-api.php:329`), which only fires on a real write. Skipping admin-room writes decays the summary row past the read cutoff and the Network Admin screens report nobody online. `wp_presence_network_summary_push_is_due()` keeps those writes.

Notes:

- Only the staleness half of `wp_presence_network_summary_needs_push()` applies to that guard. A membership change is somebody else's state changing, and their own write announces it.
- The cost is one `SELECT` on the `(room, client_id)` unique key before each write. This does not contradict #132, which measured the upsert as cheap and it still is. What this removes is write volume, not tick latency.
- I left the threshold unfiltered. Adding one trips the public surface workflow and is a commitment to keep, which is the argument @mindctrl made on #437.
- Not run on SQLite. Everything below is MariaDB.

Testing:

- `phpunit` — 432 tests, 719 assertions, 108 skipped
- `WP_MULTISITE=1 phpunit` — 432 tests, 928 assertions, 3 expected skips
- `./vendor/bin/phpcs --standard=phpcs.xml.dist` — passed
- `./vendor/bin/phpstan analyse --no-progress` — passed
- Browser A/B on wp-env against both branches, sampling `wp_presence` through the session
- Four mutation checks, each caught by the intended test: removing the guard, making the threshold never expire, dropping the state comparison, removing the network bail-out

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes  
Tool(s): Claude Code  
Model(s): Claude Opus 5  
Used for: Assisting with the implementation, tests, and this description. The change and the results above were reviewed by me before submission.

</details>
