### PR TITLE
fix: say the network does not aggregate on the Users list too

### DIFF
--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Network Sites list: "Online" column.
+ * Network Sites list: "Online" column, plus the aggregation notice both
+ * network list tables share.
  *
  * @package Presence_API
  */
@@ -45,15 +46,18 @@ function wp_presence_enqueue_network_sites_assets( $hook_suffix ) {
 }
 
 /**
- * Warns above the Sites list when the network does not aggregate presence.
+ * Warns above either network list table when the network does not aggregate
+ * presence.
  *
  * The column reads the same em dash either way, so the reason is said once
- * above the table rather than repeated down every row of it.
+ * above the table rather than repeated down every row of it. Both tables carry
+ * that column and both are wrong in the same way without this, so they share
+ * one notice rather than each wording the same thing.
  */
-function wp_presence_network_sites_aggregation_notice() {
+function wp_presence_network_aggregation_notice() {
 	$screen = get_current_screen();
 
-	if ( ! $screen || 'sites-network' !== $screen->id ) {
+	if ( ! $screen || ! in_array( $screen->id, array( 'sites-network', 'users-network' ), true ) ) {
 		return;
 	}
 

--- a/includes/network-user-list.php
+++ b/includes/network-user-list.php
@@ -23,6 +23,14 @@ function wp_presence_network_users_views( $views ) {
 		return $views;
 	}
 
+	// Withheld rather than shown as zero, matching what `wp presence network`
+	// does with its totals: nobody online is an answer this network cannot
+	// give, and the filter behind the link would return nothing on any reading.
+	// wp_presence_network_aggregation_notice() says why the column is empty.
+	if ( ! wp_presence_network_aggregation_enabled() ) {
+		return $views;
+	}
+
 	$online_count = count( wp_presence_get_network_online_user_ids() );
 	$is_current   = isset( $_GET['presence_status'] ) && 'online' === $_GET['presence_status']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 

--- a/presence-api.php
+++ b/presence-api.php
@@ -385,7 +385,7 @@ if ( is_multisite() ) {
 	add_filter( 'wpmu_blogs_columns', 'wp_presence_register_network_sites_column' );
 	add_action( 'manage_sites_custom_column', 'wp_presence_render_network_sites_column', 10, 2 );
 	add_action( 'admin_enqueue_scripts', 'wp_presence_enqueue_network_sites_assets' );
-	add_action( 'network_admin_notices', 'wp_presence_network_sites_aggregation_notice' );
+	add_action( 'network_admin_notices', 'wp_presence_network_aggregation_notice' );
 
 	add_filter( 'views_users-network', 'wp_presence_network_users_views' );
 	add_filter( 'users_list_table_query_args', 'wp_presence_filter_network_online_users' );

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -123,7 +123,7 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 	 * The column reads the same em dash either way, so the screen has to say
 	 * which it is.
 	 *
-	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 * @covers ::wp_presence_network_aggregation_notice
 	 */
 	public function test_sites_list_warns_when_the_network_does_not_aggregate() {
 		$this->become_network_admin();
@@ -132,39 +132,39 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
 
 		ob_start();
-		wp_presence_network_sites_aggregation_notice();
+		wp_presence_network_aggregation_notice();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'not aggregated across this network', $output );
 	}
 
 	/**
-	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 * @covers ::wp_presence_network_aggregation_notice
 	 */
 	public function test_sites_list_is_silent_while_the_network_aggregates() {
 		$this->become_network_admin();
 		set_current_screen( 'sites-network' );
 
 		ob_start();
-		wp_presence_network_sites_aggregation_notice();
+		wp_presence_network_aggregation_notice();
 
 		$this->assertSame( '', ob_get_clean() );
 	}
 
 	/**
 	 * network_admin_notices fires on every Network Admin screen, so the notice
-	 * has to place itself.
+	 * has to place itself. It belongs on the two that carry an Online column.
 	 *
-	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 * @covers ::wp_presence_network_aggregation_notice
 	 */
-	public function test_the_notice_stays_on_the_sites_list() {
+	public function test_the_notice_stays_off_screens_without_an_online_column() {
 		$this->become_network_admin();
 		set_current_screen( 'dashboard-network' );
 
 		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
 
 		ob_start();
-		wp_presence_network_sites_aggregation_notice();
+		wp_presence_network_aggregation_notice();
 
 		$this->assertSame( '', ob_get_clean() );
 	}
@@ -172,7 +172,7 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 	/**
 	 * The notice names a column only a network administrator is shown.
 	 *
-	 * @covers ::wp_presence_network_sites_aggregation_notice
+	 * @covers ::wp_presence_network_aggregation_notice
 	 */
 	public function test_the_notice_requires_capability() {
 		wp_set_current_user( self::$editor_id );
@@ -181,7 +181,7 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
 
 		ob_start();
-		wp_presence_network_sites_aggregation_notice();
+		wp_presence_network_aggregation_notice();
 
 		$this->assertSame( '', ob_get_clean() );
 	}

--- a/tests/test-network-users-list.php
+++ b/tests/test-network-users-list.php
@@ -71,6 +71,44 @@ class WP_Test_Network_Users_List extends WP_Presence_Network_UnitTestCase {
 	}
 
 	/**
+	 * A count of zero is a headcount, and a network that does not aggregate has
+	 * not taken one. Rows are sitting there so the number would be wrong rather
+	 * than merely unknown.
+	 *
+	 * @covers ::wp_presence_network_users_views
+	 */
+	public function test_users_view_is_withheld_when_the_network_does_not_aggregate() {
+		$this->become_network_admin();
+		$this->set_network_summary_row( $this->create_blog(), array( self::$editor_id ) );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+		wp_presence_flush_network_summary_cache();
+
+		$views = wp_presence_network_users_views( array() );
+
+		$this->assertArrayNotHasKey( 'presence_online', $views );
+	}
+
+	/**
+	 * Withholding the view leaves a column of em dashes and nothing saying why,
+	 * so the screen has to carry the same notice the Sites list does.
+	 *
+	 * @covers ::wp_presence_network_aggregation_notice
+	 */
+	public function test_the_users_list_warns_when_the_network_does_not_aggregate() {
+		$this->become_network_admin();
+		set_current_screen( 'users-network' );
+
+		add_filter( 'wp_presence_network_aggregation_enabled', '__return_false' );
+
+		ob_start();
+		wp_presence_network_aggregation_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'not aggregated across this network', $output );
+	}
+
+	/**
 	 * @covers ::wp_presence_filter_network_online_users
 	 */
 	public function test_users_query_filter_requires_network_admin_context() {


### PR DESCRIPTION
#448 taught the REST controller, WP-CLI, the Sites list and the Who's Online widget to distinguish a network that does not aggregate from a quiet one, but left the Network Users list reporting `Online (0)` with a column of em dashes and nothing saying why. Widens that PR's notice to `users-network` and withholds the Online view instead of showing a count the network cannot take, matching what `wp presence network` already does with its totals.

Fixes #411