### PR TITLE
fix: gate the network column renderers on the network capability

### DIFF
--- a/includes/network-functions.php
+++ b/includes/network-functions.php
@@ -523,6 +523,12 @@ function wp_presence_network_capability() {
 	/**
 	 * Filters the capability required to see network-wide presence data.
 	 *
+	 * What this guards is network-wide: who is online on every site, and which
+	 * sites a given user is online on. Lowering it to a capability a site-level
+	 * role already holds, such as 'edit_posts', hands presence for the whole
+	 * network to every holder on every site, including sites they are not a
+	 * member of.
+	 *
 	 * @param string $capability Default 'manage_network'.
 	 */
 	return apply_filters( 'wp_presence_network_capability', 'manage_network' );

--- a/includes/network-sites-list.php
+++ b/includes/network-sites-list.php
@@ -86,11 +86,19 @@ function wp_presence_network_aggregation_notice() {
  * snapshot is read once for the request; what each row adds is resolving the
  * handful of people whose avatars it is about to draw.
  *
+ * Gates on the capability again rather than trusting the registration above:
+ * core calls this for whatever columns the screen ended up with, and ours is
+ * not the only thing that can put a name in that list.
+ *
  * @param string $column_name Column being rendered.
  * @param int    $blog_id     The site ID for the current row.
  */
 function wp_presence_render_network_sites_column( $column_name, $blog_id ) {
 	if ( 'presence_online' !== $column_name ) {
+		return;
+	}
+
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
 		return;
 	}
 

--- a/includes/network-user-list.php
+++ b/includes/network-user-list.php
@@ -108,6 +108,10 @@ function wp_presence_register_network_users_column( $columns ) {
  * avatar URL for everyone online would be the whole cost of the read for
  * output this column never uses.
  *
+ * Gates on the capability again rather than trusting the registration above:
+ * core calls this for whatever columns the screen ended up with, and ours is
+ * not the only thing that can put a name in that list.
+ *
  * @param string $output      Existing column output.
  * @param string $column_name Column being rendered.
  * @param int    $user_id     The user ID for the current row.
@@ -115,6 +119,10 @@ function wp_presence_register_network_users_column( $columns ) {
  */
 function wp_presence_render_network_users_column( $output, $column_name, $user_id ) {
 	if ( 'presence_online' !== $column_name ) {
+		return $output;
+	}
+
+	if ( ! current_user_can( wp_presence_network_capability() ) ) {
 		return $output;
 	}
 

--- a/tests/test-multisite-boundary.php
+++ b/tests/test-multisite-boundary.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for the site boundary itself, as opposed to the network surfaces that
+ * cross it deliberately.
+ *
+ * Presence was scoped by table prefix by construction until the network
+ * summary arrived, so nothing asserted the boundary directly: the prefix made
+ * it true. These hold that property in place now that a capability, rather
+ * than the schema, is what keeps network reads apart from site reads.
+ *
+ * @package Presence_API
+ *
+ * @group presence
+ * @group ms-required
+ */
+class WP_Test_Multisite_Boundary extends WP_Presence_Network_UnitTestCase {
+
+	private static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * An editor on one site has no role on a site they were never added to, so
+	 * the same room resolves differently either side of a switch. user_can()
+	 * is what carries the site context here; nothing in the room string does.
+	 *
+	 * @covers ::wp_can_access_presence_room
+	 */
+	public function test_admin_room_is_denied_on_a_site_the_user_is_not_a_member_of() {
+		$site_b = $this->create_blog();
+
+		$this->assertTrue(
+			wp_can_access_presence_room( 'admin/online', self::$editor_id ),
+			'An editor should reach the admin room on their own site.'
+		);
+
+		switch_to_blog( $site_b );
+		$on_site_b = wp_can_access_presence_room( 'admin/online', self::$editor_id );
+		restore_current_blog();
+
+		$this->assertFalse( $on_site_b );
+	}
+
+	/**
+	 * @covers ::wp_get_presence
+	 */
+	public function test_a_row_written_on_one_site_is_not_readable_from_another() {
+		$site_b = $this->create_blog();
+
+		$this->set_presence_on_site( $site_b, self::$editor_id );
+
+		switch_to_blog( $site_b );
+		$read_on_b = wp_get_presence( 'admin/online' );
+		restore_current_blog();
+
+		$read_on_a = wp_get_presence( 'admin/online' );
+
+		$this->assertCount( 1, $read_on_b, 'The row should be readable on the site that wrote it.' );
+		$this->assertSame( array(), $read_on_a );
+	}
+}

--- a/tests/test-network-sites-column.php
+++ b/tests/test-network-sites-column.php
@@ -14,9 +14,11 @@
 class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 
 	private static $editor_id;
+	private static $subscriber_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 	}
 
 	/**
@@ -26,6 +28,27 @@ class WP_Test_Network_Sites_Column extends WP_Presence_Network_UnitTestCase {
 		$columns = wp_presence_register_network_sites_column( array( 'blogname' => 'Site' ) );
 
 		$this->assertArrayNotHasKey( 'presence_online', $columns, 'A visitor with no capability should not see the column.' );
+	}
+
+	/**
+	 * The header is gated, so nothing registers this column for a user without
+	 * the capability. That holds only while ours is the only thing that can put
+	 * the name on the screen, which is not a property this file controls.
+	 *
+	 * @covers ::wp_presence_render_network_sites_column
+	 */
+	public function test_sites_column_renders_nothing_without_capability() {
+		$this->become_network_admin();
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		wp_set_current_user( self::$subscriber_id );
+
+		ob_start();
+		wp_presence_render_network_sites_column( 'presence_online', $blog_id );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
 	}
 
 	/**

--- a/tests/test-network-users-list.php
+++ b/tests/test-network-users-list.php
@@ -16,9 +16,11 @@
 class WP_Test_Network_Users_List extends WP_Presence_Network_UnitTestCase {
 
 	private static $editor_id;
+	private static $subscriber_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 	}
 
 	/**
@@ -211,9 +213,30 @@ class WP_Test_Network_Users_List extends WP_Presence_Network_UnitTestCase {
 	 * @covers ::wp_presence_get_network_sites_for_user
 	 */
 	public function test_users_column_shows_a_dash_for_an_offline_user() {
+		$this->become_network_admin();
+
 		$output = wp_presence_render_network_users_column( '', 'presence_online', self::$editor_id );
 
 		$this->assertSame( '&#8212;', $output );
+	}
+
+	/**
+	 * test_users_column_shows_a_dash_for_an_offline_user() also calls this
+	 * uncapped, but it passes because that user is offline. This one is online,
+	 * so only a gate can keep the site names back.
+	 *
+	 * @covers ::wp_presence_render_network_users_column
+	 */
+	public function test_users_column_renders_nothing_without_capability() {
+		$this->become_network_admin();
+		$blog_id = $this->create_blog();
+		$this->set_presence_on_site( $blog_id, self::$editor_id );
+
+		wp_set_current_user( self::$subscriber_id );
+
+		$output = wp_presence_render_network_users_column( 'unchanged', 'presence_online', self::$editor_id );
+
+		$this->assertSame( 'unchanged', $output );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #137

Both Network Admin render callbacks returned network-wide presence to any caller, since only the column registration was gated. That holds while ours is the only thing that can put a column called `presence_online` on those screens, which is not a property this plugin controls. Called as a subscriber:

| Uncapped call | main | this branch |
| --- | --- | --- |
| `wp_presence_render_network_users_column( '', 'presence_online', $editor )` | `localhost:8891/testpath0000025/` | returns `$output` untouched |
| `wp_presence_render_network_sites_column( 'presence_online', $blog_id )` | avatar stack and count | nothing |

Notes:
- Gated rather than pinned as unreachable with a test, which was the open question on the issue. Two lines, it matches every other entry point in those files, and unreachability stops being true the moment another plugin registers the name.
- The cross-site denial the issue asks for already holds, so that test is a regression guard rather than a fix. Same for the site-scoped read.
- `test_users_column_shows_a_dash_for_an_offline_user` called the renderer uncapped and passed because the user was offline. It becomes a network admin first, which is what it always meant to assert.
- The `wp_presence_network_capability` docblock now says what a lowered value grants.

Testing:
- `npm run test:multisite`: 466 tests, 986 assertions, 3 skipped.
- `npm test`: 466 tests, 739 assertions, 131 skipped.
- `composer phpcs`: clean.
- Mutations: caps read from the main site inside the switch fails the denial test, the read pinned to `$wpdb->base_prefix` fails the isolation test, deleting either gate fails that column's test, and nothing else moves.
- Browser: an mu-plugin filtering the capability to `do_not_allow` and registering its own `presence_online` column, which is the third-plugin case above. On `main` that viewer sees the avatar stacks and the site names; on this branch both columns are empty. A super admin sees no change either way.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes  
Tool(s): Claude Code  
Model(s): Claude Opus 5  
Used for: Drafting the gate, the tests and this description. I ran the measurements, the mutation checks and the browser comparison, and reviewed what landed.

</details>
