### PR TITLE
test: retry Playwright tests in CI

### DIFF
--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -44,6 +44,7 @@ const NETWORK_SPECS = /presence-network-[^/]+\.test\.js$/;
 export default defineConfig( {
 	globalSetup: path.resolve( __dirname, 'global-setup.js' ),
 	reporter: process.env.CI ? [ [ 'github' ] ] : [ [ 'list' ] ],
+	retries: process.env.CI ? 2 : 0,
 	workers: 1,
 	timeout: 100_000,
 	reportSlowTests: null,


### PR DESCRIPTION
Add two Playwright retries in CI while preserving zero retries for local runs. This allows transient wordpress.org timeouts to be retried without masking failures during local development.

Fixes #403

### Testing

- Verified both Playwright projects resolve to 0 retries locally and 2 retries in CI.
- `npx playwright test --config tests/e2e/playwright.config.js --list` - 44 tests discovered.
- `npm run test:unit -- --runInBand` - 21 tests passed.
- `npm run test:scripts` - 79 tests passed.
- `git diff --check`

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Code and tests.

</details>