### PR TITLE
chore: test up to WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: joefusco, intenzi, ashishjii, iamchitti, iqbal1hossain, wp24horas, aldorza, bejignesh, stfulldev, obenland, moriikuri, ishitaj34
 Tags: presence, awareness, heartbeat, real-time
 Requires at least: 7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 0.2.1
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
WordPress 7.1 is out and the test suite already runs against it, so the readme header was the only place still naming 7.0.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with the release preparation.

</details>
