### PR TITLE
feat: carry the room's editor count on the editor heartbeat response 

### DIFF
--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -69,6 +69,7 @@
 		'presence-heartbeat-query-ms',
 		'presence-heartbeat-ttl',
 		'presence-heartbeat-room-list',
+		'presence-heartbeat-collaborators',
 	];
 
 	const tabCoordinator = window.wpPresenceCreateTabCoordinator(pingContextKey, RELAYED_TICK_KEYS);

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -362,7 +362,7 @@ function wp_presence_collaboration_state_key( $room ) {
  * Fires 'wp_presence_collaboration_ended' when editor count goes from 2+ to 1.
  *
  * @since 0.1.21
- * @since 0.3.0 Returns the current editor count instead of void.
+ * @since 0.4.0 Returns the current editor count instead of void.
  *
  * @param string $room The presence room identifier.
  * @return int The number of editors currently present in the room.

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -280,6 +280,10 @@ function wp_presence_admin_heartbeat_received( $response, $data, $screen_id ) { 
 /**
  * Handles the editor presence heartbeat and creates a presence entry for the post being edited.
  *
+ * Also carries the room's current editor count back as
+ * `presence-heartbeat-collaborators`, so a client can decide whether to start
+ * a real-time sync loop without polling for it separately.
+ *
  * @param array  $response  The Heartbeat response.
  * @param array  $data      The $_POST data sent.
  * @param string $screen_id The screen ID.
@@ -331,7 +335,7 @@ function wp_presence_editor_heartbeat_received( $response, $data, $screen_id ) {
 		$user_id
 	);
 
-	wp_presence_check_collaboration_threshold( $room );
+	$response['presence-heartbeat-collaborators'] = wp_presence_check_collaboration_threshold( $room );
 
 	return $response;
 }
@@ -358,8 +362,10 @@ function wp_presence_collaboration_state_key( $room ) {
  * Fires 'wp_presence_collaboration_ended' when editor count goes from 2+ to 1.
  *
  * @since 0.1.21
+ * @since 0.3.0 Returns the current editor count instead of void.
  *
  * @param string $room The presence room identifier.
+ * @return int The number of editors currently present in the room.
  */
 function wp_presence_check_collaboration_threshold( $room ) {
 	$entries = wp_get_presence( $room );
@@ -410,4 +416,6 @@ function wp_presence_check_collaboration_threshold( $room ) {
 	} elseif ( false !== $stored ) {
 		delete_transient( $key );
 	}
+
+	return $editor_count;
 }

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -279,7 +279,72 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 		$this->assertSame( 'editing', $entries[0]->data['action'] );
 		$this->assertSame( 'post', $entries[0]->data['screen'] );
 
-		$this->assertSame( array( 'existing' => true ), $response );
+		$this->assertSame(
+			array(
+				'existing'                        => true,
+				'presence-heartbeat-collaborators' => 1,
+			),
+			$response
+		);
+	}
+
+	/**
+	 * Gutenberg reads this to decide whether to start its sync loop, so the
+	 * count has to reflect everyone in the room, not just the ticking client.
+	 *
+	 * @covers ::wp_presence_editor_heartbeat_received
+	 */
+	public function test_editor_heartbeat_response_carries_the_room_s_editor_count() {
+		$post_id  = self::factory()->post->create();
+		$editor_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $editor_2 );
+		wp_presence_editor_heartbeat_received(
+			array(),
+			array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+			'post'
+		);
+
+		wp_set_current_user( self::$editor_id );
+		$response = wp_presence_editor_heartbeat_received(
+			array(),
+			array( 'presence-editor-ping' => array( 'post_id' => $post_id ) ),
+			'post'
+		);
+
+		$this->assertSame( 2, $response['presence-heartbeat-collaborators'] );
+	}
+
+	/**
+	 * A ping that never reaches the write path (no post ID, missing
+	 * capability) has no count to report, so the key must not appear.
+	 *
+	 * @covers ::wp_presence_editor_heartbeat_received
+	 */
+	public function test_editor_heartbeat_omits_collaborator_count_without_a_post_id() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = wp_presence_editor_heartbeat_received( array(), array(), 'post' );
+
+		$this->assertArrayNotHasKey( 'presence-heartbeat-collaborators', $response );
+	}
+
+	/**
+	 * The admin heartbeat handler is a different write path (admin/online,
+	 * not a post room), so it has no editor count of its own to report.
+	 *
+	 * @covers ::wp_presence_admin_heartbeat_received
+	 */
+	public function test_admin_heartbeat_omits_collaborator_count() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = wp_presence_admin_heartbeat_received(
+			array(),
+			array( 'presence-ping' => array( 'screen' => 'dashboard' ) ),
+			'dashboard'
+		);
+
+		$this->assertArrayNotHasKey( 'presence-heartbeat-collaborators', $response );
 	}
 
 	/**


### PR DESCRIPTION
## Why
[#451](https://github.com/WordPress/presence-api/issues/451)  `wp_presence_check_collaboration_threshold()` already fires `wp_presence_collaboration_started`/`_ended` PHP actions on the 1↔2+ editor edge, but those are server-side only. The editor heartbeat handler calls it and discards the result, so a browser has no way to learn the edge without polling something separately. That makes the signal unusable for the case it exists for: letting the block editor decide whether to start its real-time sync loop. Today Gutenberg derives `hasCollaborators` from its own poll response, costing a solo editor ~840 requests an hour to discover nobody else is there.

## What
- `wp_presence_check_collaboration_threshold()` now returns the current editor count (int) instead of void, back-compatible, since nothing previously used the return value.
- `wp_presence_editor_heartbeat_received()` sets that count on the response as `presence-heartbeat-collaborators`.
- `presence-heartbeat-collaborators` added to `RELAYED_TICK_KEYS` in `assets/js/presence-ping.js` so a coalesced sibling tab still receives it.
- No filter added on the key, consistent with every other `presence-heartbeat-*` key, and with the argument recorded in #450 against filters that become commitments.

## How
- `includes/heartbeat.php`: `$editor_count` is computed and used for the started/ended action edge exactly as before; the only change is returning it, and assigning it into `$response` at the call site.
- `assets/js/presence-ping.js`: one-line addition to the existing relay list, same pattern as the other `presence-heartbeat-*` keys.
- No new hooks, no new REST surface, no schema change.

## Test instructions
1. `composer phpcs` / `composer phpstan` both clean on the changed files.
2. `npm test` (needs `wp-env`/Docker)  runs the PHPUnit suite, including new/updated tests in `tests/test-heartbeat.php`:
   - `test_editor_heartbeat_writes_presence`  updated to assert the full response shape now includes `presence-heartbeat-collaborators`.
   - `test_editor_heartbeat_response_carries_the_room_s_editor_count`  two editors ticking → response reports `2`.
   - `test_editor_heartbeat_omits_collaborator_count_without_a_post_id`  a ping that never reaches the write path carries no key.
   - `test_admin_heartbeat_omits_collaborator_count`: the unrelated admin heartbeat response never carries the key.
3. Manual sanity check: open a post in two browser sessions as different editors, watch Heartbeat responses in devtools; `data.presence-heartbeat-collaborators` should read `2` on both, and drop to `1` when one leaves.
