### PR TITLE
ci: fail the Plugin Check job when Plugin Check reports an error

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -49,4 +49,15 @@ jobs:
           wp-env run cli wp plugin activate presence-api
 
       - name: Run Plugin Check
-        run: wp-env run cli wp plugin check presence-api --format=strict-table
+        run: |
+          wp-env run cli wp plugin check presence-api \
+            --format=strict-json \
+            --fields=file,line,column,type,code,message > plugin-check.json
+
+          jq -r '.[] | "\(.type)  \(.file):\(.line):\(.column)  \(.code)\n    \(.message)"' plugin-check.json
+
+          errors="$( jq '[ .[] | select( .type == "ERROR" ) ] | length' plugin-check.json )"
+          if [ "$errors" -gt 0 ]; then
+            echo "Plugin Check reported $errors error(s)."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ build/
 coverage.xml
 .env
 .wp-env.override.json
+plugin-check.json
 .DS_Store


### PR DESCRIPTION
## Description

Fixes #412

Plugin Check has no flag that can fail the job. `--severity`, `--error-severity` and `--ignore-warnings` only change what gets printed, and `wp plugin check` exits 0 either way. So the check has to happen in the step itself.

Errors fail the job, warnings don't. The current warnings are all pre-existing, so gating them would fail the job on merge day for problems no PR caused.

Tested both ways. Setting `Tested up to` back to 7.0 brings the error back and the job fails. When there is nothing to report, the command prints `[]` and the job passes.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Checking the Plugin Check CLI for a severity flag and testing the gate both ways.

</details>