### PR TITLE
test: lint the JavaScript toolchain and extract the Who's Online widget scripts

### DIFF
--- a/.github/scripts/aggregate-props.js
+++ b/.github/scripts/aggregate-props.js
@@ -6,182 +6,261 @@ const RELEASE_BRANCH = 'release-please--';
 // preview releases (preview-pr-N) and release-please drafts, neither of which
 // may set the cutoff.
 const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
-const WPORG_LOOKUP = 'https://profiles.wordpress.org/wp-json/wporg-github/v1/lookup/';
+const WPORG_LOOKUP =
+	'https://profiles.wordpress.org/wp-json/wporg-github/v1/lookup/';
 // props-bot writes this sentence under an "## Unlinked Accounts" heading for
 // every contributor with no WordPress.org account linked to their GitHub one.
 // See commentProps() in WordPress/props-bot-action, src/github.js. Logins
 // cannot contain a period, so the sentence ends at the first one.
-const UNLINKED = /^The following contributors have not linked their GitHub and WordPress\.org accounts: ([^.]+)\./m;
+const UNLINKED =
+	/^The following contributors have not linked their GitHub and WordPress\.org accounts: ([^.]+)\./m;
 
-function findCutoff(releases) {
-  return releases
-    .filter(r => !r.draft && r.published_at && RELEASE_TAG.test(r.tag_name || ''))
-    .map(r => r.published_at)
-    .sort()
-    .pop();
+function findCutoff( releases ) {
+	return releases
+		.filter(
+			( r ) =>
+				! r.draft &&
+				r.published_at &&
+				RELEASE_TAG.test( r.tag_name || '' )
+		)
+		.map( ( r ) => r.published_at )
+		.sort()
+		.pop();
 }
 
-function parsePropsNames(body) {
-  const match = body.match(/Props ([^.]+)\./);
-  if (!match) return [];
-  return match[1].split(', ').map(n => n.trim()).filter(Boolean);
+function parsePropsNames( body ) {
+	const match = body.match( /Props ([^.]+)\./ );
+	if ( ! match ) {
+		return [];
+	}
+	return match[ 1 ]
+		.split( ', ' )
+		.map( ( n ) => n.trim() )
+		.filter( Boolean );
 }
 
 // props-bot omits the SVN block entirely when nobody on the pull request is
 // linked yet, so a props comment is not always a comment containing "Props ".
 // Matching only on that would skip exactly the pull requests this recovery
 // exists for: the ones whose only contributor had not linked at merge time.
-function isPropsBotComment(comment) {
-  return (
-    comment.user.login === 'github-actions[bot]' &&
-    (comment.body.includes('Props ') || UNLINKED.test(comment.body))
-  );
+function isPropsBotComment( comment ) {
+	return (
+		comment.user.login === 'github-actions[bot]' &&
+		( comment.body.includes( 'Props ' ) || UNLINKED.test( comment.body ) )
+	);
 }
 
-function parseUnlinkedLogins(body) {
-  const match = body.match(UNLINKED);
-  if (!match) return [];
-  return match[1].split(',').map(n => n.trim().replace(/^@/, '')).filter(Boolean);
+function parseUnlinkedLogins( body ) {
+	const match = body.match( UNLINKED );
+	if ( ! match ) {
+		return [];
+	}
+	return match[ 1 ]
+		.split( ',' )
+		.map( ( n ) => n.trim().replace( /^@/, '' ) )
+		.filter( Boolean );
 }
 
 // Asks WordPress.org which of these GitHub logins now have a linked profile.
 // Same endpoint props-bot uses, so a login resolves here exactly when it would
 // have resolved there.
-async function resolveWPOrgLogins(logins, { userAgent, fetchImpl = fetch }) {
-  if (logins.length === 0) return [];
+async function resolveWPOrgLogins( logins, { userAgent, fetchImpl = fetch } ) {
+	if ( logins.length === 0 ) {
+		return [];
+	}
 
-  const response = await fetchImpl(WPORG_LOOKUP, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'User-Agent': userAgent },
-    body: JSON.stringify({ github_user: logins }),
-  });
+	const response = await fetchImpl( WPORG_LOOKUP, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'User-Agent': userAgent,
+		},
+		body: JSON.stringify( { github_user: logins } ),
+	} );
 
-  if (!response.ok) {
-    throw new Error(`WordPress.org lookup responded ${response.status}.`);
-  }
+	if ( ! response.ok ) {
+		throw new Error(
+			`WordPress.org lookup responded ${ response.status }.`
+		);
+	}
 
-  const data = await response.json();
+	const data = await response.json();
 
-  // An unlinked login comes back as `false` rather than an object.
-  return logins.map(login => data?.[login]?.slug).filter(Boolean);
+	// An unlinked login comes back as `false` rather than an object.
+	return logins.map( ( login ) => data?.[ login ]?.slug ).filter( Boolean );
 }
 
-function sortProps(names, sortLast) {
-  const unique = [...new Set(names)];
-  if (!sortLast) return unique;
-  return [...unique.filter(n => n !== sortLast), ...(unique.includes(sortLast) ? [sortLast] : [])];
+function sortProps( names, sortLast ) {
+	const unique = [ ...new Set( names ) ];
+	if ( ! sortLast ) {
+		return unique;
+	}
+	return [
+		...unique.filter( ( n ) => n !== sortLast ),
+		...( unique.includes( sortLast ) ? [ sortLast ] : [] ),
+	];
 }
 
 // Mirrors the props-bot comment layout so the props line is a copyable code
 // block rather than prose.
-function buildComment(names) {
-  return [
-    MARKER,
-    '',
-    'Core Committers: Use this line as a base for the props when committing in SVN:',
-    '',
-    '```',
-    `Props ${names.join(', ')}.`,
-    '```',
-  ].join('\n');
+function buildComment( names ) {
+	return [
+		MARKER,
+		'',
+		'Core Committers: Use this line as a base for the props when committing in SVN:',
+		'',
+		'```',
+		`Props ${ names.join( ', ' ) }.`,
+		'```',
+	].join( '\n' );
 }
 
-async function run({ github, context, core, env = process.env, fetchImpl = fetch }) {
-  const { owner, repo } = context.repo;
-  const sortLast = env.PROPS_SORT_LAST || '';
+async function run( {
+	github,
+	context,
+	core,
+	env = process.env,
+	fetchImpl = fetch,
+} ) {
+	const { owner, repo } = context.repo;
+	const sortLast = env.PROPS_SORT_LAST || '';
 
-  // 1. Resolve the release PR. release-please only reports it on runs where it
-  //    touched the PR, so fall back to whichever release PR is open. Without
-  //    this, contributors merged after the last touch are never aggregated.
-  let prNumber = Number(env.PR_NUMBER);
-  if (!prNumber) {
-    const { data: openPRs } = await github.rest.pulls.list({
-      owner, repo, state: 'open', base: 'main', per_page: 100,
-    });
-    prNumber = openPRs.find(pr => pr.head.ref.startsWith(RELEASE_BRANCH))?.number ?? 0;
-  }
-  if (!prNumber) { core.info('No open release PR; skipping comment.'); return; }
+	// 1. Resolve the release PR. release-please only reports it on runs where it
+	//    touched the PR, so fall back to whichever release PR is open. Without
+	//    this, contributors merged after the last touch are never aggregated.
+	let prNumber = Number( env.PR_NUMBER );
+	if ( ! prNumber ) {
+		const { data: openPRs } = await github.rest.pulls.list( {
+			owner,
+			repo,
+			state: 'open',
+			base: 'main',
+			per_page: 100,
+		} );
+		prNumber =
+			openPRs.find( ( pr ) => pr.head.ref.startsWith( RELEASE_BRANCH ) )
+				?.number ?? 0;
+	}
+	if ( ! prNumber ) {
+		core.info( 'No open release PR; skipping comment.' );
+		return;
+	}
 
-  // 2. Get cutoff from the latest published plugin release.
-  const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
-  const cutoff = findCutoff(releases);
+	// 2. Get cutoff from the latest published plugin release.
+	const { data: releases } = await github.rest.repos.listReleases( {
+		owner,
+		repo,
+		per_page: 100,
+	} );
+	const cutoff = findCutoff( releases );
 
-  // 3. List merged PRs since cutoff, skipping the release PR and bot-managed branches.
-  const allClosed = await github.paginate(
-    github.rest.pulls.list,
-    { owner, repo, state: 'closed', base: 'main', per_page: 100 }
-  );
-  const mergedPRs = allClosed.filter(pr =>
-    pr.merged_at &&
-    pr.number !== prNumber &&
-    !pr.head.ref.startsWith(RELEASE_BRANCH) &&
-    !pr.head.ref.startsWith('docs/add-') &&
-    (!cutoff || pr.merged_at >= cutoff)
-  );
+	// 3. List merged PRs since cutoff, skipping the release PR and bot-managed branches.
+	const allClosed = await github.paginate( github.rest.pulls.list, {
+		owner,
+		repo,
+		state: 'closed',
+		base: 'main',
+		per_page: 100,
+	} );
+	const mergedPRs = allClosed.filter(
+		( pr ) =>
+			pr.merged_at &&
+			pr.number !== prNumber &&
+			! pr.head.ref.startsWith( RELEASE_BRANCH ) &&
+			! pr.head.ref.startsWith( 'docs/add-' ) &&
+			( ! cutoff || pr.merged_at >= cutoff )
+	);
 
-  // 4. Collect each merged PR's latest props-bot comment.
-  const propsBodies = (
-    await Promise.all(
-      mergedPRs.map(pr =>
-        github.rest.issues.listComments({ owner, repo, issue_number: pr.number, per_page: 100 })
-      )
-    )
-  )
-    .map(({ data: comments }) => comments.findLast(isPropsBotComment))
-    .filter(Boolean)
-    .map(c => c.body);
+	// 4. Collect each merged PR's latest props-bot comment.
+	const propsBodies = (
+		await Promise.all(
+			mergedPRs.map( ( pr ) =>
+				github.rest.issues.listComments( {
+					owner,
+					repo,
+					issue_number: pr.number,
+					per_page: 100,
+				} )
+			)
+		)
+	)
+		.map( ( { data: comments } ) => comments.findLast( isPropsBotComment ) )
+		.filter( Boolean )
+		.map( ( c ) => c.body );
 
-  const propped = propsBodies.flatMap(parsePropsNames);
-  const unlinked = [...new Set(propsBodies.flatMap(parseUnlinkedLogins))];
+	const propped = propsBodies.flatMap( parsePropsNames );
+	const unlinked = [
+		...new Set( propsBodies.flatMap( parseUnlinkedLogins ) ),
+	];
 
-  if (propped.length === 0 && unlinked.length === 0) {
-    core.info('No props found across merged PRs; skipping comment.');
-    return;
-  }
+	if ( propped.length === 0 && unlinked.length === 0 ) {
+		core.info( 'No props found across merged PRs; skipping comment.' );
+		return;
+	}
 
-  // 5. Re-resolve anyone props-bot recorded as unlinked. That comment is a
-  //    snapshot taken while the pull request was open, and every trigger in
-  //    props-bot.yml requires an open pull request, so nothing refreshes it
-  //    after merge. Without this, linking a WordPress.org account any time
-  //    after your own pull request merges drops you from the release props
-  //    permanently. Checking here moves the deadline to the release.
-  let recovered = [];
-  try {
-    recovered = await resolveWPOrgLogins(unlinked, {
-      userAgent: `${owner}/${repo}`,
-      fetchImpl,
-    });
-  } catch (error) {
-    // Losing a late linker is better than losing the whole props comment.
-    core.warning(`Could not re-check unlinked accounts: ${error.message}`);
-  }
+	// 5. Re-resolve anyone props-bot recorded as unlinked. That comment is a
+	//    snapshot taken while the pull request was open, and every trigger in
+	//    props-bot.yml requires an open pull request, so nothing refreshes it
+	//    after merge. Without this, linking a WordPress.org account any time
+	//    after your own pull request merges drops you from the release props
+	//    permanently. Checking here moves the deadline to the release.
+	let recovered = [];
+	try {
+		recovered = await resolveWPOrgLogins( unlinked, {
+			userAgent: `${ owner }/${ repo }`,
+			fetchImpl,
+		} );
+	} catch ( error ) {
+		// Losing a late linker is better than losing the whole props comment.
+		core.warning(
+			`Could not re-check unlinked accounts: ${ error.message }`
+		);
+	}
 
-  if (recovered.length > 0) {
-    core.info(`Contributors linked since their pull request merged: ${recovered.join(', ')}.`);
-  }
+	if ( recovered.length > 0 ) {
+		core.info(
+			`Contributors linked since their pull request merged: ${ recovered.join(
+				', '
+			) }.`
+		);
+	}
 
-  const allNames = [...propped, ...recovered];
+	const allNames = [ ...propped, ...recovered ];
 
-  if (allNames.length === 0) {
-    core.info('Every contributor since the last release is still unlinked; skipping comment.');
-    return;
-  }
+	if ( allNames.length === 0 ) {
+		core.info(
+			'Every contributor since the last release is still unlinked; skipping comment.'
+		);
+		return;
+	}
 
-  // 6. Deduplicate and sort.
-  const sorted = sortProps(allNames, sortLast);
+	// 6. Deduplicate and sort.
+	const sorted = sortProps( allNames, sortLast );
 
-  // 7. Find or create sticky comment on the release PR.
-  const { data: releaseComments } = await github.rest.issues.listComments({
-    owner, repo, issue_number: prNumber,
-  });
-  const existing = releaseComments.find(c => c.body.includes(MARKER));
-  const body = buildComment(sorted);
+	// 7. Find or create sticky comment on the release PR.
+	const { data: releaseComments } = await github.rest.issues.listComments( {
+		owner,
+		repo,
+		issue_number: prNumber,
+	} );
+	const existing = releaseComments.find( ( c ) => c.body.includes( MARKER ) );
+	const body = buildComment( sorted );
 
-  if (existing) {
-    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-  } else {
-    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
-  }
+	if ( existing ) {
+		await github.rest.issues.updateComment( {
+			owner,
+			repo,
+			comment_id: existing.id,
+			body,
+		} );
+	} else {
+		await github.rest.issues.createComment( {
+			owner,
+			repo,
+			issue_number: prNumber,
+			body,
+		} );
+	}
 }
 
 module.exports = run;

--- a/.github/scripts/aggregate-props.test.js
+++ b/.github/scripts/aggregate-props.test.js
@@ -1,18 +1,18 @@
 'use strict';
 
-const { test, mock } = require('node:test');
-const assert = require('node:assert/strict');
+const { test, mock } = require( 'node:test' );
+const assert = require( 'node:assert/strict' );
 
-const run = require('./aggregate-props.js');
+const run = require( './aggregate-props.js' );
 const {
-  findCutoff,
-  parsePropsNames,
-  parseUnlinkedLogins,
-  resolveWPOrgLogins,
-  isPropsBotComment,
-  sortProps,
-  buildComment,
-  MARKER,
+	findCutoff,
+	parsePropsNames,
+	parseUnlinkedLogins,
+	resolveWPOrgLogins,
+	isPropsBotComment,
+	sortProps,
+	buildComment,
+	MARKER,
 } = run;
 
 // ---------------------------------------------------------------------------
@@ -22,511 +22,649 @@ const {
 const RELEASE_PR = 99;
 const context = { repo: { owner: 'WordPress', repo: 'presence-api' } };
 
-function makePR(number, ref, merged_at = '2026-07-10T00:00:00Z') {
-  return { number, merged_at, head: { ref } };
+function makePR( number, ref, merged_at = '2026-07-10T00:00:00Z' ) {
+	return { number, merged_at, head: { ref } };
 }
 
-function propsComment(body) {
-  return { id: 1, user: { login: 'github-actions[bot]' }, body };
+function propsComment( body ) {
+	return { id: 1, user: { login: 'github-actions[bot]' }, body };
 }
 
-function makeRelease(tag_name, published_at, draft = false) {
-  return { tag_name, published_at, draft };
+function makeRelease( tag_name, published_at, draft = false ) {
+	return { tag_name, published_at, draft };
 }
 
-function buildGithub({ releases = [], prs = [], openPRs = [], commentsByPR = {} } = {}) {
-  return {
-    rest: {
-      repos: {
-        listReleases: async () => ({ data: releases }),
-      },
-      pulls: { list: async ({ state }) => ({ data: state === 'open' ? openPRs : prs }) },
-      issues: {
-        listComments: async ({ issue_number }) => ({ data: commentsByPR[issue_number] ?? [] }),
-        createComment: mock.fn(async () => {}),
-        updateComment: mock.fn(async () => {}),
-      },
-    },
-    paginate: async (_fn, _params) => prs,
-  };
+function buildGithub( {
+	releases = [],
+	prs = [],
+	openPRs = [],
+	commentsByPR = {},
+} = {} ) {
+	return {
+		rest: {
+			repos: {
+				listReleases: async () => ( { data: releases } ),
+			},
+			pulls: {
+				list: async ( { state } ) => ( {
+					data: state === 'open' ? openPRs : prs,
+				} ),
+			},
+			issues: {
+				listComments: async ( { issue_number } ) => ( {
+					data: commentsByPR[ issue_number ] ?? [],
+				} ),
+				createComment: mock.fn( async () => {} ),
+				updateComment: mock.fn( async () => {} ),
+			},
+		},
+		paginate: async ( _fn, _params ) => prs,
+	};
 }
 
-function makeEnv(overrides = {}) {
-  return { PR_NUMBER: String(RELEASE_PR), PROPS_SORT_LAST: '', ...overrides };
+function makeEnv( overrides = {} ) {
+	return {
+		PR_NUMBER: String( RELEASE_PR ),
+		PROPS_SORT_LAST: '',
+		...overrides,
+	};
 }
 
 // Reproduces the layout commentProps() emits in WordPress/props-bot-action,
 // including its habit of dropping the SVN block when nobody is linked.
-function propsBotBody({ svn = [], unlinked = [] } = {}) {
-  let body =
-    'The following accounts have interacted with this PR and/or linked issues.' +
-    ' I will continue to update these lists as activity occurs. You can also' +
-    ' manually ask me to refresh this list by adding the `props-bot` label.\n\n';
+function propsBotBody( { svn = [], unlinked = [] } = {} ) {
+	let body =
+		'The following accounts have interacted with this PR and/or linked issues.' +
+		' I will continue to update these lists as activity occurs. You can also' +
+		' manually ask me to refresh this list by adding the `props-bot` label.\n\n';
 
-  if (unlinked.length > 0) {
-    body +=
-      '## Unlinked Accounts\n\n' +
-      'The following contributors have not linked their GitHub and WordPress.org accounts: @' +
-      unlinked.join(', @') +
-      '.\n\n' +
-      'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/)' +
-      ' to ensure your work is properly credited in WordPress releases.\n\n';
-  }
+	if ( unlinked.length > 0 ) {
+		body +=
+			'## Unlinked Accounts\n\n' +
+			'The following contributors have not linked their GitHub and WordPress.org accounts: @' +
+			unlinked.join( ', @' ) +
+			'.\n\n' +
+			'Contributors, please [read how to link your accounts](https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/)' +
+			' to ensure your work is properly credited in WordPress releases.\n\n';
+	}
 
-  if (svn.length > 0) {
-    body +=
-      'Core Committers: Use this line as a base for the props when committing in SVN:\n' +
-      '```\nProps ' + svn.join(', ') + '.\n```\n\n';
-  }
+	if ( svn.length > 0 ) {
+		body +=
+			'Core Committers: Use this line as a base for the props when committing in SVN:\n' +
+			'```\nProps ' +
+			svn.join( ', ' ) +
+			'.\n```\n\n';
+	}
 
-  return body;
+	return body;
 }
 
 // `slugs` maps a GitHub login to the WordPress.org slug it now resolves to.
 // Anything absent comes back as `false`, which is what the real endpoint sends
 // for an account that is still unlinked.
-function fakeLookup(slugs = {}, { ok = true, status = 200 } = {}) {
-  return mock.fn(async (_url, options) => {
-    const { github_user: logins } = JSON.parse(options.body);
-    const data = Object.fromEntries(
-      logins.map(login => [login, slugs[login] ? { slug: slugs[login] } : false])
-    );
-    return { ok, status, json: async () => data };
-  });
+function fakeLookup( slugs = {}, { ok = true, status = 200 } = {} ) {
+	return mock.fn( async ( _url, options ) => {
+		const { github_user: logins } = JSON.parse( options.body );
+		const data = Object.fromEntries(
+			logins.map( ( login ) => [
+				login,
+				slugs[ login ] ? { slug: slugs[ login ] } : false,
+			] )
+		);
+		return { ok, status, json: async () => data };
+	} );
 }
 
 // ---------------------------------------------------------------------------
 // parsePropsNames
 // ---------------------------------------------------------------------------
 
-test('parsePropsNames: extracts a single name', () => {
-  assert.deepEqual(parsePropsNames('Props alice.'), ['alice']);
-});
+test( 'parsePropsNames: extracts a single name', () => {
+	assert.deepEqual( parsePropsNames( 'Props alice.' ), [ 'alice' ] );
+} );
 
-test('parsePropsNames: extracts multiple comma-separated names', () => {
-  assert.deepEqual(parsePropsNames('Props alice, bob, carol.'), ['alice', 'bob', 'carol']);
-});
+test( 'parsePropsNames: extracts multiple comma-separated names', () => {
+	assert.deepEqual( parsePropsNames( 'Props alice, bob, carol.' ), [
+		'alice',
+		'bob',
+		'carol',
+	] );
+} );
 
-test('parsePropsNames: returns empty array when no Props line is present', () => {
-  assert.deepEqual(parsePropsNames('No props here.'), []);
-});
+test( 'parsePropsNames: returns empty array when no Props line is present', () => {
+	assert.deepEqual( parsePropsNames( 'No props here.' ), [] );
+} );
 
-test('parsePropsNames: handles Props line embedded in a longer comment body', () => {
-  const body = [
-    'Thank you for the contribution!',
-    '',
-    'Props alice, bob.',
-    '',
-    '## Unlinked Accounts',
-  ].join('\n');
-  assert.deepEqual(parsePropsNames(body), ['alice', 'bob']);
-});
+test( 'parsePropsNames: handles Props line embedded in a longer comment body', () => {
+	const body = [
+		'Thank you for the contribution!',
+		'',
+		'Props alice, bob.',
+		'',
+		'## Unlinked Accounts',
+	].join( '\n' );
+	assert.deepEqual( parsePropsNames( body ), [ 'alice', 'bob' ] );
+} );
 
-test('parsePropsNames: trims whitespace around names', () => {
-  assert.deepEqual(parsePropsNames('Props  alice ,  bob .'), ['alice', 'bob']);
-});
+test( 'parsePropsNames: trims whitespace around names', () => {
+	assert.deepEqual( parsePropsNames( 'Props  alice ,  bob .' ), [
+		'alice',
+		'bob',
+	] );
+} );
 
 // ---------------------------------------------------------------------------
 // parseUnlinkedLogins
 // ---------------------------------------------------------------------------
 
-test('parseUnlinkedLogins: extracts the logins, stripping the @ and ignoring the period in WordPress.org', () => {
-  const body = propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh', 'bob', 'carol99'] });
-  assert.deepEqual(parseUnlinkedLogins(body), ['alice-gh', 'bob', 'carol99']);
-});
+test( 'parseUnlinkedLogins: extracts the logins, stripping the @ and ignoring the period in WordPress.org', () => {
+	const body = propsBotBody( {
+		svn: [ 'joefusco' ],
+		unlinked: [ 'alice-gh', 'bob', 'carol99' ],
+	} );
+	assert.deepEqual( parseUnlinkedLogins( body ), [
+		'alice-gh',
+		'bob',
+		'carol99',
+	] );
+} );
 
-test('parseUnlinkedLogins: returns empty array when there is no unlinked section', () => {
-  assert.deepEqual(parseUnlinkedLogins(propsBotBody({ svn: ['alice'] })), []);
-});
+test( 'parseUnlinkedLogins: returns empty array when there is no unlinked section', () => {
+	assert.deepEqual(
+		parseUnlinkedLogins( propsBotBody( { svn: [ 'alice' ] } ) ),
+		[]
+	);
+} );
 
 // ---------------------------------------------------------------------------
 // isPropsBotComment
 // ---------------------------------------------------------------------------
 
-test('isPropsBotComment: matches a comment that only has an unlinked section', () => {
-  // props-bot omits the SVN block when nobody is linked, so there is no
-  // "Props " anywhere in the body.
-  const body = propsBotBody({ unlinked: ['alice-gh'] });
-  assert.ok(!body.includes('Props '));
-  assert.ok(isPropsBotComment(propsComment(body)));
-});
+test( 'isPropsBotComment: matches a comment that only has an unlinked section', () => {
+	// props-bot omits the SVN block when nobody is linked, so there is no
+	// "Props " anywhere in the body.
+	const body = propsBotBody( { unlinked: [ 'alice-gh' ] } );
+	assert.ok( ! body.includes( 'Props ' ) );
+	assert.ok( isPropsBotComment( propsComment( body ) ) );
+} );
 
 // ---------------------------------------------------------------------------
 // resolveWPOrgLogins
 // ---------------------------------------------------------------------------
 
-test('resolveWPOrgLogins: returns slugs for logins that resolve and drops the rest', async () => {
-  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
-  assert.deepEqual(
-    await resolveWPOrgLogins(['alice-gh', 'bob'], { userAgent: 'test', fetchImpl }),
-    ['alice']
-  );
-});
+test( 'resolveWPOrgLogins: returns slugs for logins that resolve and drops the rest', async () => {
+	const fetchImpl = fakeLookup( { 'alice-gh': 'alice' } );
+	assert.deepEqual(
+		await resolveWPOrgLogins( [ 'alice-gh', 'bob' ], {
+			userAgent: 'test',
+			fetchImpl,
+		} ),
+		[ 'alice' ]
+	);
+} );
 
-test('resolveWPOrgLogins: throws when the endpoint fails', async () => {
-  const fetchImpl = fakeLookup({}, { ok: false, status: 503 });
-  await assert.rejects(
-    () => resolveWPOrgLogins(['alice-gh'], { userAgent: 'test', fetchImpl }),
-    /503/
-  );
-});
+test( 'resolveWPOrgLogins: throws when the endpoint fails', async () => {
+	const fetchImpl = fakeLookup( {}, { ok: false, status: 503 } );
+	await assert.rejects(
+		() =>
+			resolveWPOrgLogins( [ 'alice-gh' ], {
+				userAgent: 'test',
+				fetchImpl,
+			} ),
+		/503/
+	);
+} );
 
 // ---------------------------------------------------------------------------
 // findCutoff
 // ---------------------------------------------------------------------------
 
-test('findCutoff: returns the newest published plugin release', () => {
-  assert.equal(
-    findCutoff([
-      makeRelease('v0.1.8', '2026-07-24T17:51:03Z'),
-      makeRelease('v0.1.9', '2026-07-26T15:22:39Z'),
-    ]),
-    '2026-07-26T15:22:39Z'
-  );
-});
+test( 'findCutoff: returns the newest published plugin release', () => {
+	assert.equal(
+		findCutoff( [
+			makeRelease( 'v0.1.8', '2026-07-24T17:51:03Z' ),
+			makeRelease( 'v0.1.9', '2026-07-26T15:22:39Z' ),
+		] ),
+		'2026-07-26T15:22:39Z'
+	);
+} );
 
-test('findCutoff: ignores Playground preview releases', () => {
-  assert.equal(
-    findCutoff([
-      makeRelease('preview-pr-149', '2026-07-27T18:01:25Z'),
-      makeRelease('v0.1.9', '2026-07-26T15:22:39Z'),
-    ]),
-    '2026-07-26T15:22:39Z'
-  );
-});
+test( 'findCutoff: ignores Playground preview releases', () => {
+	assert.equal(
+		findCutoff( [
+			makeRelease( 'preview-pr-149', '2026-07-27T18:01:25Z' ),
+			makeRelease( 'v0.1.9', '2026-07-26T15:22:39Z' ),
+		] ),
+		'2026-07-26T15:22:39Z'
+	);
+} );
 
-test('findCutoff: ignores draft releases', () => {
-  assert.equal(
-    findCutoff([
-      makeRelease('v0.2.0', '2026-08-01T00:00:00Z', true),
-      makeRelease('v0.1.9', '2026-07-26T15:22:39Z'),
-    ]),
-    '2026-07-26T15:22:39Z'
-  );
-});
+test( 'findCutoff: ignores draft releases', () => {
+	assert.equal(
+		findCutoff( [
+			makeRelease( 'v0.2.0', '2026-08-01T00:00:00Z', true ),
+			makeRelease( 'v0.1.9', '2026-07-26T15:22:39Z' ),
+		] ),
+		'2026-07-26T15:22:39Z'
+	);
+} );
 
-test('findCutoff: returns undefined when there is no published release', () => {
-  assert.equal(findCutoff([makeRelease('preview-pr-1', '2026-07-01T00:00:00Z')]), undefined);
-  assert.equal(findCutoff([]), undefined);
-});
+test( 'findCutoff: returns undefined when there is no published release', () => {
+	assert.equal(
+		findCutoff( [ makeRelease( 'preview-pr-1', '2026-07-01T00:00:00Z' ) ] ),
+		undefined
+	);
+	assert.equal( findCutoff( [] ), undefined );
+} );
 
 // ---------------------------------------------------------------------------
 // sortProps
 // ---------------------------------------------------------------------------
 
-test('sortProps: deduplicates repeated names', () => {
-  assert.deepEqual(sortProps(['alice', 'bob', 'alice'], ''), ['alice', 'bob']);
-});
+test( 'sortProps: deduplicates repeated names', () => {
+	assert.deepEqual( sortProps( [ 'alice', 'bob', 'alice' ], '' ), [
+		'alice',
+		'bob',
+	] );
+} );
 
-test('sortProps: moves sortLast to the end', () => {
-  assert.deepEqual(
-    sortProps(['alice', 'maintainer', 'bob'], 'maintainer'),
-    ['alice', 'bob', 'maintainer']
-  );
-});
+test( 'sortProps: moves sortLast to the end', () => {
+	assert.deepEqual(
+		sortProps( [ 'alice', 'maintainer', 'bob' ], 'maintainer' ),
+		[ 'alice', 'bob', 'maintainer' ]
+	);
+} );
 
-test('sortProps: leaves order unchanged when sortLast is not in the list', () => {
-  assert.deepEqual(sortProps(['alice', 'bob'], 'maintainer'), ['alice', 'bob']);
-});
+test( 'sortProps: leaves order unchanged when sortLast is not in the list', () => {
+	assert.deepEqual( sortProps( [ 'alice', 'bob' ], 'maintainer' ), [
+		'alice',
+		'bob',
+	] );
+} );
 
-test('sortProps: leaves order unchanged when sortLast is empty string', () => {
-  assert.deepEqual(sortProps(['alice', 'bob', 'carol'], ''), ['alice', 'bob', 'carol']);
-});
+test( 'sortProps: leaves order unchanged when sortLast is empty string', () => {
+	assert.deepEqual( sortProps( [ 'alice', 'bob', 'carol' ], '' ), [
+		'alice',
+		'bob',
+		'carol',
+	] );
+} );
 
-test('sortProps: deduplicates before applying sortLast', () => {
-  assert.deepEqual(
-    sortProps(['maintainer', 'alice', 'maintainer', 'bob'], 'maintainer'),
-    ['alice', 'bob', 'maintainer']
-  );
-});
+test( 'sortProps: deduplicates before applying sortLast', () => {
+	assert.deepEqual(
+		sortProps(
+			[ 'maintainer', 'alice', 'maintainer', 'bob' ],
+			'maintainer'
+		),
+		[ 'alice', 'bob', 'maintainer' ]
+	);
+} );
 
 // ---------------------------------------------------------------------------
 // buildComment
 // ---------------------------------------------------------------------------
 
-test('buildComment: starts with the sticky marker', () => {
-  assert.ok(buildComment(['alice', 'bob']).startsWith(MARKER));
-});
+test( 'buildComment: starts with the sticky marker', () => {
+	assert.ok( buildComment( [ 'alice', 'bob' ] ).startsWith( MARKER ) );
+} );
 
-test('buildComment: formats the Props line correctly', () => {
-  assert.ok(buildComment(['alice', 'bob']).includes('Props alice, bob.'));
-});
+test( 'buildComment: formats the Props line correctly', () => {
+	assert.ok(
+		buildComment( [ 'alice', 'bob' ] ).includes( 'Props alice, bob.' )
+	);
+} );
 
-test('buildComment: wraps the Props line in a fenced code block', () => {
-  assert.ok(buildComment(['alice', 'bob']).includes('```\nProps alice, bob.\n```'));
-});
+test( 'buildComment: wraps the Props line in a fenced code block', () => {
+	assert.ok(
+		buildComment( [ 'alice', 'bob' ] ).includes(
+			'```\nProps alice, bob.\n```'
+		)
+	);
+} );
 
-test('buildComment: keeps the props line parseable by parsePropsNames', () => {
-  assert.deepEqual(parsePropsNames(buildComment(['alice', 'bob'])), ['alice', 'bob']);
-});
+test( 'buildComment: keeps the props line parseable by parsePropsNames', () => {
+	assert.deepEqual( parsePropsNames( buildComment( [ 'alice', 'bob' ] ) ), [
+		'alice',
+		'bob',
+	] );
+} );
 
 // ---------------------------------------------------------------------------
 // run()
 // ---------------------------------------------------------------------------
 
-test('run: creates a new comment when no sticky comment exists', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment('Props alice, bob.')],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: () => {}, setFailed: mock.fn() };
+test( 'run: creates a new comment when no sticky comment exists', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [ propsComment( 'Props alice, bob.' ) ],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: () => {}, setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv() });
+	await run( { github, context, core, env: makeEnv() } );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 1);
-  const { issue_number, body } = github.rest.issues.createComment.mock.calls[0].arguments[0];
-  assert.equal(issue_number, RELEASE_PR);
-  assert.ok(body.startsWith(MARKER));
-  assert.ok(body.includes('Props alice, bob.'));
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 1 );
+	const { issue_number, body } =
+		github.rest.issues.createComment.mock.calls[ 0 ].arguments[ 0 ];
+	assert.equal( issue_number, RELEASE_PR );
+	assert.ok( body.startsWith( MARKER ) );
+	assert.ok( body.includes( 'Props alice, bob.' ) );
+} );
 
-test('run: updates an existing sticky comment', async () => {
-  const stale = { id: 55, user: { login: 'github-actions[bot]' }, body: `${MARKER}\n\nProps old.` };
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment('Props carol.')],
-      [RELEASE_PR]: [stale],
-    },
-  });
-  const core = { info: () => {}, setFailed: mock.fn() };
+test( 'run: updates an existing sticky comment', async () => {
+	const stale = {
+		id: 55,
+		user: { login: 'github-actions[bot]' },
+		body: `${ MARKER }\n\nProps old.`,
+	};
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [ propsComment( 'Props carol.' ) ],
+			[ RELEASE_PR ]: [ stale ],
+		},
+	} );
+	const core = { info: () => {}, setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv() });
+	await run( { github, context, core, env: makeEnv() } );
 
-  assert.equal(github.rest.issues.updateComment.mock.calls.length, 1);
-  const { comment_id, body } = github.rest.issues.updateComment.mock.calls[0].arguments[0];
-  assert.equal(comment_id, 55);
-  assert.ok(body.includes('Props carol.'));
-});
+	assert.equal( github.rest.issues.updateComment.mock.calls.length, 1 );
+	const { comment_id, body } =
+		github.rest.issues.updateComment.mock.calls[ 0 ].arguments[ 0 ];
+	assert.equal( comment_id, 55 );
+	assert.ok( body.includes( 'Props carol.' ) );
+} );
 
-test('run: skips posting when no merged PRs have props comments', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: { 10: [], [RELEASE_PR]: [] },
-  });
-  const core = { info: mock.fn(), setFailed: mock.fn() };
+test( 'run: skips posting when no merged PRs have props comments', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: { 10: [], [ RELEASE_PR ]: [] },
+	} );
+	const core = { info: mock.fn(), setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv() });
+	await run( { github, context, core, env: makeEnv() } );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
-  assert.equal(github.rest.issues.updateComment.mock.calls.length, 0);
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 0 );
+	assert.equal( github.rest.issues.updateComment.mock.calls.length, 0 );
+} );
 
-test('run: excludes PRs merged before the cutoff date', async () => {
-  const github = buildGithub({
-    releases: [makeRelease('v0.1.9', '2026-07-15T00:00:00Z')],
-    prs: [makePR(10, 'feature/old', '2026-07-01T00:00:00Z')],
-    commentsByPR: {
-      10: [propsComment('Props alice.')],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), setFailed: mock.fn() };
+test( 'run: excludes PRs merged before the cutoff date', async () => {
+	const github = buildGithub( {
+		releases: [ makeRelease( 'v0.1.9', '2026-07-15T00:00:00Z' ) ],
+		prs: [ makePR( 10, 'feature/old', '2026-07-01T00:00:00Z' ) ],
+		commentsByPR: {
+			10: [ propsComment( 'Props alice.' ) ],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv() });
+	await run( { github, context, core, env: makeEnv() } );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 0 );
+} );
 
-test('run: excludes the release PR itself', async () => {
-  const github = buildGithub({
-    prs: [makePR(RELEASE_PR, 'feature/foo')],
-    commentsByPR: { [RELEASE_PR]: [propsComment('Props alice.')] },
-  });
-  const core = { info: mock.fn(), setFailed: mock.fn() };
+test( 'run: excludes the release PR itself', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( RELEASE_PR, 'feature/foo' ) ],
+		commentsByPR: { [ RELEASE_PR ]: [ propsComment( 'Props alice.' ) ] },
+	} );
+	const core = { info: mock.fn(), setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv() });
+	await run( { github, context, core, env: makeEnv() } );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 0 );
+} );
 
-test('run: excludes release-please-- and docs/add- branches', async () => {
-  const github = buildGithub({
-    prs: [
-      makePR(20, 'release-please--branches--main'),
-      makePR(21, 'docs/add-alice-to-contributors'),
-    ],
-    commentsByPR: {
-      20: [propsComment('Props alice.')],
-      21: [propsComment('Props bob.')],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), setFailed: mock.fn() };
+test( 'run: excludes release-please-- and docs/add- branches', async () => {
+	const github = buildGithub( {
+		prs: [
+			makePR( 20, 'release-please--branches--main' ),
+			makePR( 21, 'docs/add-alice-to-contributors' ),
+		],
+		commentsByPR: {
+			20: [ propsComment( 'Props alice.' ) ],
+			21: [ propsComment( 'Props bob.' ) ],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv() });
+	await run( { github, context, core, env: makeEnv() } );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 0 );
+} );
 
-test('run: applies PROPS_SORT_LAST and deduplicates across PRs', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo'), makePR(11, 'feature/bar')],
-    commentsByPR: {
-      10: [propsComment('Props alice, maintainer.')],
-      11: [propsComment('Props bob, alice.')],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: () => {}, setFailed: mock.fn() };
+test( 'run: applies PROPS_SORT_LAST and deduplicates across PRs', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ), makePR( 11, 'feature/bar' ) ],
+		commentsByPR: {
+			10: [ propsComment( 'Props alice, maintainer.' ) ],
+			11: [ propsComment( 'Props bob, alice.' ) ],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: () => {}, setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv({ PROPS_SORT_LAST: 'maintainer' }) });
+	await run( {
+		github,
+		context,
+		core,
+		env: makeEnv( { PROPS_SORT_LAST: 'maintainer' } ),
+	} );
 
-  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
-  assert.ok(body.includes('Props alice, bob, maintainer.'));
-});
+	const body =
+		github.rest.issues.createComment.mock.calls[ 0 ].arguments[ 0 ].body;
+	assert.ok( body.includes( 'Props alice, bob, maintainer.' ) );
+} );
 
-test('run: falls back to the open release PR when PR_NUMBER is absent', async () => {
-  const github = buildGithub({
-    openPRs: [
-      { number: 7, head: { ref: 'feature/unrelated' } },
-      { number: RELEASE_PR, head: { ref: 'release-please--branches--main' } },
-    ],
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment('Props alice.')],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: () => {}, setFailed: mock.fn() };
+test( 'run: falls back to the open release PR when PR_NUMBER is absent', async () => {
+	const github = buildGithub( {
+		openPRs: [
+			{ number: 7, head: { ref: 'feature/unrelated' } },
+			{
+				number: RELEASE_PR,
+				head: { ref: 'release-please--branches--main' },
+			},
+		],
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [ propsComment( 'Props alice.' ) ],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: () => {}, setFailed: mock.fn() };
 
-  await run({ github, context, core, env: { PR_NUMBER: '', PROPS_SORT_LAST: '' } });
+	await run( {
+		github,
+		context,
+		core,
+		env: { PR_NUMBER: '', PROPS_SORT_LAST: '' },
+	} );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 1);
-  assert.equal(
-    github.rest.issues.createComment.mock.calls[0].arguments[0].issue_number,
-    RELEASE_PR
-  );
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 1 );
+	assert.equal(
+		github.rest.issues.createComment.mock.calls[ 0 ].arguments[ 0 ]
+			.issue_number,
+		RELEASE_PR
+	);
+} );
 
 // ---------------------------------------------------------------------------
 // run(): recovering contributors who linked after their pull request merged
 // ---------------------------------------------------------------------------
 
-test('run: credits a contributor who linked after their pull request merged', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
-  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+test( 'run: credits a contributor who linked after their pull request merged', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [
+				propsComment(
+					propsBotBody( {
+						svn: [ 'joefusco' ],
+						unlinked: [ 'alice-gh' ],
+					} )
+				),
+			],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+	const fetchImpl = fakeLookup( { 'alice-gh': 'alice' } );
 
-  await run({ github, context, core, env: makeEnv(), fetchImpl });
+	await run( { github, context, core, env: makeEnv(), fetchImpl } );
 
-  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
-  assert.ok(body.includes('Props joefusco, alice.'));
-});
+	const body =
+		github.rest.issues.createComment.mock.calls[ 0 ].arguments[ 0 ].body;
+	assert.ok( body.includes( 'Props joefusco, alice.' ) );
+} );
 
-test('run: credits a contributor whose pull request had no props line at all', async () => {
-  // Nobody on the pull request was linked at merge time, so props-bot wrote an
-  // unlinked section and no SVN block.
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ unlinked: ['alice-gh'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
-  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+test( 'run: credits a contributor whose pull request had no props line at all', async () => {
+	// Nobody on the pull request was linked at merge time, so props-bot wrote an
+	// unlinked section and no SVN block.
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [
+				propsComment( propsBotBody( { unlinked: [ 'alice-gh' ] } ) ),
+			],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+	const fetchImpl = fakeLookup( { 'alice-gh': 'alice' } );
 
-  await run({ github, context, core, env: makeEnv(), fetchImpl });
+	await run( { github, context, core, env: makeEnv(), fetchImpl } );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 1);
-  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
-  assert.ok(body.includes('Props alice.'));
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 1 );
+	const body =
+		github.rest.issues.createComment.mock.calls[ 0 ].arguments[ 0 ].body;
+	assert.ok( body.includes( 'Props alice.' ) );
+} );
 
-test('run: posts nothing when every contributor is still unlinked', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ unlinked: ['alice-gh'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+test( 'run: posts nothing when every contributor is still unlinked', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [
+				propsComment( propsBotBody( { unlinked: [ 'alice-gh' ] } ) ),
+			],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
 
-  await run({ github, context, core, env: makeEnv(), fetchImpl: fakeLookup() });
+	await run( {
+		github,
+		context,
+		core,
+		env: makeEnv(),
+		fetchImpl: fakeLookup(),
+	} );
 
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
-  assert.equal(github.rest.issues.updateComment.mock.calls.length, 0);
-});
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 0 );
+	assert.equal( github.rest.issues.updateComment.mock.calls.length, 0 );
+} );
 
-test('run: does not call WordPress.org when nobody is unlinked', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ svn: ['alice'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
-  const fetchImpl = fakeLookup();
+test( 'run: does not call WordPress.org when nobody is unlinked', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [ propsComment( propsBotBody( { svn: [ 'alice' ] } ) ) ],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+	const fetchImpl = fakeLookup();
 
-  await run({ github, context, core, env: makeEnv(), fetchImpl });
+	await run( { github, context, core, env: makeEnv(), fetchImpl } );
 
-  assert.equal(fetchImpl.mock.calls.length, 0);
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 1);
-});
+	assert.equal( fetchImpl.mock.calls.length, 0 );
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 1 );
+} );
 
-test('run: still posts known props when the WordPress.org lookup fails', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+test( 'run: still posts known props when the WordPress.org lookup fails', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: {
+			10: [
+				propsComment(
+					propsBotBody( {
+						svn: [ 'joefusco' ],
+						unlinked: [ 'alice-gh' ],
+					} )
+				),
+			],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
 
-  await run({
-    github, context, core,
-    env: makeEnv(),
-    fetchImpl: fakeLookup({}, { ok: false, status: 503 }),
-  });
+	await run( {
+		github,
+		context,
+		core,
+		env: makeEnv(),
+		fetchImpl: fakeLookup( {}, { ok: false, status: 503 } ),
+	} );
 
-  assert.equal(core.warning.mock.calls.length, 1);
-  assert.equal(core.setFailed.mock.calls.length, 0);
-  const body = github.rest.issues.createComment.mock.calls[0].arguments[0].body;
-  assert.ok(body.includes('Props joefusco.'));
-});
+	assert.equal( core.warning.mock.calls.length, 1 );
+	assert.equal( core.setFailed.mock.calls.length, 0 );
+	const body =
+		github.rest.issues.createComment.mock.calls[ 0 ].arguments[ 0 ].body;
+	assert.ok( body.includes( 'Props joefusco.' ) );
+} );
 
-test('run: asks WordPress.org about each unlinked login only once', async () => {
-  const github = buildGithub({
-    prs: [makePR(10, 'feature/foo'), makePR(11, 'feature/bar')],
-    commentsByPR: {
-      10: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
-      11: [propsComment(propsBotBody({ svn: ['joefusco'], unlinked: ['alice-gh'] }))],
-      [RELEASE_PR]: [],
-    },
-  });
-  const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
-  const fetchImpl = fakeLookup({ 'alice-gh': 'alice' });
+test( 'run: asks WordPress.org about each unlinked login only once', async () => {
+	const github = buildGithub( {
+		prs: [ makePR( 10, 'feature/foo' ), makePR( 11, 'feature/bar' ) ],
+		commentsByPR: {
+			10: [
+				propsComment(
+					propsBotBody( {
+						svn: [ 'joefusco' ],
+						unlinked: [ 'alice-gh' ],
+					} )
+				),
+			],
+			11: [
+				propsComment(
+					propsBotBody( {
+						svn: [ 'joefusco' ],
+						unlinked: [ 'alice-gh' ],
+					} )
+				),
+			],
+			[ RELEASE_PR ]: [],
+		},
+	} );
+	const core = { info: mock.fn(), warning: mock.fn(), setFailed: mock.fn() };
+	const fetchImpl = fakeLookup( { 'alice-gh': 'alice' } );
 
-  await run({ github, context, core, env: makeEnv(), fetchImpl });
+	await run( { github, context, core, env: makeEnv(), fetchImpl } );
 
-  assert.equal(fetchImpl.mock.calls.length, 1);
-  const sent = JSON.parse(fetchImpl.mock.calls[0].arguments[1].body);
-  assert.deepEqual(sent.github_user, ['alice-gh']);
-});
+	assert.equal( fetchImpl.mock.calls.length, 1 );
+	const sent = JSON.parse( fetchImpl.mock.calls[ 0 ].arguments[ 1 ].body );
+	assert.deepEqual( sent.github_user, [ 'alice-gh' ] );
+} );
 
-test('run: skips when PR_NUMBER is absent and no release PR is open', async () => {
-  const github = buildGithub({
-    openPRs: [{ number: 7, head: { ref: 'feature/unrelated' } }],
-    prs: [makePR(10, 'feature/foo')],
-    commentsByPR: { 10: [propsComment('Props alice.')] },
-  });
-  const core = { info: mock.fn(), setFailed: mock.fn() };
+test( 'run: skips when PR_NUMBER is absent and no release PR is open', async () => {
+	const github = buildGithub( {
+		openPRs: [ { number: 7, head: { ref: 'feature/unrelated' } } ],
+		prs: [ makePR( 10, 'feature/foo' ) ],
+		commentsByPR: { 10: [ propsComment( 'Props alice.' ) ] },
+	} );
+	const core = { info: mock.fn(), setFailed: mock.fn() };
 
-  await run({ github, context, core, env: { PR_NUMBER: '', PROPS_SORT_LAST: '' } });
+	await run( {
+		github,
+		context,
+		core,
+		env: { PR_NUMBER: '', PROPS_SORT_LAST: '' },
+	} );
 
-  assert.equal(core.setFailed.mock.calls.length, 0);
-  assert.equal(github.rest.issues.createComment.mock.calls.length, 0);
-});
+	assert.equal( core.setFailed.mock.calls.length, 0 );
+	assert.equal( github.rest.issues.createComment.mock.calls.length, 0 );
+} );

--- a/.github/scripts/dedupe-changelog.js
+++ b/.github/scripts/dedupe-changelog.js
@@ -28,44 +28,46 @@ const HEADING = /^#{1,6}\s/;
 // The text of an entry with everything that distinguishes the two copies of
 // the same change removed, leaving the subject the conventional commit and the
 // pull request title share.
-function entryKey(line) {
-  return line.replace(SHA_LINK, '').replace(CLOSES, '').trim();
+function entryKey( line ) {
+	return line.replace( SHA_LINK, '' ).replace( CLOSES, '' ).trim();
 }
 
-function dedupeChangelog(text) {
-  const out = [];
-  // Scoped per heading, so the same subject under Features and under Bug
-  // Fixes stays in both, and two releases that each fix the same thing keep
-  // their own entry.
-  let seen = new Map();
+function dedupeChangelog( text ) {
+	const out = [];
+	// Scoped per heading, so the same subject under Features and under Bug
+	// Fixes stays in both, and two releases that each fix the same thing keep
+	// their own entry.
+	let seen = new Map();
 
-  for (const line of text.split('\n')) {
-    if (HEADING.test(line)) {
-      seen = new Map();
-      out.push(line);
-      continue;
-    }
+	for ( const line of text.split( '\n' ) ) {
+		if ( HEADING.test( line ) ) {
+			seen = new Map();
+			out.push( line );
+			continue;
+		}
 
-    if (!ENTRY.test(line)) {
-      out.push(line);
-      continue;
-    }
+		if ( ! ENTRY.test( line ) ) {
+			out.push( line );
+			continue;
+		}
 
-    const key = entryKey(line);
-    const previous = seen.get(key);
+		const key = entryKey( line );
+		const previous = seen.get( key );
 
-    if (previous === undefined) {
-      seen.set(key, out.push(line) - 1);
-      continue;
-    }
+		if ( previous === undefined ) {
+			seen.set( key, out.push( line ) - 1 );
+			continue;
+		}
 
-    // Keep whichever copy says more. The branch commit's entry is the one
-    // that carries the `closes` link, and it is always the second of the
-    // pair, so keeping the first would drop the issue reference every time.
-    if (line.length > out[previous].length) out[previous] = line;
-  }
+		// Keep whichever copy says more. The branch commit's entry is the one
+		// that carries the `closes` link, and it is always the second of the
+		// pair, so keeping the first would drop the issue reference every time.
+		if ( line.length > out[ previous ].length ) {
+			out[ previous ] = line;
+		}
+	}
 
-  return out.join('\n');
+	return out.join( '\n' );
 }
 
 module.exports = dedupeChangelog;
@@ -74,21 +76,26 @@ module.exports.entryKey = entryKey;
 
 // CLI: `node dedupe-changelog.js CHANGELOG.md`. Rewrites in place, and says
 // nothing when there was nothing to remove so the workflow log stays quiet.
-if (require.main === module) {
-  const fs = require('node:fs');
-  const file = process.argv[2];
+if ( require.main === module ) {
+	const fs = require( 'node:fs' );
+	const file = process.argv[ 2 ];
 
-  if (!file) {
-    console.error('Usage: node dedupe-changelog.js <file>');
-    process.exit(1);
-  }
+	if ( ! file ) {
+		console.error( 'Usage: node dedupe-changelog.js <file>' );
+		process.exit( 1 );
+	}
 
-  const original = fs.readFileSync(file, 'utf8');
-  const deduped = dedupeChangelog(original);
+	const original = fs.readFileSync( file, 'utf8' );
+	const deduped = dedupeChangelog( original );
 
-  if (deduped !== original) {
-    fs.writeFileSync(file, deduped);
-    const removed = original.split('\n').length - deduped.split('\n').length;
-    console.log(`Removed ${removed} duplicate changelog ${removed === 1 ? 'entry' : 'entries'} from ${file}.`);
-  }
+	if ( deduped !== original ) {
+		fs.writeFileSync( file, deduped );
+		const removed =
+			original.split( '\n' ).length - deduped.split( '\n' ).length;
+		console.log(
+			`Removed ${ removed } duplicate changelog ${
+				removed === 1 ? 'entry' : 'entries'
+			} from ${ file }.`
+		);
+	}
 }

--- a/.github/scripts/dedupe-changelog.test.js
+++ b/.github/scripts/dedupe-changelog.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const { test } = require('node:test');
-const assert = require('node:assert/strict');
+const { test } = require( 'node:test' );
+const assert = require( 'node:assert/strict' );
 
-const dedupeChangelog = require('./dedupe-changelog.js');
+const dedupeChangelog = require( './dedupe-changelog.js' );
 const { entryKey } = dedupeChangelog;
 
 // ---------------------------------------------------------------------------
@@ -13,184 +13,247 @@ const { entryKey } = dedupeChangelog;
 const COMMIT = 'https://github.com/WordPress/presence-api/commit';
 const ISSUE = 'https://github.com/WordPress/presence-api/issues';
 
-function entry(subject, sha, closes) {
-  const link = `([${sha}](${COMMIT}/${sha}))`;
-  return closes
-    ? `* ${subject} ${link}, closes [#${closes}](${ISSUE}/${closes})`
-    : `* ${subject} ${link}`;
+function entry( subject, sha, closes ) {
+	const link = `([${ sha }](${ COMMIT }/${ sha }))`;
+	return closes
+		? `* ${ subject } ${ link }, closes [#${ closes }](${ ISSUE }/${ closes })`
+		: `* ${ subject } ${ link }`;
 }
 
 // ---------------------------------------------------------------------------
 // entryKey
 // ---------------------------------------------------------------------------
 
-test('entryKey: strips the trailing commit link', () => {
-  assert.equal(entryKey(entry('fix the thing', 'abc1234')), '* fix the thing');
-});
+test( 'entryKey: strips the trailing commit link', () => {
+	assert.equal(
+		entryKey( entry( 'fix the thing', 'abc1234' ) ),
+		'* fix the thing'
+	);
+} );
 
-test('entryKey: strips the closes clause', () => {
-  assert.equal(entryKey(entry('fix the thing', 'abc1234', 141)), '* fix the thing');
-});
+test( 'entryKey: strips the closes clause', () => {
+	assert.equal(
+		entryKey( entry( 'fix the thing', 'abc1234', 141 ) ),
+		'* fix the thing'
+	);
+} );
 
-test('entryKey: matches the same subject across different shas', () => {
-  assert.equal(
-    entryKey(entry('fix the thing', 'abc1234')),
-    entryKey(entry('fix the thing', 'def5678'))
-  );
-});
+test( 'entryKey: matches the same subject across different shas', () => {
+	assert.equal(
+		entryKey( entry( 'fix the thing', 'abc1234' ) ),
+		entryKey( entry( 'fix the thing', 'def5678' ) )
+	);
+} );
 
-test('entryKey: keeps different subjects distinct', () => {
-  assert.notEqual(
-    entryKey(entry('fix the thing', 'abc1234')),
-    entryKey(entry('fix the other thing', 'abc1234'))
-  );
-});
+test( 'entryKey: keeps different subjects distinct', () => {
+	assert.notEqual(
+		entryKey( entry( 'fix the thing', 'abc1234' ) ),
+		entryKey( entry( 'fix the other thing', 'abc1234' ) )
+	);
+} );
 
 // ---------------------------------------------------------------------------
 // dedupeChangelog
 // ---------------------------------------------------------------------------
 
-test('dedupeChangelog: removes an entry duplicated by the merge commit', () => {
-  const input = [
-    '### Bug Fixes',
-    '',
-    entry('fix the thing', 'aaaaaaa'),
-    entry('fix the thing', 'bbbbbbb'),
-  ].join('\n');
+test( 'dedupeChangelog: removes an entry duplicated by the merge commit', () => {
+	const input = [
+		'### Bug Fixes',
+		'',
+		entry( 'fix the thing', 'aaaaaaa' ),
+		entry( 'fix the thing', 'bbbbbbb' ),
+	].join( '\n' );
 
-  assert.equal(
-    dedupeChangelog(input),
-    ['### Bug Fixes', '', entry('fix the thing', 'aaaaaaa')].join('\n')
-  );
-});
+	assert.equal(
+		dedupeChangelog( input ),
+		[ '### Bug Fixes', '', entry( 'fix the thing', 'aaaaaaa' ) ].join(
+			'\n'
+		)
+	);
+} );
 
-test('dedupeChangelog: keeps entries with different subjects', () => {
-  const input = [
-    '### Bug Fixes',
-    '',
-    entry('fix the thing', 'aaaaaaa'),
-    entry('fix the other thing', 'bbbbbbb'),
-  ].join('\n');
+test( 'dedupeChangelog: keeps entries with different subjects', () => {
+	const input = [
+		'### Bug Fixes',
+		'',
+		entry( 'fix the thing', 'aaaaaaa' ),
+		entry( 'fix the other thing', 'bbbbbbb' ),
+	].join( '\n' );
 
-  assert.equal(dedupeChangelog(input), input);
-});
+	assert.equal( dedupeChangelog( input ), input );
+} );
 
-test('dedupeChangelog: keeps the copy carrying the closes link', () => {
-  const input = [
-    '### Bug Fixes',
-    '',
-    entry('fix the thing', 'aaaaaaa'),
-    entry('fix the thing', 'bbbbbbb', 141),
-  ].join('\n');
+test( 'dedupeChangelog: keeps the copy carrying the closes link', () => {
+	const input = [
+		'### Bug Fixes',
+		'',
+		entry( 'fix the thing', 'aaaaaaa' ),
+		entry( 'fix the thing', 'bbbbbbb', 141 ),
+	].join( '\n' );
 
-  assert.equal(
-    dedupeChangelog(input),
-    ['### Bug Fixes', '', entry('fix the thing', 'bbbbbbb', 141)].join('\n')
-  );
-});
+	assert.equal(
+		dedupeChangelog( input ),
+		[ '### Bug Fixes', '', entry( 'fix the thing', 'bbbbbbb', 141 ) ].join(
+			'\n'
+		)
+	);
+} );
 
-test('dedupeChangelog: keeps the surviving entry in the original position', () => {
-  const input = [
-    '### Bug Fixes',
-    '',
-    entry('alpha', 'aaaaaaa'),
-    entry('alpha', 'bbbbbbb', 141),
-    entry('beta', 'ccccccc'),
-  ].join('\n');
+test( 'dedupeChangelog: keeps the surviving entry in the original position', () => {
+	const input = [
+		'### Bug Fixes',
+		'',
+		entry( 'alpha', 'aaaaaaa' ),
+		entry( 'alpha', 'bbbbbbb', 141 ),
+		entry( 'beta', 'ccccccc' ),
+	].join( '\n' );
 
-  assert.equal(
-    dedupeChangelog(input),
-    ['### Bug Fixes', '', entry('alpha', 'bbbbbbb', 141), entry('beta', 'ccccccc')].join('\n')
-  );
-});
+	assert.equal(
+		dedupeChangelog( input ),
+		[
+			'### Bug Fixes',
+			'',
+			entry( 'alpha', 'bbbbbbb', 141 ),
+			entry( 'beta', 'ccccccc' ),
+		].join( '\n' )
+	);
+} );
 
-test('dedupeChangelog: scopes deduplication to a section', () => {
-  const input = [
-    '### Features',
-    '',
-    entry('support screens', 'aaaaaaa'),
-    '',
-    '### Bug Fixes',
-    '',
-    entry('support screens', 'bbbbbbb'),
-  ].join('\n');
+test( 'dedupeChangelog: scopes deduplication to a section', () => {
+	const input = [
+		'### Features',
+		'',
+		entry( 'support screens', 'aaaaaaa' ),
+		'',
+		'### Bug Fixes',
+		'',
+		entry( 'support screens', 'bbbbbbb' ),
+	].join( '\n' );
 
-  assert.equal(dedupeChangelog(input), input);
-});
+	assert.equal( dedupeChangelog( input ), input );
+} );
 
-test('dedupeChangelog: scopes deduplication to a release', () => {
-  const input = [
-    '## [0.1.10](compare) (2026-07-27)',
-    '',
-    '### Bug Fixes',
-    '',
-    entry('fix the thing', 'aaaaaaa'),
-    '',
-    '## [0.1.9](compare) (2026-07-26)',
-    '',
-    '### Bug Fixes',
-    '',
-    entry('fix the thing', 'bbbbbbb'),
-  ].join('\n');
+test( 'dedupeChangelog: scopes deduplication to a release', () => {
+	const input = [
+		'## [0.1.10](compare) (2026-07-27)',
+		'',
+		'### Bug Fixes',
+		'',
+		entry( 'fix the thing', 'aaaaaaa' ),
+		'',
+		'## [0.1.9](compare) (2026-07-26)',
+		'',
+		'### Bug Fixes',
+		'',
+		entry( 'fix the thing', 'bbbbbbb' ),
+	].join( '\n' );
 
-  assert.equal(dedupeChangelog(input), input);
-});
+	assert.equal( dedupeChangelog( input ), input );
+} );
 
-test('dedupeChangelog: leaves already-clean text untouched', () => {
-  const input = ['# Changelog', '', '### Bug Fixes', '', entry('fix the thing', 'aaaaaaa')].join('\n');
-  assert.equal(dedupeChangelog(input), input);
-});
+test( 'dedupeChangelog: leaves already-clean text untouched', () => {
+	const input = [
+		'# Changelog',
+		'',
+		'### Bug Fixes',
+		'',
+		entry( 'fix the thing', 'aaaaaaa' ),
+	].join( '\n' );
+	assert.equal( dedupeChangelog( input ), input );
+} );
 
-test('dedupeChangelog: preserves blank lines and headings', () => {
-  const input = ['# Changelog', '', '', '## [0.1.10](compare) (2026-07-27)', '', ''].join('\n');
-  assert.equal(dedupeChangelog(input), input);
-});
+test( 'dedupeChangelog: preserves blank lines and headings', () => {
+	const input = [
+		'# Changelog',
+		'',
+		'',
+		'## [0.1.10](compare) (2026-07-27)',
+		'',
+		'',
+	].join( '\n' );
+	assert.equal( dedupeChangelog( input ), input );
+} );
 
-test('dedupeChangelog: handles empty input', () => {
-  assert.equal(dedupeChangelog(''), '');
-});
+test( 'dedupeChangelog: handles empty input', () => {
+	assert.equal( dedupeChangelog( '' ), '' );
+} );
 
-test('dedupeChangelog: ignores prose that is not a list entry', () => {
-  const input = ['Some note about the thing.', 'Some note about the thing.'].join('\n');
-  assert.equal(dedupeChangelog(input), input);
-});
+test( 'dedupeChangelog: ignores prose that is not a list entry', () => {
+	const input = [
+		'Some note about the thing.',
+		'Some note about the thing.',
+	].join( '\n' );
+	assert.equal( dedupeChangelog( input ), input );
+} );
 
-test('dedupeChangelog: reproduces the manual cleanup in 921d838', () => {
-  const input = [
-    '## [0.1.10](https://github.com/WordPress/presence-api/compare/v0.1.9...v0.1.10) (2026-07-27)',
-    '',
-    '',
-    '### Bug Fixes',
-    '',
-    entry('credit every contributor in the release props comment', 'd069193'),
-    entry('credit every contributor in the release props comment', 'dd0f7b2'),
-    entry("move the admin/online write out of the Who's Online widget", 'b7b500b', 141),
-    entry('render release props in a code block like props-bot', '3a2ae99'),
-    entry('render release props in a code block like props-bot', 'ac720d6'),
-  ].join('\n');
+test( 'dedupeChangelog: reproduces the manual cleanup in 921d838', () => {
+	const input = [
+		'## [0.1.10](https://github.com/WordPress/presence-api/compare/v0.1.9...v0.1.10) (2026-07-27)',
+		'',
+		'',
+		'### Bug Fixes',
+		'',
+		entry(
+			'credit every contributor in the release props comment',
+			'd069193'
+		),
+		entry(
+			'credit every contributor in the release props comment',
+			'dd0f7b2'
+		),
+		entry(
+			"move the admin/online write out of the Who's Online widget",
+			'b7b500b',
+			141
+		),
+		entry(
+			'render release props in a code block like props-bot',
+			'3a2ae99'
+		),
+		entry(
+			'render release props in a code block like props-bot',
+			'ac720d6'
+		),
+	].join( '\n' );
 
-  assert.equal(
-    dedupeChangelog(input),
-    [
-      '## [0.1.10](https://github.com/WordPress/presence-api/compare/v0.1.9...v0.1.10) (2026-07-27)',
-      '',
-      '',
-      '### Bug Fixes',
-      '',
-      entry('credit every contributor in the release props comment', 'd069193'),
-      entry("move the admin/online write out of the Who's Online widget", 'b7b500b', 141),
-      entry('render release props in a code block like props-bot', '3a2ae99'),
-    ].join('\n')
-  );
-});
+	assert.equal(
+		dedupeChangelog( input ),
+		[
+			'## [0.1.10](https://github.com/WordPress/presence-api/compare/v0.1.9...v0.1.10) (2026-07-27)',
+			'',
+			'',
+			'### Bug Fixes',
+			'',
+			entry(
+				'credit every contributor in the release props comment',
+				'd069193'
+			),
+			entry(
+				"move the admin/online write out of the Who's Online widget",
+				'b7b500b',
+				141
+			),
+			entry(
+				'render release props in a code block like props-bot',
+				'3a2ae99'
+			),
+		].join( '\n' )
+	);
+} );
 
-test('dedupeChangelog: leaves near-duplicate wording alone', () => {
-  const input = [
-    '### Bug Fixes',
-    '',
-    entry('use 10up action ASSETS_DIR instead of separate assets workflow', 'aaaaaaa'),
-    entry('use 10up action ASSETS_DIR, remove separate assets workflow', 'bbbbbbb'),
-  ].join('\n');
+test( 'dedupeChangelog: leaves near-duplicate wording alone', () => {
+	const input = [
+		'### Bug Fixes',
+		'',
+		entry(
+			'use 10up action ASSETS_DIR instead of separate assets workflow',
+			'aaaaaaa'
+		),
+		entry(
+			'use 10up action ASSETS_DIR, remove separate assets workflow',
+			'bbbbbbb'
+		),
+	].join( '\n' );
 
-  assert.equal(dedupeChangelog(input), input);
-});
+	assert.equal( dedupeChangelog( input ), input );
+} );

--- a/.github/scripts/detect-public-surface.js
+++ b/.github/scripts/detect-public-surface.js
@@ -10,92 +10,218 @@
 // The plugin ships what is in these paths. `tests/` calls `apply_filters` and
 // `do_action` constantly without publishing anything, and built assets under
 // `assets/js/build/` duplicate the surfaces already counted in `src/`.
-const SCANNED = [/^includes\//, /^assets\/js\//, /^src\//, /^(presence-api|uninstall)\.php$/];
-const IGNORED = [/^assets\/js\/build\//, /\/test\//, /\.test\.js$/];
+const SCANNED = [
+	/^includes\//,
+	/^assets\/js\//,
+	/^src\//,
+	/^(presence-api|uninstall)\.php$/,
+];
+const IGNORED = [ /^assets\/js\/build\//, /\/test\//, /\.test\.js$/ ];
 
 // WordPress's own, which a plugin reads without ever owning. `ABSPATH` alone
 // opens every file in the tree, so without this the surfaces that are the
 // plugin's drown in guards that promise a site nothing. This is core's
 // documented `wp-config.php` set plus the flags it defines at run time; a name
 // core adds later belongs here too.
-const CORE_CONSTANTS = new Set([
-  // Bootstrap, paths, and URLs.
-  'ABSPATH', 'WPINC', 'WP_LANG_DIR', 'WP_CONTENT_DIR', 'WP_CONTENT_URL',
-  'WP_PLUGIN_DIR', 'WP_PLUGIN_URL', 'WPMU_PLUGIN_DIR', 'WPMU_PLUGIN_URL',
-  'WP_TEMP_DIR', 'WP_HOME', 'WP_SITEURL', 'UPLOADS', 'TEMPLATEPATH',
-  'STYLESHEETPATH', 'WP_DEFAULT_THEME', 'WP_USE_THEMES', 'SHORTINIT',
-  // Debugging and asset loading.
-  'WP_DEBUG', 'WP_DEBUG_LOG', 'WP_DEBUG_DISPLAY', 'SCRIPT_DEBUG', 'SAVEQUERIES',
-  'WP_DISABLE_FATAL_ERROR_HANDLER', 'WP_START_TIMESTAMP', 'WP_MEMORY_LIMIT',
-  'WP_MAX_MEMORY_LIMIT', 'CONCATENATE_SCRIPTS', 'COMPRESS_SCRIPTS',
-  'COMPRESS_CSS', 'ENFORCE_GZIP',
-  // Which kind of request this is.
-  'DOING_AJAX', 'DOING_CRON', 'DOING_AUTOSAVE', 'REST_REQUEST', 'XMLRPC_REQUEST',
-  'WP_ADMIN', 'WP_BLOG_ADMIN', 'WP_NETWORK_ADMIN', 'WP_USER_ADMIN', 'WP_CLI',
-  'WP_INSTALLING', 'WP_INSTALLING_NETWORK', 'WP_SETUP_CONFIG', 'WP_REPAIRING',
-  'WP_ALLOW_REPAIR', 'WP_SANDBOX_SCRAPING', 'WP_UNINSTALL_PLUGIN',
-  'WP_LOAD_IMPORTERS', 'WP_IMPORTING', 'IS_PROFILE_PAGE', 'WP_RUN_CORE_TESTS',
-  // Multisite.
-  'MULTISITE', 'WP_ALLOW_MULTISITE', 'SUBDOMAIN_INSTALL', 'VHOST', 'SUNRISE',
-  'DOMAIN_CURRENT_SITE', 'PATH_CURRENT_SITE', 'SITE_ID_CURRENT_SITE',
-  'BLOG_ID_CURRENT_SITE', 'NOBLOGREDIRECT', 'UPLOADBLOGSDIR', 'BLOGUPLOADDIR',
-  'WPMU_ACCEL_REDIRECT', 'WPMU_SENDFILE',
-  // Cron.
-  'DISABLE_WP_CRON', 'ALTERNATE_WP_CRON', 'WP_CRON_LOCK_TIMEOUT',
-  // Updates and the filesystem API.
-  'WP_AUTO_UPDATE_CORE', 'AUTOMATIC_UPDATER_DISABLED',
-  'CORE_UPGRADE_SKIP_NEW_BUNDLED', 'DISALLOW_FILE_EDIT', 'DISALLOW_FILE_MODS',
-  'DISALLOW_UNFILTERED_HTML', 'ALLOW_UNFILTERED_UPLOADS', 'FS_METHOD',
-  'FS_CHMOD_DIR', 'FS_CHMOD_FILE', 'FTP_BASE', 'FTP_CONTENT_DIR',
-  'FTP_PLUGIN_DIR', 'FTP_HOST', 'FTP_USER', 'FTP_PASS', 'FTP_SSL', 'FTP_PUBKEY',
-  'FTP_PRIKEY',
-  // Content and editing.
-  'EMPTY_TRASH_DAYS', 'AUTOSAVE_INTERVAL', 'WP_POST_REVISIONS', 'MEDIA_TRASH',
-  'IMAGE_EDIT_OVERWRITE',
-  // Database.
-  'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'DB_CHARSET', 'DB_COLLATE',
-  'CUSTOM_USER_TABLE', 'CUSTOM_USER_META_TABLE',
-  // Cookies, keys, and salts.
-  'FORCE_SSL_ADMIN', 'FORCE_SSL_LOGIN', 'COOKIE_DOMAIN', 'COOKIEPATH',
-  'SITECOOKIEPATH', 'ADMIN_COOKIE_PATH', 'PLUGINS_COOKIE_PATH', 'COOKIEHASH',
-  'AUTH_COOKIE', 'SECURE_AUTH_COOKIE', 'LOGGED_IN_COOKIE', 'TEST_COOKIE',
-  'USER_COOKIE', 'PASS_COOKIE', 'RECOVERY_MODE_COOKIE', 'RECOVERY_MODE_EMAIL',
-  'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY', 'AUTH_SALT',
-  'SECURE_AUTH_SALT', 'LOGGED_IN_SALT', 'NONCE_SALT',
-  // Caching and environment.
-  'WP_CACHE', 'WP_CACHE_KEY_SALT', 'WP_ENVIRONMENT_TYPE', 'WP_DEVELOPMENT_MODE',
-  'WP_LOCAL_DEV',
-  // Localization.
-  'WPLANG', 'WP_LANG',
-  // The time and byte spans core defines for everyone.
-  'MINUTE_IN_SECONDS', 'HOUR_IN_SECONDS', 'DAY_IN_SECONDS', 'WEEK_IN_SECONDS',
-  'MONTH_IN_SECONDS', 'YEAR_IN_SECONDS', 'KB_IN_BYTES', 'MB_IN_BYTES',
-  'GB_IN_BYTES', 'TB_IN_BYTES', 'PB_IN_BYTES', 'EB_IN_BYTES', 'ZB_IN_BYTES',
-  'YB_IN_BYTES',
-]);
+const CORE_CONSTANTS = new Set( [
+	// Bootstrap, paths, and URLs.
+	'ABSPATH',
+	'WPINC',
+	'WP_LANG_DIR',
+	'WP_CONTENT_DIR',
+	'WP_CONTENT_URL',
+	'WP_PLUGIN_DIR',
+	'WP_PLUGIN_URL',
+	'WPMU_PLUGIN_DIR',
+	'WPMU_PLUGIN_URL',
+	'WP_TEMP_DIR',
+	'WP_HOME',
+	'WP_SITEURL',
+	'UPLOADS',
+	'TEMPLATEPATH',
+	'STYLESHEETPATH',
+	'WP_DEFAULT_THEME',
+	'WP_USE_THEMES',
+	'SHORTINIT',
+	// Debugging and asset loading.
+	'WP_DEBUG',
+	'WP_DEBUG_LOG',
+	'WP_DEBUG_DISPLAY',
+	'SCRIPT_DEBUG',
+	'SAVEQUERIES',
+	'WP_DISABLE_FATAL_ERROR_HANDLER',
+	'WP_START_TIMESTAMP',
+	'WP_MEMORY_LIMIT',
+	'WP_MAX_MEMORY_LIMIT',
+	'CONCATENATE_SCRIPTS',
+	'COMPRESS_SCRIPTS',
+	'COMPRESS_CSS',
+	'ENFORCE_GZIP',
+	// Which kind of request this is.
+	'DOING_AJAX',
+	'DOING_CRON',
+	'DOING_AUTOSAVE',
+	'REST_REQUEST',
+	'XMLRPC_REQUEST',
+	'WP_ADMIN',
+	'WP_BLOG_ADMIN',
+	'WP_NETWORK_ADMIN',
+	'WP_USER_ADMIN',
+	'WP_CLI',
+	'WP_INSTALLING',
+	'WP_INSTALLING_NETWORK',
+	'WP_SETUP_CONFIG',
+	'WP_REPAIRING',
+	'WP_ALLOW_REPAIR',
+	'WP_SANDBOX_SCRAPING',
+	'WP_UNINSTALL_PLUGIN',
+	'WP_LOAD_IMPORTERS',
+	'WP_IMPORTING',
+	'IS_PROFILE_PAGE',
+	'WP_RUN_CORE_TESTS',
+	// Multisite.
+	'MULTISITE',
+	'WP_ALLOW_MULTISITE',
+	'SUBDOMAIN_INSTALL',
+	'VHOST',
+	'SUNRISE',
+	'DOMAIN_CURRENT_SITE',
+	'PATH_CURRENT_SITE',
+	'SITE_ID_CURRENT_SITE',
+	'BLOG_ID_CURRENT_SITE',
+	'NOBLOGREDIRECT',
+	'UPLOADBLOGSDIR',
+	'BLOGUPLOADDIR',
+	'WPMU_ACCEL_REDIRECT',
+	'WPMU_SENDFILE',
+	// Cron.
+	'DISABLE_WP_CRON',
+	'ALTERNATE_WP_CRON',
+	'WP_CRON_LOCK_TIMEOUT',
+	// Updates and the filesystem API.
+	'WP_AUTO_UPDATE_CORE',
+	'AUTOMATIC_UPDATER_DISABLED',
+	'CORE_UPGRADE_SKIP_NEW_BUNDLED',
+	'DISALLOW_FILE_EDIT',
+	'DISALLOW_FILE_MODS',
+	'DISALLOW_UNFILTERED_HTML',
+	'ALLOW_UNFILTERED_UPLOADS',
+	'FS_METHOD',
+	'FS_CHMOD_DIR',
+	'FS_CHMOD_FILE',
+	'FTP_BASE',
+	'FTP_CONTENT_DIR',
+	'FTP_PLUGIN_DIR',
+	'FTP_HOST',
+	'FTP_USER',
+	'FTP_PASS',
+	'FTP_SSL',
+	'FTP_PUBKEY',
+	'FTP_PRIKEY',
+	// Content and editing.
+	'EMPTY_TRASH_DAYS',
+	'AUTOSAVE_INTERVAL',
+	'WP_POST_REVISIONS',
+	'MEDIA_TRASH',
+	'IMAGE_EDIT_OVERWRITE',
+	// Database.
+	'DB_NAME',
+	'DB_USER',
+	'DB_PASSWORD',
+	'DB_HOST',
+	'DB_CHARSET',
+	'DB_COLLATE',
+	'CUSTOM_USER_TABLE',
+	'CUSTOM_USER_META_TABLE',
+	// Cookies, keys, and salts.
+	'FORCE_SSL_ADMIN',
+	'FORCE_SSL_LOGIN',
+	'COOKIE_DOMAIN',
+	'COOKIEPATH',
+	'SITECOOKIEPATH',
+	'ADMIN_COOKIE_PATH',
+	'PLUGINS_COOKIE_PATH',
+	'COOKIEHASH',
+	'AUTH_COOKIE',
+	'SECURE_AUTH_COOKIE',
+	'LOGGED_IN_COOKIE',
+	'TEST_COOKIE',
+	'USER_COOKIE',
+	'PASS_COOKIE',
+	'RECOVERY_MODE_COOKIE',
+	'RECOVERY_MODE_EMAIL',
+	'AUTH_KEY',
+	'SECURE_AUTH_KEY',
+	'LOGGED_IN_KEY',
+	'NONCE_KEY',
+	'AUTH_SALT',
+	'SECURE_AUTH_SALT',
+	'LOGGED_IN_SALT',
+	'NONCE_SALT',
+	// Caching and environment.
+	'WP_CACHE',
+	'WP_CACHE_KEY_SALT',
+	'WP_ENVIRONMENT_TYPE',
+	'WP_DEVELOPMENT_MODE',
+	'WP_LOCAL_DEV',
+	// Localization.
+	'WPLANG',
+	'WP_LANG',
+	// The time and byte spans core defines for everyone.
+	'MINUTE_IN_SECONDS',
+	'HOUR_IN_SECONDS',
+	'DAY_IN_SECONDS',
+	'WEEK_IN_SECONDS',
+	'MONTH_IN_SECONDS',
+	'YEAR_IN_SECONDS',
+	'KB_IN_BYTES',
+	'MB_IN_BYTES',
+	'GB_IN_BYTES',
+	'TB_IN_BYTES',
+	'PB_IN_BYTES',
+	'EB_IN_BYTES',
+	'ZB_IN_BYTES',
+	'YB_IN_BYTES',
+] );
 
 const PHP_RULES = [
-  [
-    /\b(apply_filters|do_action)(?:_ref_array|_deprecated)?\s*\(\s*(['"])(.*?)\2/g,
-    (m) => `${'apply_filters' === m[1] ? 'filter' : 'action'}:${m[3]}`,
-  ],
-  // Every constant the plugin asks after, in either form a site can reach it:
-  // the guarded define, where a value already in `wp-config.php` wins, and the
-  // bare read of one only a site ever sets. Renaming either breaks that site.
-  [/\bdefined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1\s*\)/g, (m) => `constant:${m[2]}`],
-  // Routes are usually concatenated (`'/' . $this->rest_base . '/rooms'`), so
-  // take the whole second argument rather than the first literal inside it.
-  [/register_rest_route\s*\(\s*[^,]+,\s*([^,]+?)\s*,/g, (m) => `rest:${route(m[1])}`],
-  [/WP_CLI::add_command\s*\(\s*(['"])(.*?)\1/g, (m) => `cli:${m[2]}`],
+	[
+		/\b(apply_filters|do_action)(?:_ref_array|_deprecated)?\s*\(\s*(['"])(.*?)\2/g,
+		( m ) =>
+			`${ 'apply_filters' === m[ 1 ] ? 'filter' : 'action' }:${ m[ 3 ] }`,
+	],
+	// Every constant the plugin asks after, in either form a site can reach it:
+	// the guarded define, where a value already in `wp-config.php` wins, and the
+	// bare read of one only a site ever sets. Renaming either breaks that site.
+	[
+		/\bdefined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1\s*\)/g,
+		( m ) => `constant:${ m[ 2 ] }`,
+	],
+	// Routes are usually concatenated (`'/' . $this->rest_base . '/rooms'`), so
+	// take the whole second argument rather than the first literal inside it.
+	[
+		/register_rest_route\s*\(\s*[^,]+,\s*([^,]+?)\s*,/g,
+		( m ) => `rest:${ route( m[ 1 ] ) }`,
+	],
+	[ /WP_CLI::add_command\s*\(\s*(['"])(.*?)\1/g, ( m ) => `cli:${ m[ 2 ] }` ],
 ];
 
 const JS_RULES = [
-  [/\bwindow\.(wpPresence[\w$]*)\s*=(?!=)/g, (m) => `js-global:window.${m[1]}`],
-  [/\bwindow\.wp\.presence\.([\w$]+)\s*=(?!=)/g, (m) => `js-global:wp.presence.${m[1]}`],
-  [
-    /\b(?:wp\.hooks\.)?(applyFilters|doAction)\s*\(\s*(['"`])(.*?)\2/g,
-    (m) => `${'applyFilters' === m[1] ? 'js-filter' : 'js-action'}:${m[3]}`,
-  ],
+	[
+		/\bwindow\.(wpPresence[\w$]*)\s*=(?!=)/g,
+		( m ) => `js-global:window.${ m[ 1 ] }`,
+	],
+	[
+		/\bwindow\.wp\.presence\.([\w$]+)\s*=(?!=)/g,
+		( m ) => `js-global:wp.presence.${ m[ 1 ] }`,
+	],
+	[
+		/\b(?:wp\.hooks\.)?(applyFilters|doAction)\s*\(\s*(['"`])(.*?)\2/g,
+		( m ) =>
+			`${ 'applyFilters' === m[ 1 ] ? 'js-filter' : 'js-action' }:${
+				m[ 3 ]
+			}`,
+	],
 ];
 
 // `@access private` in PHP per core's standards, `@private` in JS.
@@ -104,13 +230,20 @@ const PRIVATE = /@(?:private\b|access\s+private\b)/;
 // The workflow greps for this literal to edit its own comment in place.
 const MARKER = '<!-- presence-api:public-surface -->';
 
-function isScanned(path) {
-  return !IGNORED.some((re) => re.test(path)) && SCANNED.some((re) => re.test(path));
+function isScanned( path ) {
+	return (
+		! IGNORED.some( ( re ) => re.test( path ) ) &&
+		SCANNED.some( ( re ) => re.test( path ) )
+	);
 }
 
 // `'/' . $this->rest_base . '/rooms'` reads back as `/$this->rest_base/rooms`.
-function route(raw) {
-  return raw.replace(/['"]/g, '').replace(/\s*\.\s*/g, '').replace(/\s+/g, ' ').trim();
+function route( raw ) {
+	return raw
+		.replace( /['"]/g, '' )
+		.replace( /\s*\.\s*/g, '' )
+		.replace( /\s+/g, ' ' )
+		.trim();
 }
 
 // The docblock directly above `index`, or an empty string when the nearest one
@@ -118,31 +251,31 @@ function route(raw) {
 // them, which covers `$ttl = apply_filters( ... )` and `window.x = function () {}`
 // while stopping a docblock from leaking onto whatever statement follows the one
 // it describes.
-function docblockAbove(source, index) {
-  const before = source.slice(0, index);
-  const close = before.lastIndexOf('*/');
+function docblockAbove( source, index ) {
+	const before = source.slice( 0, index );
+	const close = before.lastIndexOf( '*/' );
 
-  // A statement terminator or a brace between the two means the docblock
-  // belongs to something else.
-  if (-1 === close || /[;{}]/.test(before.slice(close + 2))) {
-    return '';
-  }
+	// A statement terminator or a brace between the two means the docblock
+	// belongs to something else.
+	if ( -1 === close || /[;{}]/.test( before.slice( close + 2 ) ) ) {
+		return '';
+	}
 
-  const open = before.lastIndexOf('/**', close);
+	const open = before.lastIndexOf( '/**', close );
 
-  return -1 === open ? '' : before.slice(open, close);
+	return -1 === open ? '' : before.slice( open, close );
 }
 
 // A docblock of nothing but tags is a signature, not a write-up: the bar is a
 // sentence saying what the surface is for, which is what core's code reference
 // renders. Documenting the hook where it fires beats a hand-kept list, which
 // drifts the first time nobody updates it.
-function describes(block) {
-  return block
-    .replace(/^\/\*\*/, '')
-    .split('\n')
-    .map((line) => line.replace(/^\s*\*+\s*/, '').trim())
-    .some((line) => '' !== line && !line.startsWith('@'));
+function describes( block ) {
+	return block
+		.replace( /^\/\*\*/, '' )
+		.split( '\n' )
+		.map( ( line ) => line.replace( /^\s*\*+\s*/, '' ).trim() )
+		.some( ( line ) => '' !== line && ! line.startsWith( '@' ) );
 }
 
 // The constants a body of source defines outright. A `define()` with no
@@ -151,15 +284,22 @@ function describes(block) {
 // Sources are weighed together rather than one at a time: the file that defines
 // a constant is rarely the file that reads it, and either half alone misreads
 // the other. The CLI passes the whole ref.
-function ownConstants(sources) {
-  const named = (regex) => sources.flatMap((source) => [...source.matchAll(regex)].map((m) => m[2]));
-  const own = new Set(named(/\bdefine\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g));
+function ownConstants( sources ) {
+	const named = ( regex ) =>
+		sources.flatMap( ( source ) =>
+			[ ...source.matchAll( regex ) ].map( ( m ) => m[ 2 ] )
+		);
+	const own = new Set(
+		named( /\bdefine\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g )
+	);
 
-  for (const name of named(/!\s*defined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g)) {
-    own.delete(name);
-  }
+	for ( const name of named(
+		/!\s*defined\s*\(\s*(['"])([A-Z][A-Z0-9_]*)\1/g
+	) ) {
+		own.delete( name );
+	}
 
-  return own;
+	return own;
 }
 
 // Identifiers are `kind:name` and carry no path, so the same hook found at a new
@@ -167,77 +307,91 @@ function ownConstants(sources) {
 // it describes it; a private marker in that docblock withdraws it entirely.
 // `own` names the constants something else already defines outright, which only
 // a caller holding the whole ref can know; alone, a file speaks for itself.
-function findSurfaces(source, path, own = ownConstants([source])) {
-  const rules = path.endsWith('.php') ? PHP_RULES : path.endsWith('.js') ? JS_RULES : [];
+function findSurfaces( source, path, own = ownConstants( [ source ] ) ) {
+	let rules = [];
+	if ( path.endsWith( '.php' ) ) {
+		rules = PHP_RULES;
+	} else if ( path.endsWith( '.js' ) ) {
+		rules = JS_RULES;
+	}
 
-  // A constant is only a promise if a site can set it.
-  const reachable = (id) => {
-    if (!id.startsWith('constant:')) {
-      return true;
-    }
+	// A constant is only a promise if a site can set it.
+	const reachable = ( id ) => {
+		if ( ! id.startsWith( 'constant:' ) ) {
+			return true;
+		}
 
-    const name = id.slice('constant:'.length);
+		const name = id.slice( 'constant:'.length );
 
-    return !CORE_CONSTANTS.has(name) && !own.has(name);
-  };
+		return ! CORE_CONSTANTS.has( name ) && ! own.has( name );
+	};
 
-  const found = rules.flatMap(([regex, build]) =>
-    [...source.matchAll(regex)]
-      .map((m) => ({ id: build(m), block: docblockAbove(source, m.index) }))
-      .filter(({ id }) => !id.endsWith(':') && reachable(id))
-  );
+	const found = rules.flatMap( ( [ regex, build ] ) =>
+		[ ...source.matchAll( regex ) ]
+			.map( ( m ) => ( {
+				id: build( m ),
+				block: docblockAbove( source, m.index ),
+			} ) )
+			.filter( ( { id } ) => ! id.endsWith( ':' ) && reachable( id ) )
+	);
 
-  // The marker withdraws the name, not the one occurrence carrying it: a
-  // constant declared private and consulted again later is private at the read
-  // too, and nothing is gained by making someone repeat the docblock.
-  const withdrawn = new Set(found.filter(({ block }) => PRIVATE.test(block)).map(({ id }) => id));
+	// The marker withdraws the name, not the one occurrence carrying it: a
+	// constant declared private and consulted again later is private at the read
+	// too, and nothing is gained by making someone repeat the docblock.
+	const withdrawn = new Set(
+		found
+			.filter( ( { block } ) => PRIVATE.test( block ) )
+			.map( ( { id } ) => id )
+	);
 
-  return found
-    .filter(({ id }) => !withdrawn.has(id))
-    .map(({ id, block }) => ({ id, documented: describes(block) }));
+	return found
+		.filter( ( { id } ) => ! withdrawn.has( id ) )
+		.map( ( { id, block } ) => ( { id, documented: describes( block ) } ) );
 }
 
 // Additions only. A hook fired from two places is documented once and
 // cross-referenced from the other, the way core does it, so one write-up
 // anywhere at the head covers the surface.
-function newSurfaces(base, head) {
-  const before = new Set(base.map((s) => s.id));
-  const fresh = new Map();
+function newSurfaces( base, head ) {
+	const before = new Set( base.map( ( s ) => s.id ) );
+	const fresh = new Map();
 
-  for (const { id, documented } of head) {
-    if (!before.has(id)) {
-      fresh.set(id, documented || Boolean(fresh.get(id)));
-    }
-  }
+	for ( const { id, documented } of head ) {
+		if ( ! before.has( id ) ) {
+			fresh.set( id, documented || Boolean( fresh.get( id ) ) );
+		}
+	}
 
-  return [...fresh]
-    .map(([id, documented]) => ({ id, documented }))
-    .sort((a, b) => a.id.localeCompare(b.id));
+	return [ ...fresh ]
+		.map( ( [ id, documented ] ) => ( { id, documented } ) )
+		.sort( ( a, b ) => a.id.localeCompare( b.id ) );
 }
 
 // Kind first, so every line opens on the same kind of token instead of a name
 // of arbitrary length, and what is left to do trails the name in italics so it
 // reads as an aside rather than part of the surface.
-function formatAudit(surfaces) {
-  return surfaces
-    .map(({ id, documented }) => {
-      const at = id.indexOf(':');
+function formatAudit( surfaces ) {
+	return surfaces
+		.map( ( { id, documented } ) => {
+			const at = id.indexOf( ':' );
 
-      return `- (${id.slice(0, at)}) \`${id.slice(at + 1)}\`${documented ? '' : ' - *requires documentation*'}`;
-    })
-    .join('\n');
+			return `- (${ id.slice( 0, at ) }) \`${ id.slice( at + 1 ) }\`${
+				documented ? '' : ' - *requires documentation*'
+			}`;
+		} )
+		.join( '\n' );
 }
 
 // An h3 heading, matching the Playground preview comment, so the two bots read
 // the same way down a thread.
-function formatComment(surfaces) {
-  return [
-    MARKER,
-    `### 🚩 New public surface${1 === surfaces.length ? '' : 's'}`,
-    '',
-    formatAudit(surfaces),
-    '',
-  ].join('\n');
+function formatComment( surfaces ) {
+	return [
+		MARKER,
+		`### 🚩 New public surface${ 1 === surfaces.length ? '' : 's' }`,
+		'',
+		formatAudit( surfaces ),
+		'',
+	].join( '\n' );
 }
 
 module.exports = findSurfaces;
@@ -252,52 +406,67 @@ module.exports.MARKER = MARKER;
 // CLI: `node detect-public-surface.js <base-ref> <head-ref>`. Reads both trees
 // through git, never the working directory, so the head is never checked out.
 // Writes `count` to $GITHUB_OUTPUT and the comment body to comment.md.
-if (require.main === module) {
-  const { execFileSync } = require('node:child_process');
-  const fs = require('node:fs');
+if ( require.main === module ) {
+	const { execFileSync } = require( 'node:child_process' );
+	const fs = require( 'node:fs' );
 
-  const [baseRef, headRef] = process.argv.slice(2);
+	const [ baseRef, headRef ] = process.argv.slice( 2 );
 
-  if (!baseRef || !headRef) {
-    console.error('Usage: node detect-public-surface.js <base-ref> <head-ref>');
-    process.exit(1);
-  }
+	if ( ! baseRef || ! headRef ) {
+		console.error(
+			'Usage: node detect-public-surface.js <base-ref> <head-ref>'
+		);
+		process.exit( 1 );
+	}
 
-  const git = (args) => execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+	const git = ( args ) =>
+		execFileSync( 'git', args, {
+			encoding: 'utf8',
+			maxBuffer: 64 * 1024 * 1024,
+		} );
 
-  const read = (ref, path) => {
-    try {
-      return git(['show', `${ref}:${path}`]);
-    } catch {
-      return '';
-    }
-  };
+	const read = ( ref, path ) => {
+		try {
+			return git( [ 'show', `${ ref }:${ path }` ] );
+		} catch {
+			return '';
+		}
+	};
 
-  const scan = (ref) => {
-    const files = git(['ls-tree', '-r', '--name-only', ref])
-      .split('\n')
-      .filter(isScanned)
-      .map((path) => ({ path, source: read(ref, path) }));
+	const scan = ( ref ) => {
+		const files = git( [ 'ls-tree', '-r', '--name-only', ref ] )
+			.split( '\n' )
+			.filter( isScanned )
+			.map( ( path ) => ( { path, source: read( ref, path ) } ) );
 
-    // One owned set for the whole ref. A constant defined outright in
-    // `presence-api.php` is the plugin's own in every file that reads it, which
-    // no file can tell on its own.
-    const own = ownConstants(files.map(({ source }) => source));
+		// One owned set for the whole ref. A constant defined outright in
+		// `presence-api.php` is the plugin's own in every file that reads it, which
+		// no file can tell on its own.
+		const own = ownConstants( files.map( ( { source } ) => source ) );
 
-    return files.flatMap(({ path, source }) => findSurfaces(source, path, own));
-  };
+		return files.flatMap( ( { path, source } ) =>
+			findSurfaces( source, path, own )
+		);
+	};
 
-  const surfaces = newSurfaces(scan(baseRef), scan(headRef));
+	const surfaces = newSurfaces( scan( baseRef ), scan( headRef ) );
 
-  if (surfaces.length) {
-    console.log(`Found ${surfaces.length} new public ${1 === surfaces.length ? 'surface' : 'surfaces'}:`);
-    console.log(formatAudit(surfaces));
-    fs.writeFileSync('comment.md', formatComment(surfaces));
-  } else {
-    console.log('No new public surfaces.');
-  }
+	if ( surfaces.length ) {
+		console.log(
+			`Found ${ surfaces.length } new public ${
+				1 === surfaces.length ? 'surface' : 'surfaces'
+			}:`
+		);
+		console.log( formatAudit( surfaces ) );
+		fs.writeFileSync( 'comment.md', formatComment( surfaces ) );
+	} else {
+		console.log( 'No new public surfaces.' );
+	}
 
-  if (process.env.GITHUB_OUTPUT) {
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `count=${surfaces.length}\n`);
-  }
+	if ( process.env.GITHUB_OUTPUT ) {
+		fs.appendFileSync(
+			process.env.GITHUB_OUTPUT,
+			`count=${ surfaces.length }\n`
+		);
+	}
 }

--- a/.github/scripts/detect-public-surface.test.js
+++ b/.github/scripts/detect-public-surface.test.js
@@ -1,49 +1,60 @@
 'use strict';
 
-const { test } = require('node:test');
-const assert = require('node:assert/strict');
+const { test } = require( 'node:test' );
+const assert = require( 'node:assert/strict' );
 
-const findSurfaces = require('./detect-public-surface.js');
-const { newSurfaces, ownConstants, formatAudit, formatComment, isScanned, MARKER } =
-  findSurfaces;
+const findSurfaces = require( './detect-public-surface.js' );
+const {
+	newSurfaces,
+	ownConstants,
+	formatAudit,
+	formatComment,
+	isScanned,
+	MARKER,
+} = findSurfaces;
 
-const ids = (surfaces) => surfaces.map((s) => s.id);
-const php = (source) => ids(findSurfaces(source, 'includes/functions.php'));
-const js = (source) => ids(findSurfaces(source, 'assets/js/presence-ping.js'));
-const surface = (id, documented = false) => ({ id, documented });
+const ids = ( surfaces ) => surfaces.map( ( s ) => s.id );
+const php = ( source ) =>
+	ids( findSurfaces( source, 'includes/functions.php' ) );
+const js = ( source ) =>
+	ids( findSurfaces( source, 'assets/js/presence-ping.js' ) );
+const surface = ( id, documented = false ) => ( { id, documented } );
 
 // ---------------------------------------------------------------------------
 // PHP hooks
 // ---------------------------------------------------------------------------
 
-test('reads filters and actions apart', () => {
-  assert.deepEqual(php("apply_filters( 'wp_presence_default_ttl', 30 );"), [
-    'filter:wp_presence_default_ttl',
-  ]);
-  assert.deepEqual(php("do_action( 'wp_presence_admin_room_changed' );"), [
-    'action:wp_presence_admin_room_changed',
-  ]);
-});
+test( 'reads filters and actions apart', () => {
+	assert.deepEqual(
+		php( "apply_filters( 'wp_presence_default_ttl', 30 );" ),
+		[ 'filter:wp_presence_default_ttl' ]
+	);
+	assert.deepEqual( php( "do_action( 'wp_presence_admin_room_changed' );" ), [
+		'action:wp_presence_admin_room_changed',
+	] );
+} );
 
-test('reads the _ref_array and _deprecated variants', () => {
-  assert.deepEqual(
-    php("apply_filters_ref_array( 'a', $x ); do_action_deprecated( 'b', $y, '1.0' );"),
-    ['filter:a', 'action:b']
-  );
-});
+test( 'reads the _ref_array and _deprecated variants', () => {
+	assert.deepEqual(
+		php(
+			"apply_filters_ref_array( 'a', $x ); do_action_deprecated( 'b', $y, '1.0' );"
+		),
+		[ 'filter:a', 'action:b' ]
+	);
+} );
 
-test('keeps an interpolated hook name whole', () => {
-  assert.deepEqual(php('do_action( "wp_presence_{$room}_joined" );'), [
-    'action:wp_presence_{$room}_joined',
-  ]);
-});
+test( 'keeps an interpolated hook name whole', () => {
+	assert.deepEqual( php( 'do_action( "wp_presence_{$room}_joined" );' ), [
+		'action:wp_presence_{$room}_joined',
+	] );
+} );
 
 // ---------------------------------------------------------------------------
 // Constants, REST, CLI
 // ---------------------------------------------------------------------------
 
-test('counts a guarded constant, ignores a bare define and core guards', () => {
-  const source = `
+test( 'counts a guarded constant, ignores a bare define and core guards', () => {
+	const source = `
     if ( ! defined( 'ABSPATH' ) ) {
       exit;
     }
@@ -52,28 +63,28 @@ test('counts a guarded constant, ignores a bare define and core guards', () => {
     }
     define( 'WP_PRESENCE_INTERNAL', 5 );
   `;
-  assert.deepEqual(php(source), ['constant:WP_PRESENCE_DEFAULT_TTL']);
-});
+	assert.deepEqual( php( source ), [ 'constant:WP_PRESENCE_DEFAULT_TTL' ] );
+} );
 
-test('counts a constant the plugin only ever reads', () => {
-  // Nothing here defines it: a site sets it in `wp-config.php` or it stays
-  // undefined, which is what makes the name a promise in the first place.
-  const source = `
+test( 'counts a constant the plugin only ever reads', () => {
+	// Nothing here defines it: a site sets it in `wp-config.php` or it stays
+	// undefined, which is what makes the name a promise in the first place.
+	const source = `
     if ( defined( 'DISABLE_WP_PRESENCE' ) && DISABLE_WP_PRESENCE ) {
       return;
     }
   `;
-  assert.deepEqual(php(source), ['constant:DISABLE_WP_PRESENCE']);
-});
+	assert.deepEqual( php( source ), [ 'constant:DISABLE_WP_PRESENCE' ] );
+} );
 
-test("a name outside the plugin's prefix is still the plugin's promise", () => {
-  assert.deepEqual(php("if ( defined( 'PRESENCE_API_DEBUG' ) ) {}"), [
-    'constant:PRESENCE_API_DEBUG',
-  ]);
-});
+test( "a name outside the plugin's prefix is still the plugin's promise", () => {
+	assert.deepEqual( php( "if ( defined( 'PRESENCE_API_DEBUG' ) ) {}" ), [
+		'constant:PRESENCE_API_DEBUG',
+	] );
+} );
 
-test("core constants are WordPress's promise, in either form", () => {
-  const source = `
+test( "core constants are WordPress's promise, in either form", () => {
+	const source = `
     if ( ! defined( 'ABSPATH' ) ) {
       exit;
     }
@@ -84,21 +95,21 @@ test("core constants are WordPress's promise, in either form", () => {
     if ( defined( 'WP_CLI' ) && WP_CLI ) {}
     if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {}
   `;
-  assert.deepEqual(php(source), []);
-});
+	assert.deepEqual( php( source ), [] );
+} );
 
-test('a constant defined outright stays internal, however often it is read', () => {
-  const source = `
+test( 'a constant defined outright stays internal, however often it is read', () => {
+	const source = `
     define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );
     if ( defined( 'WP_PRESENCE_MAX_KEY_LENGTH' ) ) {
       $max = WP_PRESENCE_MAX_KEY_LENGTH;
     }
   `;
-  assert.deepEqual(php(source), []);
-});
+	assert.deepEqual( php( source ), [] );
+} );
 
-test('a guarded define and a read of it are the one surface', () => {
-  const source = `
+test( 'a guarded define and a read of it are the one surface', () => {
+	const source = `
     if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
       define( 'WP_PRESENCE_DEFAULT_TTL', 150 );
     }
@@ -106,39 +117,42 @@ test('a guarded define and a read of it are the one surface', () => {
       $ttl = WP_PRESENCE_DEFAULT_TTL;
     }
   `;
-  assert.deepEqual(ids(newSurfaces([], findSurfaces(source, 'includes/functions.php'))), [
-    'constant:WP_PRESENCE_DEFAULT_TTL',
-  ]);
-});
+	assert.deepEqual(
+		ids(
+			newSurfaces( [], findSurfaces( source, 'includes/functions.php' ) )
+		),
+		[ 'constant:WP_PRESENCE_DEFAULT_TTL' ]
+	);
+} );
 
-test('a docblock above the read documents the constant', () => {
-  const [read] = findSurfaces(
-    `/**
+test( 'a docblock above the read documents the constant', () => {
+	const [ read ] = findSurfaces(
+		`/**
  * Whether presence is switched off for the whole site.
  */
 if ( defined( 'DISABLE_WP_PRESENCE' ) && DISABLE_WP_PRESENCE ) {}`,
-    'includes/functions.php'
-  );
-  assert.equal(read.id, 'constant:DISABLE_WP_PRESENCE');
-  assert.equal(read.documented, true);
-});
+		'includes/functions.php'
+	);
+	assert.equal( read.id, 'constant:DISABLE_WP_PRESENCE' );
+	assert.equal( read.documented, true );
+} );
 
-test('@access private withdraws a constant the same way', () => {
-  const source = `/**
+test( '@access private withdraws a constant the same way', () => {
+	const source = `/**
  * Internal kill switch.
  *
  * @since 0.1.0
  * @access private
  */
 if ( defined( 'WP_PRESENCE_INTERNAL_OFF' ) && WP_PRESENCE_INTERNAL_OFF ) {}`;
-  assert.deepEqual(php(source), []);
-  assert.deepEqual(php(source.replace(' * @access private\n', '')), [
-    'constant:WP_PRESENCE_INTERNAL_OFF',
-  ]);
-});
+	assert.deepEqual( php( source ), [] );
+	assert.deepEqual( php( source.replace( ' * @access private\n', '' ) ), [
+		'constant:WP_PRESENCE_INTERNAL_OFF',
+	] );
+} );
 
-test('the core list covers the constants a plugin actually guards on', () => {
-  const source = `
+test( 'the core list covers the constants a plugin actually guards on', () => {
+	const source = `
     if ( defined( 'SHORTINIT' ) && SHORTINIT ) {}
     if ( defined( 'WP_USE_THEMES' ) && WP_USE_THEMES ) {}
     if ( defined( 'WP_ALLOW_REPAIR' ) && WP_ALLOW_REPAIR ) {}
@@ -149,35 +163,41 @@ test('the core list covers the constants a plugin actually guards on', () => {
     if ( defined( 'COOKIEHASH' ) ) {}
     if ( defined( 'SUNRISE' ) && SUNRISE ) {}
   `;
-  assert.deepEqual(php(source), []);
-});
+	assert.deepEqual( php( source ), [] );
+} );
 
-test("a constant defined in one file is the plugin's own in every other", () => {
-  const bootstrap = "define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );";
-  const reader = "if ( defined( 'WP_PRESENCE_MAX_KEY_LENGTH' ) ) {}";
+test( "a constant defined in one file is the plugin's own in every other", () => {
+	const bootstrap = "define( 'WP_PRESENCE_MAX_KEY_LENGTH', 191 );";
+	const reader = "if ( defined( 'WP_PRESENCE_MAX_KEY_LENGTH' ) ) {}";
 
-  // Alone, the reading file cannot tell an internal from a promise.
-  assert.deepEqual(php(reader), ['constant:WP_PRESENCE_MAX_KEY_LENGTH']);
+	// Alone, the reading file cannot tell an internal from a promise.
+	assert.deepEqual( php( reader ), [
+		'constant:WP_PRESENCE_MAX_KEY_LENGTH',
+	] );
 
-  // Weighed with the file that defines it, the way the CLI weighs a whole ref.
-  const own = ownConstants([bootstrap, reader]);
-  assert.deepEqual(ids(findSurfaces(reader, 'includes/functions.php', own)), []);
-});
+	// Weighed with the file that defines it, the way the CLI weighs a whole ref.
+	const own = ownConstants( [ bootstrap, reader ] );
+	assert.deepEqual(
+		ids( findSurfaces( reader, 'includes/functions.php', own ) ),
+		[]
+	);
+} );
 
-test('a guard anywhere in the ref keeps the constant settable', () => {
-  const bootstrap = `if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
+test( 'a guard anywhere in the ref keeps the constant settable', () => {
+	const bootstrap = `if ( ! defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {
       define( 'WP_PRESENCE_DEFAULT_TTL', 150 );
     }`;
-  const reader = "if ( defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {}";
-  const own = ownConstants([bootstrap, reader]);
+	const reader = "if ( defined( 'WP_PRESENCE_DEFAULT_TTL' ) ) {}";
+	const own = ownConstants( [ bootstrap, reader ] );
 
-  assert.deepEqual(ids(findSurfaces(reader, 'includes/functions.php', own)), [
-    'constant:WP_PRESENCE_DEFAULT_TTL',
-  ]);
-});
+	assert.deepEqual(
+		ids( findSurfaces( reader, 'includes/functions.php', own ) ),
+		[ 'constant:WP_PRESENCE_DEFAULT_TTL' ]
+	);
+} );
 
-test('a private declaration stays private where the constant is read again', () => {
-  const source = `/**
+test( 'a private declaration stays private where the constant is read again', () => {
+	const source = `/**
  * Internal kill switch.
  *
  * @since 0.1.0
@@ -190,204 +210,239 @@ if ( ! defined( 'WP_PRESENCE_INTERNAL' ) ) {
 if ( defined( 'WP_PRESENCE_INTERNAL' ) && WP_PRESENCE_INTERNAL ) {
 	return;
 }`;
-  assert.deepEqual(php(source), []);
-});
+	assert.deepEqual( php( source ), [] );
+} );
 
-test('reads a route through a variable namespace', () => {
-  assert.deepEqual(
-    php("register_rest_route( $this->namespace, '/presence', array() );"),
-    ['rest:/presence']
-  );
-});
+test( 'reads a route through a variable namespace', () => {
+	assert.deepEqual(
+		php( "register_rest_route( $this->namespace, '/presence', array() );" ),
+		[ 'rest:/presence' ]
+	);
+} );
 
-test('reads a concatenated route whole, not just its first literal', () => {
-  const source = `register_rest_route(
+test( 'reads a concatenated route whole, not just its first literal', () => {
+	const source = `register_rest_route(
     $this->namespace,
     '/' . $this->rest_base . '/rooms',
     array()
   );`;
-  assert.deepEqual(php(source), ['rest:/$this->rest_base/rooms']);
-});
+	assert.deepEqual( php( source ), [ 'rest:/$this->rest_base/rooms' ] );
+} );
 
-test('reads a CLI command', () => {
-  assert.deepEqual(php("WP_CLI::add_command( 'presence', $class );"), ['cli:presence']);
-});
+test( 'reads a CLI command', () => {
+	assert.deepEqual( php( "WP_CLI::add_command( 'presence', $class );" ), [
+		'cli:presence',
+	] );
+} );
 
 // ---------------------------------------------------------------------------
 // JavaScript
 // ---------------------------------------------------------------------------
 
-test('reads browser globals and the wp.presence namespace', () => {
-  assert.deepEqual(js('window.wpPresenceCreateTabCoordinator = function () {};'), [
-    'js-global:window.wpPresenceCreateTabCoordinator',
-  ]);
-  assert.deepEqual(js('window.wp.presence.markScreenStale = function () {};'), [
-    'js-global:wp.presence.markScreenStale',
-  ]);
-});
+test( 'reads browser globals and the wp.presence namespace', () => {
+	assert.deepEqual(
+		js( 'window.wpPresenceCreateTabCoordinator = function () {};' ),
+		[ 'js-global:window.wpPresenceCreateTabCoordinator' ]
+	);
+	assert.deepEqual(
+		js( 'window.wp.presence.markScreenStale = function () {};' ),
+		[ 'js-global:wp.presence.markScreenStale' ]
+	);
+} );
 
-test('a comparison against a global is not a declaration', () => {
-  assert.deepEqual(js('if ( window.wpPresenceThing === undefined ) {}'), []);
-});
+test( 'a comparison against a global is not a declaration', () => {
+	assert.deepEqual(
+		js( 'if ( window.wpPresenceThing === undefined ) {}' ),
+		[]
+	);
+} );
 
-test('reads wp.hooks calls', () => {
-  assert.deepEqual(js("wp.hooks.applyFilters( 'presence.entry', x );"), [
-    'js-filter:presence.entry',
-  ]);
-});
+test( 'reads wp.hooks calls', () => {
+	assert.deepEqual( js( "wp.hooks.applyFilters( 'presence.entry', x );" ), [
+		'js-filter:presence.entry',
+	] );
+} );
 
-test('php rules do not run against a js file, or the reverse', () => {
-  assert.deepEqual(js("apply_filters( 'not_php', 1 );"), []);
-  assert.deepEqual(php('window.wpPresenceThing = 1;'), []);
-});
+test( 'php rules do not run against a js file, or the reverse', () => {
+	assert.deepEqual( js( "apply_filters( 'not_php', 1 );" ), [] );
+	assert.deepEqual( php( 'window.wpPresenceThing = 1;' ), [] );
+} );
 
 // ---------------------------------------------------------------------------
 // @private
 // ---------------------------------------------------------------------------
 
-test('a @private docblock keeps an internal seam out', () => {
-  const source = `/**
+test( 'a @private docblock keeps an internal seam out', () => {
+	const source = `/**
  * Builds an avatar stack.
  *
  * @private
  */
 window.wpPresenceBuildAvatarStack = function ( users, max ) {};`;
-  assert.deepEqual(js(source), []);
-  assert.deepEqual(js(source.replace(' * @private\n', '')), [
-    'js-global:window.wpPresenceBuildAvatarStack',
-  ]);
-});
+	assert.deepEqual( js( source ), [] );
+	assert.deepEqual( js( source.replace( ' * @private\n', '' ) ), [
+		'js-global:window.wpPresenceBuildAvatarStack',
+	] );
+} );
 
-test('@private applies to the statement it documents, not the next one', () => {
-  const source = `/**
+test( '@private applies to the statement it documents, not the next one', () => {
+	const source = `/**
  * @private
  */
 window.wpPresenceInternal = function () {};
 window.wpPresencePublic = function () {};`;
-  assert.deepEqual(js(source), ['js-global:window.wpPresencePublic']);
-});
+	assert.deepEqual( js( source ), [ 'js-global:window.wpPresencePublic' ] );
+} );
 
-test('@access private withdraws a surface the same way', () => {
-  const source = `/**
+test( '@access private withdraws a surface the same way', () => {
+	const source = `/**
  * Fires internally.
  *
  * @since 0.1.0
  * @access private
  */
 do_action( 'wp_presence_internal' );`;
-  assert.deepEqual(php(source), []);
-  assert.deepEqual(php(source.replace(' * @access private\n', '')), ['action:wp_presence_internal']);
-});
+	assert.deepEqual( php( source ), [] );
+	assert.deepEqual( php( source.replace( ' * @access private\n', '' ) ), [
+		'action:wp_presence_internal',
+	] );
+} );
 
-test('@private reads the same above a php hook', () => {
-  const source = `/**
+test( '@private reads the same above a php hook', () => {
+	const source = `/**
  * Fires internally.
  *
  * @private
  */
 do_action( 'wp_presence_internal' );`;
-  assert.deepEqual(php(source), []);
-});
+	assert.deepEqual( php( source ), [] );
+} );
 
 // ---------------------------------------------------------------------------
 // The documented bar
 // ---------------------------------------------------------------------------
 
-test('a docblock saying what the hook is for documents it, through the assignment', () => {
-  const [long] = findSurfaces(
-    `/**
+test( 'a docblock saying what the hook is for documents it, through the assignment', () => {
+	const [ long ] = findSurfaces(
+		`/**
  * Filters the default TTL.
  *
  * @since 0.1.0
  * @param int $ttl Seconds.
  */
 $ttl = apply_filters( 'wp_presence_default_ttl', 30 );`,
-    'includes/functions.php'
-  );
-  const [short] = findSurfaces(
-    "/** Filters the TTL. */\napply_filters( 'a', 1 );",
-    'includes/functions.php'
-  );
-  assert.equal(long.documented, true);
-  assert.equal(short.documented, true);
-});
+		'includes/functions.php'
+	);
+	const [ short ] = findSurfaces(
+		"/** Filters the TTL. */\napply_filters( 'a', 1 );",
+		'includes/functions.php'
+	);
+	assert.equal( long.documented, true );
+	assert.equal( short.documented, true );
+} );
 
-test('tags with no sentence are a signature, not a write-up', () => {
-  const [tagged] = findSurfaces(
-    "/**\n * @since 0.1.0\n */\napply_filters( 'a', 1 );",
-    'includes/functions.php'
-  );
-  const [bare] = findSurfaces("apply_filters( 'a', 1 );", 'includes/functions.php');
-  assert.equal(tagged.documented, false);
-  assert.equal(bare.documented, false);
-});
+test( 'tags with no sentence are a signature, not a write-up', () => {
+	const [ tagged ] = findSurfaces(
+		"/**\n * @since 0.1.0\n */\napply_filters( 'a', 1 );",
+		'includes/functions.php'
+	);
+	const [ bare ] = findSurfaces(
+		"apply_filters( 'a', 1 );",
+		'includes/functions.php'
+	);
+	assert.equal( tagged.documented, false );
+	assert.equal( bare.documented, false );
+} );
 
 // ---------------------------------------------------------------------------
 // newSurfaces
 // ---------------------------------------------------------------------------
 
-test('a hook moved to another file is not new', () => {
-  // The identifier carries no path, so both sides collapse to the same entry.
-  const base = findSurfaces("apply_filters( 'a', 1 );", 'includes/one.php');
-  const head = findSurfaces("apply_filters( 'a', 1 );", 'includes/two.php');
-  assert.deepEqual(newSurfaces(base, head), []);
-});
+test( 'a hook moved to another file is not new', () => {
+	// The identifier carries no path, so both sides collapse to the same entry.
+	const base = findSurfaces( "apply_filters( 'a', 1 );", 'includes/one.php' );
+	const head = findSurfaces( "apply_filters( 'a', 1 );", 'includes/two.php' );
+	assert.deepEqual( newSurfaces( base, head ), [] );
+} );
 
-test('reports additions, ignores removals, and sorts', () => {
-  const fresh = newSurfaces(
-    [surface('filter:a'), surface('action:gone')],
-    [surface('filter:a'), surface('filter:c'), surface('action:b')]
-  );
-  assert.deepEqual(ids(fresh), ['action:b', 'filter:c']);
-});
+test( 'reports additions, ignores removals, and sorts', () => {
+	const fresh = newSurfaces(
+		[ surface( 'filter:a' ), surface( 'action:gone' ) ],
+		[ surface( 'filter:a' ), surface( 'filter:c' ), surface( 'action:b' ) ]
+	);
+	assert.deepEqual( ids( fresh ), [ 'action:b', 'filter:c' ] );
+} );
 
-test('one write-up covers a hook fired from two places', () => {
-  const [only] = newSurfaces([], [surface('filter:a'), surface('filter:a', true)]);
-  assert.equal(only.documented, true);
-});
+test( 'one write-up covers a hook fired from two places', () => {
+	const [ only ] = newSurfaces(
+		[],
+		[ surface( 'filter:a' ), surface( 'filter:a', true ) ]
+	);
+	assert.equal( only.documented, true );
+} );
 
 // ---------------------------------------------------------------------------
 // isScanned
 // ---------------------------------------------------------------------------
 
-test('scans shipped code only', () => {
-  for (const path of ['includes/functions.php', 'presence-api.php', 'assets/js/ping.js']) {
-    assert.equal(isScanned(path), true, path);
-  }
-  // `tests/` is the loudest false-positive source: it calls hooks constantly
-  // without publishing any. Built assets duplicate `src/`.
-  for (const path of [
-    'tests/test-functions.php',
-    'assets/js/build/index.js',
-    'src/utils/test/coordinator.test.js',
-    '.github/scripts/detect-public-surface.js',
-  ]) {
-    assert.equal(isScanned(path), false, path);
-  }
-});
+test( 'scans shipped code only', () => {
+	for ( const path of [
+		'includes/functions.php',
+		'presence-api.php',
+		'assets/js/ping.js',
+	] ) {
+		assert.equal( isScanned( path ), true, path );
+	}
+	// `tests/` is the loudest false-positive source: it calls hooks constantly
+	// without publishing any. Built assets duplicate `src/`.
+	for ( const path of [
+		'tests/test-functions.php',
+		'assets/js/build/index.js',
+		'src/utils/test/coordinator.test.js',
+		'.github/scripts/detect-public-surface.js',
+	] ) {
+		assert.equal( isScanned( path ), false, path );
+	}
+} );
 
 // ---------------------------------------------------------------------------
 // formatAudit
 // ---------------------------------------------------------------------------
 
-test('leads each entry with its kind and qualifies the undocumented ones', () => {
-  const report = formatAudit([surface('filter:wp_presence_new_hook'), surface('action:b', true)]);
-  assert.equal(report, '- (filter) `wp_presence_new_hook` - *requires documentation*\n- (action) `b`');
-});
+test( 'leads each entry with its kind and qualifies the undocumented ones', () => {
+	const report = formatAudit( [
+		surface( 'filter:wp_presence_new_hook' ),
+		surface( 'action:b', true ),
+	] );
+	assert.equal(
+		report,
+		'- (filter) `wp_presence_new_hook` - *requires documentation*\n- (action) `b`'
+	);
+} );
 
-test('splits on the first colon so a namespaced hook name survives', () => {
-  assert.match(formatAudit([surface('js-filter:presence.entry', true)]), /\(js-filter\) `presence\.entry`/);
-});
+test( 'splits on the first colon so a namespaced hook name survives', () => {
+	assert.match(
+		formatAudit( [ surface( 'js-filter:presence.entry', true ) ] ),
+		/\(js-filter\) `presence\.entry`/
+	);
+} );
 
 // ---------------------------------------------------------------------------
 // formatComment
 // ---------------------------------------------------------------------------
 
-test('leads with the marker so the workflow can find its own comment', () => {
-  assert.ok(formatComment([surface('filter:a')]).startsWith(`${MARKER}\n### 🚩 New public surface\n`));
-});
+test( 'leads with the marker so the workflow can find its own comment', () => {
+	assert.ok(
+		formatComment( [ surface( 'filter:a' ) ] ).startsWith(
+			`${ MARKER }\n### 🚩 New public surface\n`
+		)
+	);
+} );
 
-test('agrees in number', () => {
-  const two = formatComment([surface('filter:a', true), surface('action:b', true)]);
-  assert.match(two, /^### 🚩 New public surfaces$/m);
-});
+test( 'agrees in number', () => {
+	const two = formatComment( [
+		surface( 'filter:a', true ),
+		surface( 'action:b', true ),
+	] );
+	assert.match( two, /^### 🚩 New public surfaces$/m );
+} );

--- a/.github/scripts/sync-contributors.js
+++ b/.github/scripts/sync-contributors.js
@@ -8,38 +8,42 @@
 
 'use strict';
 
-const fs    = require( 'fs' );
+const fs = require( 'fs' );
 const https = require( 'https' );
 
 const { MARKER, parsePropsNames } = require( './aggregate-props.js' );
 
 const readmeFile = process.argv[ 2 ] || 'readme.txt';
-const prNumber   = process.env.PR_NUMBER;
-const token      = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
-const repo       = process.env.GITHUB_REPOSITORY;
+const prNumber = process.env.PR_NUMBER;
+const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
 
 if ( ! prNumber || ! token || ! repo ) {
-	console.log( 'Missing PR_NUMBER, GH_TOKEN, or GITHUB_REPOSITORY — skipping.' );
+	console.log(
+		'Missing PR_NUMBER, GH_TOKEN, or GITHUB_REPOSITORY — skipping.'
+	);
 	process.exit( 0 );
 }
 
 function apiGet( path ) {
 	return new Promise( ( resolve, reject ) => {
-		https.get(
-			`https://api.github.com${ path }`,
-			{
-				headers: {
-					Authorization:  `Bearer ${ token }`,
-					Accept:         'application/vnd.github+json',
-					'User-Agent':   'presence-api-sync-contributors',
+		https
+			.get(
+				`https://api.github.com${ path }`,
+				{
+					headers: {
+						Authorization: `Bearer ${ token }`,
+						Accept: 'application/vnd.github+json',
+						'User-Agent': 'presence-api-sync-contributors',
+					},
 				},
-			},
-			( res ) => {
-				let data = '';
-				res.on( 'data', ( d ) => ( data += d ) );
-				res.on( 'end', () => resolve( JSON.parse( data ) ) );
-			}
-		).on( 'error', reject );
+				( res ) => {
+					let data = '';
+					res.on( 'data', ( d ) => ( data += d ) );
+					res.on( 'end', () => resolve( JSON.parse( data ) ) );
+				}
+			)
+			.on( 'error', reject );
 	} );
 }
 
@@ -48,12 +52,14 @@ async function main() {
 		`/repos/${ repo }/issues/${ prNumber }/comments?per_page=100`
 	);
 
-	const propsComment = [ ...comments ].reverse().find(
-		( c ) => c.body && c.body.includes( MARKER )
-	);
+	const propsComment = [ ...comments ]
+		.reverse()
+		.find( ( c ) => c.body && c.body.includes( MARKER ) );
 
 	if ( ! propsComment ) {
-		console.log( 'No release-props comment found — skipping contributor sync.' );
+		console.log(
+			'No release-props comment found — skipping contributor sync.'
+		);
 		return;
 	}
 
@@ -64,14 +70,14 @@ async function main() {
 	}
 
 	const readme = fs.readFileSync( readmeFile, 'utf8' );
-	const match  = readme.match( /^Contributors: (.+)$/m );
+	const match = readme.match( /^Contributors: (.+)$/m );
 	if ( ! match ) {
 		console.log( 'Contributors line not found in readme — skipping.' );
 		return;
 	}
 
 	const existing = match[ 1 ].split( ',' ).map( ( n ) => n.trim() );
-	const toAdd    = incoming.filter( ( n ) => ! existing.includes( n ) );
+	const toAdd = incoming.filter( ( n ) => ! existing.includes( n ) );
 
 	if ( ! toAdd.length ) {
 		console.log( 'No new contributors to add.' );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
     needs: gate
     uses: ./.github/workflows/unit.yml
 
+  lint-js:
+    needs: gate
+    uses: ./.github/workflows/lint-js.yml
+
   plugin-check:
     needs: gate
     uses: ./.github/workflows/plugin-check.yml

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,22 @@
+name: JavaScript Lint
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-js:
+    name: ESLint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint:js

--- a/assets/js/active-posts.js
+++ b/assets/js/active-posts.js
@@ -1,6 +1,7 @@
 /**
  * Active Posts dashboard widget client.
  *
+ * @param {jQuery} $ The jQuery instance.
  * @package Presence_API
  */
 
@@ -11,110 +12,158 @@
 		return;
 	}
 
-	var i18n = window.wpPresenceActivePosts || {};
+	const i18n = window.wpPresenceActivePosts || {};
 
 	// Sitewide data, no per-tab context — the dedupe key is fixed.
-	var pingContextKey = 'wp-presence-active-posts-ping';
+	const pingContextKey = 'wp-presence-active-posts-ping';
 
-	var tabCoordinator = window.wpPresenceCreateTabCoordinator( pingContextKey, [ 'presence-active-posts' ] );
+	const tabCoordinator = window.wpPresenceCreateTabCoordinator(
+		pingContextKey,
+		[ 'presence-active-posts' ]
+	);
 
-	function esc(str) {
-		var el = document.createElement('span');
+	function esc( str ) {
+		const el = document.createElement( 'span' );
 		el.textContent = str;
 		return el.innerHTML;
 	}
 
-	$(document).on('heartbeat-send', function(event, data) {
+	$( document ).on( 'heartbeat-send', function ( event, data ) {
 		if ( ! tabCoordinator.isLeader() ) {
 			return;
 		}
-		data['presence-active-posts-ping'] = true;
-	});
+		data[ 'presence-active-posts-ping' ] = true;
+	} );
 
-	var lastSignature = '';
+	let lastSignature = '';
 
-	function captureFocus(container) {
-		var active = document.activeElement;
-		if (!active || !$.contains(container[0], active)) {
+	function captureFocus( container ) {
+		const active = document.activeElement;
+		if ( ! active || ! $.contains( container[ 0 ], active ) ) {
 			return null;
 		}
-		var item = $(active).closest('[data-post-id]');
-		return { postId: item.length ? item.data('post-id') : null };
+		const item = $( active ).closest( '[data-post-id]' );
+		return { postId: item.length ? item.data( 'post-id' ) : null };
 	}
 
-	function restoreFocus(container, info) {
-		if (!info) {
+	function restoreFocus( container, info ) {
+		if ( ! info ) {
 			return;
 		}
-		var target = null;
-		if (info.postId !== null && info.postId !== undefined) {
-			target = container.find('[data-post-id="' + info.postId + '"] a').first();
+		let target = null;
+		if ( info.postId !== null && info.postId !== undefined ) {
+			target = container
+				.find( '[data-post-id="' + info.postId + '"] a' )
+				.first();
 		}
-		if (target && target.length) {
-			target.trigger('focus');
+		if ( target && target.length ) {
+			target.trigger( 'focus' );
 		} else {
-			container.trigger('focus');
+			container.trigger( 'focus' );
 		}
 	}
 
-	function buildFullPostsHtml(posts) {
-		var html = '<ul class="presence-active-posts-list" aria-label="' + esc(i18n.postsBeingEdited) + '">';
-		posts.forEach(function(post) {
-			var anyActive = post.editors.some(function(e) { return e.status === 'active'; });
-			var statusLabel = anyActive ? '' : i18n.statusIdle;
-			html += '<li class="presence-active-post-item" data-post-id="' + post.post_id + '">';
+	function buildFullPostsHtml( posts ) {
+		let html =
+			'<ul class="presence-active-posts-list" aria-label="' +
+			esc( i18n.postsBeingEdited ) +
+			'">';
+		posts.forEach( function ( post ) {
+			const anyActive = post.editors.some( function ( e ) {
+				return e.status === 'active';
+			} );
+			const statusLabel = anyActive ? '' : i18n.statusIdle;
+			html +=
+				'<li class="presence-active-post-item" data-post-id="' +
+				post.post_id +
+				'">';
 			html += '<span class="presence-editor-stack">';
-			var stackMax = Math.min(post.editors.length, 4);
-			post.editors.slice(0, stackMax).forEach(function(editor, idx) {
-				if (editor.avatar_url) {
-					html += '<img src="' + esc(editor.avatar_url) + '" width="24" height="24" style="z-index:' + (stackMax - idx) + '" alt="' + esc(editor.display_name) + '" />';
-				}
-			});
+			const stackMax = Math.min( post.editors.length, 4 );
+			post.editors
+				.slice( 0, stackMax )
+				.forEach( function ( editor, idx ) {
+					if ( editor.avatar_url ) {
+						html +=
+							'<img src="' +
+							esc( editor.avatar_url ) +
+							'" width="24" height="24" style="z-index:' +
+							( stackMax - idx ) +
+							'" alt="' +
+							esc( editor.display_name ) +
+							'" />';
+					}
+				} );
 			html += '</span>';
 			html += '<div class="presence-active-post-info">';
-			if (post.editors.length === 1) {
-				html += '<div><span class="presence-editor-count">' + esc(post.editors[0].display_name) + '</span></div>';
+			if ( post.editors.length === 1 ) {
+				html +=
+					'<div><span class="presence-editor-count">' +
+					esc( post.editors[ 0 ].display_name ) +
+					'</span></div>';
 			} else {
-				html += '<div><span class="presence-editor-count">' + esc(i18n.editorCount.replace('%d', post.editors.length)) + '</span></div>';
+				html +=
+					'<div><span class="presence-editor-count">' +
+					esc(
+						i18n.editorCount.replace( '%d', post.editors.length )
+					) +
+					'</span></div>';
 			}
-			html += '<div><span class="presence-post-title"><a href="' + esc(post.edit_url) + '">' + esc(post.post_title) + '</a></span></div>';
+			html +=
+				'<div><span class="presence-post-title"><a href="' +
+				esc( post.edit_url ) +
+				'">' +
+				esc( post.post_title ) +
+				'</a></span></div>';
 			html += '</div>';
-			html += '<span class="presence-status-text">' + esc(statusLabel) + '</span>';
+			html +=
+				'<span class="presence-status-text">' +
+				esc( statusLabel ) +
+				'</span>';
 			html += '</li>';
-		});
+		} );
 		html += '</ul>';
 		return html;
 	}
 
-	$(document).on('heartbeat-tick', function(event, data) {
-		if (!data['presence-active-posts']) {
+	$( document ).on( 'heartbeat-tick', function ( event, data ) {
+		if ( ! data[ 'presence-active-posts' ] ) {
 			return;
 		}
 
-		var container = $('#presence-active-posts-list');
-		if (!container.length) {
+		const container = $( '#presence-active-posts-list' );
+		if ( ! container.length ) {
 			return;
 		}
 
-		var posts = data['presence-active-posts'];
-		if (!posts.length) {
-			if (lastSignature !== '') {
-				var clearFocus = captureFocus(container);
-				container.html('<p>' + esc(i18n.noPostsEdited) + '</p>');
-				restoreFocus(container, clearFocus);
+		const posts = data[ 'presence-active-posts' ];
+		if ( ! posts.length ) {
+			if ( lastSignature !== '' ) {
+				const clearFocus = captureFocus( container );
+				container.html( '<p>' + esc( i18n.noPostsEdited ) + '</p>' );
+				restoreFocus( container, clearFocus );
 				lastSignature = '';
 			}
 			return;
 		}
 
-		var sig = posts.map(function(p) {
-			return p.post_id + ':' + p.editors.map(function(e) { return e.user_id + '/' + e.status; }).join('+');
-		}).join(',');
-		if (sig !== lastSignature) {
-			var focusInfo = captureFocus(container);
-			container.html(buildFullPostsHtml(posts));
-			restoreFocus(container, focusInfo);
+		const sig = posts
+			.map( function ( p ) {
+				return (
+					p.post_id +
+					':' +
+					p.editors
+						.map( function ( e ) {
+							return e.user_id + '/' + e.status;
+						} )
+						.join( '+' )
+				);
+			} )
+			.join( ',' );
+		if ( sig !== lastSignature ) {
+			const focusInfo = captureFocus( container );
+			container.html( buildFullPostsHtml( posts ) );
+			restoreFocus( container, focusInfo );
 			lastSignature = sig;
 		}
-	});
-})(jQuery);
+	} );
+} )( jQuery );

--- a/assets/js/avatar-stack.js
+++ b/assets/js/avatar-stack.js
@@ -11,7 +11,7 @@
 	'use strict';
 
 	function esc( str ) {
-		var el = document.createElement( 'span' );
+		const el = document.createElement( 'span' );
 		el.textContent = str;
 		return el.innerHTML;
 	}
@@ -30,17 +30,24 @@
 	 */
 	window.wpPresenceBuildAvatarStack = function ( users, max ) {
 		// get_avatar_url() returns false with the Show Avatars setting off.
-		var shown = users.slice( 0, max ).filter( function ( user ) {
+		const shown = users.slice( 0, max ).filter( function ( user ) {
 			return !! user.avatar_url;
 		} );
 
-		var html = '<span class="presence-avatar-stack">';
+		let html = '<span class="presence-avatar-stack">';
 
 		// The avatars overlap, so the first one has to paint on top.
 		shown.forEach( function ( user, index ) {
-			html += '<img src="' + esc( user.avatar_url ) + '" width="20" height="20" style="z-index:' + ( shown.length - index ) + '" alt="' + esc( user.display_name ) + '" />';
+			html +=
+				'<img src="' +
+				esc( user.avatar_url ) +
+				'" width="20" height="20" style="z-index:' +
+				( shown.length - index ) +
+				'" alt="' +
+				esc( user.display_name ) +
+				'" />';
 		} );
 
 		return html + '</span>';
 	};
-}() );
+} )();

--- a/assets/js/network-whos-online-widget.js
+++ b/assets/js/network-whos-online-widget.js
@@ -1,127 +1,153 @@
 /**
  * Network Who's Online dashboard widget client.
  *
+ * @param {jQuery} $ The jQuery instance.
  * @package Presence_API
  */
 
-(function($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+( function ( $ ) {
+	if ( typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined' ) {
 		return;
 	}
 
-	var config = window.wpPresenceNetworkWhosOnline || {};
-	var i18n = config.i18n || {};
-	var viewAllUrl = config.viewAllUrl || '';
-	var avatarMax = config.avatarMax;
-	var lastHash = '';
-	var lastSignature = '';
+	const config = window.wpPresenceNetworkWhosOnline || {};
+	const i18n = config.i18n || {};
+	const viewAllUrl = config.viewAllUrl || '';
+	const avatarMax = config.avatarMax;
+	let lastHash = '';
+	let lastSignature = '';
 
-	function esc(str) {
-		var el = document.createElement('span');
+	function esc( str ) {
+		const el = document.createElement( 'span' );
 		el.textContent = str;
 		return el.innerHTML;
 	}
 
 	// The swap below replaces every node, so a keyboard user standing on a site
 	// link lands on the body unless the spot is recorded and handed back.
-	function captureFocus(container) {
-		var active = document.activeElement;
-		if (!active || !$.contains(container[0], active)) {
+	function captureFocus( container ) {
+		const active = document.activeElement;
+		if ( ! active || ! $.contains( container[ 0 ], active ) ) {
 			return null;
 		}
-		var item = $(active).closest('[data-blog-id]');
-		if (item.length) {
-			return { type: 'site', id: item.data('blog-id') };
+		const item = $( active ).closest( '[data-blog-id]' );
+		if ( item.length ) {
+			return { type: 'site', id: item.data( 'blog-id' ) };
 		}
-		if ($(active).hasClass('presence-more-link')) {
+		if ( $( active ).hasClass( 'presence-more-link' ) ) {
 			return { type: 'more' };
 		}
 		return { type: 'none' };
 	}
 
-	function restoreFocus(container, info) {
-		if (!info) {
+	function restoreFocus( container, info ) {
+		if ( ! info ) {
 			return;
 		}
-		var target = null;
-		if (info.type === 'site') {
-			target = container.find('[data-blog-id="' + info.id + '"] a').first();
-		} else if (info.type === 'more') {
-			target = container.find('.presence-more-link');
+		let target = null;
+		if ( info.type === 'site' ) {
+			target = container
+				.find( '[data-blog-id="' + info.id + '"] a' )
+				.first();
+		} else if ( info.type === 'more' ) {
+			target = container.find( '.presence-more-link' );
 		}
-		if (target && target.length) {
-			target.trigger('focus');
+		if ( target && target.length ) {
+			target.trigger( 'focus' );
 		} else {
-			container.trigger('focus');
+			container.trigger( 'focus' );
 		}
 	}
 
 	// Already cut to the sites and avatars this widget shows, so nothing is
 	// sliced here; overflow is a count the server sends, not what is left over.
-	function buildListHtml(sites, overflow, aggregating) {
-		if (!aggregating) {
-			return '<p>' + esc(i18n.notAggregated) + '</p>';
+	function buildListHtml( sites, overflow, aggregating ) {
+		if ( ! aggregating ) {
+			return '<p>' + esc( i18n.notAggregated ) + '</p>';
 		}
 
-		if (!sites.length) {
-			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
+		if ( ! sites.length ) {
+			return '<p>' + esc( i18n.noUsersOnline ) + '</p>';
 		}
 
-		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.sitesOnline) + '">';
-		sites.forEach(function(site) {
-			html += '<li class="presence-site-item" data-blog-id="' + parseInt(site.blog_id, 10) + '">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
-			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
-			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
-		});
+		let html =
+			'<ul class="presence-user-list" aria-label="' +
+			esc( i18n.sitesOnline ) +
+			'">';
+		sites.forEach( function ( site ) {
+			html +=
+				'<li class="presence-site-item" data-blog-id="' +
+				parseInt( site.blog_id, 10 ) +
+				'">' +
+				window.wpPresenceBuildAvatarStack( site.users, avatarMax );
+			html +=
+				'<span class="presence-site-info"><a href="' +
+				esc( site.url ) +
+				'">' +
+				esc( site.domain + site.path ) +
+				'</a></span>';
+			html +=
+				'<span class="presence-site-count">' +
+				site.user_count +
+				'</span></li>';
+		} );
 		html += '</ul>';
 
-		if (overflow > 0) {
+		if ( overflow > 0 ) {
 			// Both forms come from the server because _n() cannot be called from
 			// here; picking on the count is as close as this gets to its rules.
-			var moreLabel = (overflow === 1 ? i18n.moreSite : i18n.moreSites).replace('%d', overflow);
-			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">' + esc(moreLabel) + '</a>';
+			const moreLabel = (
+				overflow === 1 ? i18n.moreSite : i18n.moreSites
+			).replace( '%d', overflow );
+			html +=
+				'<a href="' +
+				esc( viewAllUrl ) +
+				'" class="presence-more-link">' +
+				esc( moreLabel ) +
+				'</a>';
 		}
 
 		return html;
 	}
 
-	$(document).on('heartbeat-send', function(event, data) {
-		data['presence-network-widget-ping'] = true;
-		if (lastHash) {
-			data['presence-network-widget-hash'] = lastHash;
+	$( document ).on( 'heartbeat-send', function ( event, data ) {
+		data[ 'presence-network-widget-ping' ] = true;
+		if ( lastHash ) {
+			data[ 'presence-network-widget-hash' ] = lastHash;
 		}
-	});
+	} );
 
-	$(document).on('heartbeat-tick', function(event, data) {
-		if (data['presence-network-widget-unchanged']) {
+	$( document ).on( 'heartbeat-tick', function ( event, data ) {
+		if ( data[ 'presence-network-widget-unchanged' ] ) {
 			return;
 		}
 
-		if (!data['presence-network-widget']) {
+		if ( ! data[ 'presence-network-widget' ] ) {
 			return;
 		}
 
-		lastHash = data['presence-network-widget-hash'] || '';
+		lastHash = data[ 'presence-network-widget-hash' ] || '';
 
-		var container = $('#presence-network-widget-list');
-		if (!container.length) {
+		const container = $( '#presence-network-widget-list' );
+		if ( ! container.length ) {
 			return;
 		}
 
-		var sites = data['presence-network-widget'];
-		var overflow = data['presence-network-widget-overflow'] || 0;
-		var aggregating = data['presence-network-widget-aggregating'] !== false;
+		const sites = data[ 'presence-network-widget' ];
+		const overflow = data[ 'presence-network-widget-overflow' ] || 0;
+		const aggregating =
+			data[ 'presence-network-widget-aggregating' ] !== false;
 
 		// Signature over what gets drawn, matching the server-side hash: a
 		// rename or a new avatar has to repaint, and the order is already the
 		// order it renders in.
-		var sig = JSON.stringify([sites, overflow, aggregating]);
+		const sig = JSON.stringify( [ sites, overflow, aggregating ] );
 
-		if (sig !== lastSignature) {
-			var focusInfo = captureFocus(container);
-			container.html(buildListHtml(sites, overflow, aggregating));
-			restoreFocus(container, focusInfo);
+		if ( sig !== lastSignature ) {
+			const focusInfo = captureFocus( container );
+			container.html( buildListHtml( sites, overflow, aggregating ) );
+			restoreFocus( container, focusInfo );
 			lastSignature = sig;
 		}
-	});
-})(jQuery);
+	} );
+} )( jQuery );

--- a/assets/js/network-whos-online-widget.js
+++ b/assets/js/network-whos-online-widget.js
@@ -1,0 +1,127 @@
+/**
+ * Network Who's Online dashboard widget client.
+ *
+ * @package Presence_API
+ */
+
+(function($) {
+	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+		return;
+	}
+
+	var config = window.wpPresenceNetworkWhosOnline || {};
+	var i18n = config.i18n || {};
+	var viewAllUrl = config.viewAllUrl || '';
+	var avatarMax = config.avatarMax;
+	var lastHash = '';
+	var lastSignature = '';
+
+	function esc(str) {
+		var el = document.createElement('span');
+		el.textContent = str;
+		return el.innerHTML;
+	}
+
+	// The swap below replaces every node, so a keyboard user standing on a site
+	// link lands on the body unless the spot is recorded and handed back.
+	function captureFocus(container) {
+		var active = document.activeElement;
+		if (!active || !$.contains(container[0], active)) {
+			return null;
+		}
+		var item = $(active).closest('[data-blog-id]');
+		if (item.length) {
+			return { type: 'site', id: item.data('blog-id') };
+		}
+		if ($(active).hasClass('presence-more-link')) {
+			return { type: 'more' };
+		}
+		return { type: 'none' };
+	}
+
+	function restoreFocus(container, info) {
+		if (!info) {
+			return;
+		}
+		var target = null;
+		if (info.type === 'site') {
+			target = container.find('[data-blog-id="' + info.id + '"] a').first();
+		} else if (info.type === 'more') {
+			target = container.find('.presence-more-link');
+		}
+		if (target && target.length) {
+			target.trigger('focus');
+		} else {
+			container.trigger('focus');
+		}
+	}
+
+	// Already cut to the sites and avatars this widget shows, so nothing is
+	// sliced here; overflow is a count the server sends, not what is left over.
+	function buildListHtml(sites, overflow, aggregating) {
+		if (!aggregating) {
+			return '<p>' + esc(i18n.notAggregated) + '</p>';
+		}
+
+		if (!sites.length) {
+			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
+		}
+
+		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.sitesOnline) + '">';
+		sites.forEach(function(site) {
+			html += '<li class="presence-site-item" data-blog-id="' + parseInt(site.blog_id, 10) + '">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
+			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
+			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
+		});
+		html += '</ul>';
+
+		if (overflow > 0) {
+			// Both forms come from the server because _n() cannot be called from
+			// here; picking on the count is as close as this gets to its rules.
+			var moreLabel = (overflow === 1 ? i18n.moreSite : i18n.moreSites).replace('%d', overflow);
+			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">' + esc(moreLabel) + '</a>';
+		}
+
+		return html;
+	}
+
+	$(document).on('heartbeat-send', function(event, data) {
+		data['presence-network-widget-ping'] = true;
+		if (lastHash) {
+			data['presence-network-widget-hash'] = lastHash;
+		}
+	});
+
+	$(document).on('heartbeat-tick', function(event, data) {
+		if (data['presence-network-widget-unchanged']) {
+			return;
+		}
+
+		if (!data['presence-network-widget']) {
+			return;
+		}
+
+		lastHash = data['presence-network-widget-hash'] || '';
+
+		var container = $('#presence-network-widget-list');
+		if (!container.length) {
+			return;
+		}
+
+		var sites = data['presence-network-widget'];
+		var overflow = data['presence-network-widget-overflow'] || 0;
+		var aggregating = data['presence-network-widget-aggregating'] !== false;
+
+		// Signature over what gets drawn, matching the server-side hash: a
+		// rename or a new avatar has to repaint, and the order is already the
+		// order it renders in.
+		var sig = JSON.stringify([sites, overflow, aggregating]);
+
+		if (sig !== lastSignature) {
+			var focusInfo = captureFocus(container);
+			container.html(buildListHtml(sites, overflow, aggregating));
+			restoreFocus(container, focusInfo);
+			lastSignature = sig;
+		}
+	});
+})(jQuery);

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -1,17 +1,17 @@
-(function ($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+( function ( $ ) {
+	if ( typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined' ) {
 		return;
 	}
 
 	const config = window.wpPresenceConfig || {};
-	const entries = Array.isArray(config.entries) ? config.entries : [];
+	const entries = Array.isArray( config.entries ) ? config.entries : [];
 	const frontContext = config.frontContext || null;
-	const editorPostId = parseInt(config.editorPostId, 10) || 0;
+	const editorPostId = parseInt( config.editorPostId, 10 ) || 0;
 	const restUrl = config.restUrl || '';
 	const nonce = config.nonce || '';
-	const idleTicks = parseInt(config.idleTicks, 10) || 0;
-	const idleInterval = parseInt(config.idleInterval, 10) || 0;
-	const ttl = parseInt(config.ttl, 10) || 150;
+	const idleTicks = parseInt( config.idleTicks, 10 ) || 0;
+	const idleInterval = parseInt( config.idleInterval, 10 ) || 0;
+	const ttl = parseInt( config.ttl, 10 ) || 150;
 	const backoffEnabled = idleTicks > 0 && idleInterval > 0;
 	const TTL_SAFETY_MARGIN = 15;
 
@@ -25,35 +25,37 @@
 	// Reads the interval lazily (not at page load) so it reflects whatever
 	// another script, e.g. post.js's lock-refresh interval, already set.
 	function widenInterval() {
-		if (normalInterval !== null) {
+		if ( normalInterval !== null ) {
 			return;
 		}
 		const current = wp.heartbeat.interval();
 		// Stay under the TTL, or an idle-but-open tab would drop out of its own room between ticks.
-		const target = Math.min(idleInterval, ttl - TTL_SAFETY_MARGIN);
-		if (target <= current) {
+		const target = Math.min( idleInterval, ttl - TTL_SAFETY_MARGIN );
+		if ( target <= current ) {
 			return;
 		}
 		normalInterval = current;
-		wp.heartbeat.interval(target);
+		wp.heartbeat.interval( target );
 	}
 
 	function resetBackoff() {
 		unchangedTicks = 0;
-		if (normalInterval !== null) {
-			wp.heartbeat.interval(normalInterval);
+		if ( normalInterval !== null ) {
+			wp.heartbeat.interval( normalInterval );
 			normalInterval = null;
 		}
 	}
 
 	// Tabs on the same screen and post send an identical ping. Key by both
 	// so a different post or screen never gets coalesced with this one.
-	const pingContextKey = 'wp-presence-ping:' + JSON.stringify({
-		screen: window.pagenow || 'front',
-		editorPostId: editorPostId,
-		frontTitle: (frontContext && frontContext.title) || '',
-		frontPostId: (frontContext && frontContext.post_id) || 0,
-	});
+	const pingContextKey =
+		'wp-presence-ping:' +
+		JSON.stringify( {
+			screen: window.pagenow || 'front',
+			editorPostId,
+			frontTitle: ( frontContext && frontContext.title ) || '',
+			frontPostId: ( frontContext && frontContext.post_id ) || 0,
+		} );
 
 	// Response keys other presence-api features read off heartbeat-tick.
 	// Followers relay these from the leader instead of going stale. This
@@ -72,128 +74,131 @@
 		'presence-heartbeat-collaborators',
 	];
 
-	const tabCoordinator = window.wpPresenceCreateTabCoordinator(pingContextKey, RELAYED_TICK_KEYS);
+	const tabCoordinator = window.wpPresenceCreateTabCoordinator(
+		pingContextKey,
+		RELAYED_TICK_KEYS
+	);
 
 	// Defer registration to document ready to ensure it runs after WP Core's post.js handler.
-	$(function () {
-		$(document).on('heartbeat-send', function (event, data) {
+	$( function () {
+		$( document ).on( 'heartbeat-send', function ( event, data ) {
 			// Skip while the document is hidden (background tab, minimized
 			// window, app switched away) so the existing entries expire via
 			// the default TTL. One early-return suppresses both presence-ping
 			// and presence-editor-ping, since the consolidated handler emits
 			// both.
-			if (document.visibilityState === 'hidden') {
-				delete data['wp-refresh-post-lock'];
+			if ( document.visibilityState === 'hidden' ) {
+				delete data[ 'wp-refresh-post-lock' ];
 				return;
 			}
 
 			hasLeft = false;
 
-			if (!tabCoordinator.isLeader()) {
+			if ( ! tabCoordinator.isLeader() ) {
 				return;
 			}
 
 			const ping = { screen: window.pagenow || 'front' };
-			if (frontContext) {
-				if (frontContext.title) {
+			if ( frontContext ) {
+				if ( frontContext.title ) {
 					ping.title = frontContext.title;
 				}
-				if (frontContext.post_id) {
+				if ( frontContext.post_id ) {
 					ping.post_id = frontContext.post_id;
 				}
 			}
-			data['presence-ping'] = ping;
+			data[ 'presence-ping' ] = ping;
 
-			if (editorPostId) {
-				data['presence-editor-ping'] = { post_id: editorPostId };
+			if ( editorPostId ) {
+				data[ 'presence-editor-ping' ] = { post_id: editorPostId };
 			}
-		});
+		} );
 
-		if (backoffEnabled) {
+		if ( backoffEnabled ) {
 			// Reuses the Who's Online widget's hash exchange on every screen,
 			// not just the Dashboard, to learn whether the room changed.
-			$(document).on('heartbeat-send', function (event, data) {
-				if (lastOnlineHash) {
-					data['presence-online-hash'] = lastOnlineHash;
+			$( document ).on( 'heartbeat-send', function ( event, data ) {
+				if ( lastOnlineHash ) {
+					data[ 'presence-online-hash' ] = lastOnlineHash;
 				}
-			});
+			} );
 
-			$(document).on('heartbeat-tick', function (event, data) {
-				if (data['presence-online-unchanged']) {
+			$( document ).on( 'heartbeat-tick', function ( event, data ) {
+				if ( data[ 'presence-online-unchanged' ] ) {
 					unchangedTicks++;
-					if (unchangedTicks >= idleTicks) {
+					if ( unchangedTicks >= idleTicks ) {
 						widenInterval();
 					}
 					return;
 				}
-				if (data['presence-online-hash']) {
-					lastOnlineHash = data['presence-online-hash'];
+				if ( data[ 'presence-online-hash' ] ) {
+					lastOnlineHash = data[ 'presence-online-hash' ];
 				}
-				if (data['presence-online']) {
+				if ( data[ 'presence-online' ] ) {
 					resetBackoff();
 				}
-			});
+			} );
 
-			document.addEventListener('keydown', resetBackoff);
+			document.addEventListener( 'keydown', resetBackoff );
 		}
-	});
+	} );
 
 	function leave() {
-		if (hasLeft || !restUrl || !entries.length) {
+		if ( hasLeft || ! restUrl || ! entries.length ) {
 			return;
 		}
 		hasLeft = true;
 
 		// keepalive lets the DELETE outlive the unload; sendBeacon is POST-only.
-		if (typeof window.fetch !== 'function') {
+		if ( typeof window.fetch !== 'function' ) {
 			return;
 		}
 
-		entries.forEach(function (entry) {
-			if (!entry || !entry.room || !entry.client_id) {
+		entries.forEach( function ( entry ) {
+			if ( ! entry || ! entry.room || ! entry.client_id ) {
 				return;
 			}
-			const url = new URL(restUrl);
-			url.searchParams.set('room', entry.room);
-			url.searchParams.set('client_id', entry.client_id);
+			const url = new URL( restUrl );
+			url.searchParams.set( 'room', entry.room );
+			url.searchParams.set( 'client_id', entry.client_id );
 			try {
-				window.fetch(url, {
+				window.fetch( url, {
 					method: 'DELETE',
 					credentials: 'same-origin',
 					keepalive: true,
-					headers: { 'X-WP-Nonce': nonce }
-				});
+					headers: { 'X-WP-Nonce': nonce },
+				} );
 			} catch {
 				// Best-effort: TTL cleanup will catch entries we couldn't remove.
 			}
-		});
+		} );
 	}
 
 	// Re-establish presence on every page load so in-admin navigation doesn't
 	// leave a gap between the unload DELETE and the heartbeat's first tick.
 	function tickNow() {
-		if (typeof wp?.heartbeat?.connectNow === 'function') {
+		if ( typeof wp?.heartbeat?.connectNow === 'function' ) {
 			wp.heartbeat.connectNow();
 		}
 	}
-	$(tickNow);
+	$( tickNow );
 	// bfcache restore: DOMContentLoaded won't fire.
-	window.addEventListener('pageshow', function (event) {
-		if (event.persisted) {
+	window.addEventListener( 'pageshow', function ( event ) {
+		if ( event.persisted ) {
 			tickNow();
 		}
-	});
+	} );
 
 	// When the tab becomes visible again, re-establish presence so the user
 	// does not sit out the next heartbeat interval.
-	document.addEventListener('visibilitychange', function () {
-		if (document.visibilityState === 'visible') {
+	document.addEventListener( 'visibilitychange', function () {
+		if ( document.visibilityState === 'visible' ) {
 			resetBackoff();
 			tickNow();
 		}
-	});
+	} );
 
-	window.addEventListener('pagehide', function () {
+	window.addEventListener( 'pagehide', function () {
 		leave();
-	});
-})(jQuery);
+	} );
+} )( jQuery );

--- a/assets/js/stale-screen.js
+++ b/assets/js/stale-screen.js
@@ -7,6 +7,7 @@
  * translated strings are passed in via `window.wpPresenceStaleScreen`,
  * which the enqueue handler emits as a `before` inline script.
  *
+ * @param {jQuery} $ The jQuery instance.
  * @package Presence_API
  */
 
@@ -17,11 +18,11 @@
 		return;
 	}
 
-	const config      = window.wpPresenceStaleScreen || {};
-	const screenKey   = config.screenKey || '';
-	const strings     = config.strings || {};
-	let baselineRev   = parseInt( config.baselineRev, 10 ) || 0;
-	let bannerShown   = false;
+	const config = window.wpPresenceStaleScreen || {};
+	const screenKey = config.screenKey || '';
+	const strings = config.strings || {};
+	let baselineRev = parseInt( config.baselineRev, 10 ) || 0;
+	let bannerShown = false;
 
 	if ( ! screenKey ) {
 		return;
@@ -30,7 +31,10 @@
 	// Tabs on the same screen send an identical ping — key by screenKey.
 	const pingContextKey = 'wp-presence-screen-ping:' + screenKey;
 
-	const tabCoordinator = window.wpPresenceCreateTabCoordinator( pingContextKey, [ 'presence-screen-rev' ] );
+	const tabCoordinator = window.wpPresenceCreateTabCoordinator(
+		pingContextKey,
+		[ 'presence-screen-rev' ]
+	);
 
 	window.wp = window.wp || {};
 	window.wp.presence = window.wp.presence || {};
@@ -41,18 +45,20 @@
 	 * Custom REST or AJAX-driven screens should call this after a successful
 	 * save so other users viewing the same screen receive a stale notice.
 	 *
-	 * @param {string} key     The screen key (e.g. 'options/my-plugin').
+	 * @param {string} key The screen key (e.g. 'options/my-plugin').
 	 * @return {Promise} jQuery Promise.
 	 */
 	window.wp.presence.markScreenStale = function ( key ) {
 		if ( ! config.restUrl || ! config.nonce ) {
-			return $.Deferred().reject( 'Missing REST configuration.' ).promise();
+			return $.Deferred()
+				.reject( 'Missing REST configuration.' )
+				.promise();
 		}
 
 		return $.ajax( {
 			url: config.restUrl,
 			method: 'POST',
-			beforeSend: function ( xhr ) {
+			beforeSend( xhr ) {
 				xhr.setRequestHeader( 'X-WP-Nonce', config.nonce );
 			},
 			data: {
@@ -97,7 +103,9 @@
 	} );
 
 	function showBanner( info, rev ) {
-		const target = document.querySelector( '.wrap' ) || document.getElementById( 'wpbody-content' );
+		const target =
+			document.querySelector( '.wrap' ) ||
+			document.getElementById( 'wpbody-content' );
 		if ( ! target ) {
 			return;
 		}
@@ -106,10 +114,14 @@
 		// Place the notice after the screen heading, matching where
 		// `do_action('admin_notices')` injects on a normal page load.
 		const heading = target.querySelector( ':scope > h1' );
-		const before  = heading && heading.nextSibling ? heading.nextSibling : target.firstChild;
+		const before =
+			heading && heading.nextSibling
+				? heading.nextSibling
+				: target.firstChild;
 
 		const notice = document.createElement( 'div' );
-		notice.className = 'notice notice-warning is-dismissible wp-presence-stale-notice';
+		notice.className =
+			'notice notice-warning is-dismissible wp-presence-stale-notice';
 		// Announce the new banner to assistive tech without interrupting
 		// whatever the user is currently doing on the screen.
 		notice.setAttribute( 'role', 'status' );
@@ -119,23 +131,23 @@
 
 		if ( info.actor_avatar_url ) {
 			const avatar = document.createElement( 'img' );
-			avatar.src       = info.actor_avatar_url;
-			avatar.width     = 24;
-			avatar.height    = 24;
+			avatar.src = info.actor_avatar_url;
+			avatar.width = 24;
+			avatar.height = 24;
 			// Decorative — the actor name is already in the adjacent text.
-			avatar.alt       = '';
+			avatar.alt = '';
 			avatar.className = 'wp-presence-stale-avatar';
 			p.appendChild( avatar );
 		}
 
 		const text = document.createElement( 'span' );
-		text.className   = 'wp-presence-stale-text';
+		text.className = 'wp-presence-stale-text';
 		text.textContent = formatMessage( info );
 		p.appendChild( text );
 
 		const reload = document.createElement( 'button' );
-		reload.type        = 'button';
-		reload.className   = 'button button-primary';
+		reload.type = 'button';
+		reload.className = 'button button-primary';
 		reload.textContent = strings.reload || 'Reload';
 		reload.addEventListener( 'click', function () {
 			window.location.reload();
@@ -144,10 +156,10 @@
 		notice.appendChild( p );
 
 		const dismiss = document.createElement( 'button' );
-		dismiss.type      = 'button';
+		dismiss.type = 'button';
 		dismiss.className = 'notice-dismiss';
 		const sr = document.createElement( 'span' );
-		sr.className   = 'screen-reader-text';
+		sr.className = 'screen-reader-text';
 		sr.textContent = strings.dismiss || 'Dismiss this notice.';
 		dismiss.appendChild( sr );
 		dismiss.addEventListener( 'click', function () {
@@ -170,10 +182,13 @@
 			// interpretation so display names with `$&`, `$1`, etc. don't
 			// get reinterpreted as backreferences.
 			return ( strings.updatedBy || '%1$s updated this screen %2$s.' )
-				.split( '%1$s' ).join( info.actor_name )
-				.split( '%2$s' ).join( timeAgo );
+				.split( '%1$s' )
+				.join( info.actor_name )
+				.split( '%2$s' )
+				.join( timeAgo );
 		}
 		return ( strings.updatedAnonymously || 'This screen was updated %s.' )
-			.split( '%s' ).join( timeAgo );
+			.split( '%s' )
+			.join( timeAgo );
 	}
 } )( jQuery );

--- a/assets/js/tab-coordinator.js
+++ b/assets/js/tab-coordinator.js
@@ -6,6 +6,7 @@
  * pinging independently. Falls back to independent pinging when Web Locks
  * or BroadcastChannel aren't available.
  *
+ * @param {jQuery} $ The jQuery instance.
  * @package Presence_API
  */
 ( function ( $ ) {
@@ -17,16 +18,18 @@
 	 * @return {{isLeader: function(): boolean}} Coordinator handle.
 	 */
 	window.wpPresenceCreateTabCoordinator = function ( key, relayedKeys ) {
-		var hasLocks = typeof navigator !== 'undefined' &&
+		const hasLocks =
+			typeof navigator !== 'undefined' &&
 			navigator.locks &&
 			typeof navigator.locks.request === 'function';
 
 		// No Locks API: ping independently, same as before.
-		var isPingLeader = ! hasLocks;
+		let isPingLeader = ! hasLocks;
 
-		var channel = hasLocks && typeof BroadcastChannel === 'function'
-			? new BroadcastChannel( key )
-			: null;
+		const channel =
+			hasLocks && typeof BroadcastChannel === 'function'
+				? new BroadcastChannel( key )
+				: null;
 
 		if ( channel ) {
 			channel.addEventListener( 'message', function ( event ) {
@@ -52,11 +55,13 @@
 					return;
 				}
 
-				var relayed = {};
-				var hasRelayedData = false;
+				const relayed = {};
+				let hasRelayedData = false;
 
 				relayedKeys.forEach( function ( relayedKey ) {
-					if ( Object.prototype.hasOwnProperty.call( data, relayedKey ) ) {
+					if (
+						Object.prototype.hasOwnProperty.call( data, relayedKey )
+					) {
 						relayed[ relayedKey ] = data[ relayedKey ];
 						hasRelayedData = true;
 					}
@@ -69,7 +74,7 @@
 		}
 
 		return {
-			isLeader: function () {
+			isLeader() {
 				return isPingLeader;
 			},
 		};

--- a/assets/js/test/network-whos-online-widget.test.js
+++ b/assets/js/test/network-whos-online-widget.test.js
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for the network Who's Online dashboard widget's focus handling.
+ *
+ * Each swap of #presence-network-widget-list would otherwise drop a keyboard
+ * user back to the document body, so captureFocus()/restoreFocus() have to
+ * find the equivalent spot in the new markup. These drive the real module
+ * through heartbeat-tick events rather than reimplementing its logic.
+ *
+ * @package Presence_API
+ */
+
+require( '../avatar-stack' );
+
+const I18N = {
+	noUsersOnline: 'No users are currently online anywhere on the network.',
+	notAggregated:
+		'Presence is not aggregated across this network, so who is online cannot be shown.',
+	sitesOnline: 'Sites with online users',
+	moreSite: '+%d more site — view all',
+	moreSites: '+%d more sites — view all',
+};
+
+function loadWidget( config ) {
+	global.wp = { heartbeat: {} };
+	window.wpPresenceNetworkWhosOnline = {
+		i18n: I18N,
+		viewAllUrl: '/wp-admin/network/sites.php',
+		avatarMax: 3,
+		...config,
+	};
+
+	let $;
+	jest.isolateModules( () => {
+		$ = require( 'jquery' );
+		global.jQuery = $;
+		require( '../network-whos-online-widget' );
+	} );
+
+	document.body.innerHTML =
+		'<div id="presence-network-widget-list" aria-live="polite" tabindex="-1"></div>';
+
+	return {
+		$,
+		container: document.getElementById( 'presence-network-widget-list' ),
+	};
+}
+
+function tick( $, sites, overflow ) {
+	$( document ).trigger( 'heartbeat-tick', [
+		{
+			'presence-network-widget': sites,
+			'presence-network-widget-overflow': overflow || 0,
+		},
+	] );
+}
+
+describe( "Network Who's Online widget focus handling", () => {
+	afterEach( () => {
+		delete global.wp;
+		delete global.jQuery;
+		delete window.wpPresenceNetworkWhosOnline;
+		document.body.innerHTML = '';
+	} );
+
+	it( "restores focus to the same site's link after a content-changing re-render", () => {
+		const { $, container } = loadWidget();
+
+		tick( $, [
+			{
+				blog_id: 1,
+				url: 'https://a.example',
+				domain: 'a.example',
+				path: '/',
+				user_count: 2,
+				users: [],
+			},
+		] );
+		container.querySelector( '[data-blog-id="1"] a' ).focus();
+
+		tick( $, [
+			{
+				blog_id: 1,
+				url: 'https://a.example',
+				domain: 'a.example',
+				path: '/',
+				user_count: 3,
+				users: [],
+			},
+		] );
+
+		expect( document.activeElement ).toBe(
+			container.querySelector( '[data-blog-id="1"] a' )
+		);
+	} );
+
+	it( 'restores focus to the "more" link after a content-changing re-render', () => {
+		const { $, container } = loadWidget();
+
+		tick(
+			$,
+			[
+				{
+					blog_id: 1,
+					url: 'https://a.example',
+					domain: 'a.example',
+					path: '/',
+					user_count: 2,
+					users: [],
+				},
+			],
+			1
+		);
+		container.querySelector( '.presence-more-link' ).focus();
+
+		tick(
+			$,
+			[
+				{
+					blog_id: 1,
+					url: 'https://a.example',
+					domain: 'a.example',
+					path: '/',
+					user_count: 3,
+					users: [],
+				},
+			],
+			1
+		);
+
+		expect( document.activeElement ).toBe(
+			container.querySelector( '.presence-more-link' )
+		);
+	} );
+
+	it( 'leaves focus alone when it is outside the widget', () => {
+		const { $ } = loadWidget();
+		const outside = document.createElement( 'button' );
+		document.body.appendChild( outside );
+		outside.focus();
+
+		tick( $, [
+			{
+				blog_id: 1,
+				url: 'https://a.example',
+				domain: 'a.example',
+				path: '/',
+				user_count: 2,
+				users: [],
+			},
+		] );
+
+		expect( document.activeElement ).toBe( outside );
+	} );
+
+	it( 'falls back to the container when the focused site disappears', () => {
+		const { $, container } = loadWidget();
+
+		tick( $, [
+			{
+				blog_id: 1,
+				url: 'https://a.example',
+				domain: 'a.example',
+				path: '/',
+				user_count: 2,
+				users: [],
+			},
+		] );
+		container.querySelector( '[data-blog-id="1"] a' ).focus();
+
+		tick( $, [
+			{
+				blog_id: 2,
+				url: 'https://b.example',
+				domain: 'b.example',
+				path: '/',
+				user_count: 1,
+				users: [],
+			},
+		] );
+
+		expect( document.activeElement ).toBe( container );
+	} );
+} );

--- a/assets/js/test/tab-coordinator.test.js
+++ b/assets/js/test/tab-coordinator.test.js
@@ -74,7 +74,11 @@ class FakeBroadcastChannel {
  * @param {number} maxRounds
  */
 function drainDeliveries( maxRounds = 10 ) {
-	for ( let round = 0; round < maxRounds && pendingDeliveries.length; round++ ) {
+	for (
+		let round = 0;
+		round < maxRounds && pendingDeliveries.length;
+		round++
+	) {
 		const batch = pendingDeliveries;
 		pendingDeliveries = [];
 		batch.forEach( ( deliver ) => deliver() );

--- a/assets/js/test/whos-online-widget.test.js
+++ b/assets/js/test/whos-online-widget.test.js
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the Who's Online dashboard widget's focus handling.
+ *
+ * Each swap of #presence-whos-online-list would otherwise drop a keyboard
+ * user back to the document body, so captureFocus()/restoreFocus() have to
+ * find the equivalent spot in the new markup. These drive the real module
+ * through heartbeat-tick events rather than reimplementing its logic.
+ *
+ * @package Presence_API
+ */
+
+require( '../avatar-stack' );
+
+const I18N = {
+	noUsersOnline: 'No users are online.',
+	onlineNow: 'Online now',
+	usersOnline: 'Users currently online',
+	additionalUsers: 'Additional online users',
+	showLess: 'Show less',
+	moreCount: '+%d more',
+	moreCountLink: '+%d more — view all users',
+	secondsAgo: '%d seconds ago',
+	minutesAgo: '%d min ago',
+	hourAgo: '%d hour ago',
+	hoursAgo: '%d hours ago',
+};
+
+function isoNow() {
+	return new Date().toISOString().slice( 0, 19 );
+}
+
+function loadWidget( config ) {
+	global.wp = { heartbeat: {} };
+	window.wpPresenceWhosOnline = {
+		screenLabels: {},
+		screenUrls: { dashboard: '/wp-admin/', posts: '/wp-admin/edit.php' },
+		idleThreshold: 300,
+		overflowThreshold: 10,
+		usersUrl: '',
+		avatarMax: 3,
+		maxRows: 5,
+		i18n: I18N,
+		...config,
+	};
+
+	let $;
+	jest.isolateModules( () => {
+		$ = require( 'jquery' );
+		global.jQuery = $;
+		require( '../whos-online-widget' );
+	} );
+
+	document.body.innerHTML =
+		'<div id="presence-whos-online-list" aria-live="polite" tabindex="-1"></div>';
+
+	return {
+		$,
+		container: document.getElementById( 'presence-whos-online-list' ),
+	};
+}
+
+function tick( $, entries ) {
+	$( document ).trigger( 'heartbeat-tick', [
+		{ 'presence-online': entries },
+	] );
+}
+
+describe( "Who's Online widget focus handling", () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+		delete global.wp;
+		delete global.jQuery;
+		delete window.wpPresenceWhosOnline;
+		document.body.innerHTML = '';
+	} );
+
+	it( "restores focus to the same user's row after a content-changing re-render", () => {
+		const { $, container } = loadWidget();
+
+		tick( $, [
+			{
+				user_id: 1,
+				display_name: 'Alice',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+		] );
+		container.querySelector( '[data-user-id="1"] a' ).focus();
+
+		tick( $, [
+			{
+				user_id: 1,
+				display_name: 'Alice',
+				screen: 'posts',
+				date_gmt: isoNow(),
+			},
+		] );
+
+		expect( container.contains( document.activeElement ) ).toBe( true );
+		expect( document.activeElement.getAttribute( 'href' ) ).toBe(
+			'/wp-admin/edit.php'
+		);
+	} );
+
+	it( 'restores focus to the overflow toggle after a content-changing re-render', () => {
+		const { $, container } = loadWidget( { maxRows: 1 } );
+
+		tick( $, [
+			{
+				user_id: 1,
+				display_name: 'Alice',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+			{
+				user_id: 2,
+				display_name: 'Bob',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+		] );
+		container.querySelector( '[data-action="expand"]' ).focus();
+
+		tick( $, [
+			{
+				user_id: 1,
+				display_name: 'Alice',
+				screen: 'posts',
+				date_gmt: isoNow(),
+			},
+			{
+				user_id: 2,
+				display_name: 'Bob',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+		] );
+
+		expect( document.activeElement ).toBe(
+			container.querySelector( '[data-action="expand"]' )
+		);
+	} );
+
+	it( 'leaves focus alone when it is outside the widget', () => {
+		const { $ } = loadWidget();
+		const outside = document.createElement( 'button' );
+		document.body.appendChild( outside );
+		outside.focus();
+
+		tick( $, [
+			{
+				user_id: 1,
+				display_name: 'Alice',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+		] );
+
+		expect( document.activeElement ).toBe( outside );
+	} );
+
+	it( 'falls back to the container when the focused row disappears', () => {
+		const { $, container } = loadWidget();
+
+		tick( $, [
+			{
+				user_id: 1,
+				display_name: 'Alice',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+		] );
+		container.querySelector( '[data-user-id="1"] a' ).focus();
+
+		tick( $, [
+			{
+				user_id: 2,
+				display_name: 'Bob',
+				screen: 'dashboard',
+				date_gmt: isoNow(),
+			},
+		] );
+
+		expect( document.activeElement ).toBe( container );
+	} );
+} );

--- a/assets/js/whos-online-widget.js
+++ b/assets/js/whos-online-widget.js
@@ -1,0 +1,261 @@
+/**
+ * Who's Online dashboard widget client.
+ *
+ * @package Presence_API
+ */
+
+(function($) {
+	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+		return;
+	}
+
+	var config = window.wpPresenceWhosOnline || {};
+	var screenLabels = config.screenLabels || {};
+	var screenUrls = config.screenUrls || {};
+	var i18n = config.i18n || {};
+	var idleThreshold = config.idleThreshold;
+	var overflowThreshold = config.overflowThreshold;
+	var usersUrl = config.usersUrl || '';
+	var avatarMax = config.avatarMax;
+
+	function esc(str) {
+		var el = document.createElement('span');
+		el.textContent = str;
+		return el.innerHTML;
+	}
+
+	function friendlyScreen(slug) {
+		if (screenLabels[slug]) {
+			return screenLabels[slug];
+		}
+		return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+	}
+
+	function relativeTime(dateGmt) {
+		var seconds = Math.floor(Date.now() / 1000 - new Date(dateGmt + 'Z').getTime() / 1000);
+		if (seconds < idleThreshold) {
+			return '';
+		}
+		if (seconds < 60) {
+			return i18n.secondsAgo.replace('%d', seconds);
+		}
+		var minutes = Math.floor(seconds / 60);
+		if (minutes < 60) {
+			return i18n.minutesAgo.replace('%d', minutes);
+		}
+		var hours = Math.floor(minutes / 60);
+		return (hours > 1 ? i18n.hoursAgo : i18n.hourAgo).replace('%d', hours);
+	}
+
+	var isExpanded = false;
+	var lastSignature = '';
+	var lastEntries = [];
+	var lastHash = '';
+
+	function captureFocus(container) {
+		var active = document.activeElement;
+		if (!active || !$.contains(container[0], active)) {
+			return null;
+		}
+		var $active = $(active);
+		var item = $active.closest('[data-user-id]');
+		if (item.length) {
+			return { type: 'user', id: item.data('user-id') };
+		}
+		var action = $active.data('action');
+		if (action) {
+			return { type: 'action', action: action };
+		}
+		return { type: 'none' };
+	}
+
+	function restoreFocus(container, info) {
+		if (!info) {
+			return;
+		}
+		var target = null;
+		if (info.type === 'user') {
+			target = container.find('[data-user-id="' + info.id + '"] a, [data-user-id="' + info.id + '"] button').first();
+		} else if (info.type === 'action') {
+			target = container.find('[data-action="' + info.action + '"]');
+		}
+		if (target && target.length) {
+			target.trigger('focus');
+		} else {
+			container.trigger('focus');
+		}
+	}
+
+	function buildRowHtml(entry) {
+		var html = '';
+		if (entry.avatar_url) {
+			html += '<img src="' + esc(entry.avatar_url) + '" width="24" height="24" alt="' + esc(entry.display_name) + '" />';
+		}
+		var timeStr = entry.date_gmt ? relativeTime(entry.date_gmt) : '';
+		var dotTitle = timeStr || i18n.onlineNow;
+		var elapsed = entry.date_gmt ? Math.floor(Date.now() / 1000 - new Date(entry.date_gmt + 'Z').getTime() / 1000) : 0;
+		var idleClass = elapsed >= idleThreshold ? ' is-idle' : '';
+		html += '<div class="presence-user-info">';
+		html += '<span class="presence-name">' + esc(entry.display_name) + '</span>';
+		if (entry.screen) {
+			var screenText = entry.screen_label || friendlyScreen(entry.screen);
+			var parts = screenText.split(' ');
+			var formatted = parts.length > 1 ? '<em>' + esc(parts[0]) + '</em> ' + esc(parts.slice(1).join(' ')) : esc(screenText);
+			if (screenUrls[entry.screen]) {
+				html += '<span class="presence-screen"><a href="' + esc(screenUrls[entry.screen]) + '">' + formatted + '</a></span>';
+			} else {
+				html += '<span class="presence-screen">' + formatted + '</span>';
+			}
+		}
+		html += '</div>';
+		html += '<span class="presence-online-dot' + idleClass + '" role="img" aria-label="' + esc(dotTitle) + '" title="' + esc(dotTitle) + '"></span>';
+		return html;
+	}
+
+	function buildFullHtml(visible, overflow, overflowTotal) {
+		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.usersOnline) + '">';
+		visible.forEach(function(entry) {
+			html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
+		});
+		html += '</ul>';
+		if (overflow.length) {
+			if (overflowTotal > overflowThreshold) {
+				// Summary mode: avatar stack + count linking to Users page.
+				html += '<a href="' + esc(usersUrl) + '" class="presence-overflow-toggle">';
+				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
+				html += '<span class="presence-overflow-text">' + esc(i18n.moreCountLink.replace('%d', overflowTotal)) + '</span></a>';
+			} else {
+				// Expandable list mode.
+				html += '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="presence-overflow-list"';
+				if (isExpanded) html += ' style="display:none"';
+				html += '>';
+				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
+				html += '<span class="presence-overflow-text">' + esc(i18n.moreCount.replace('%d', overflow.length)) + '</span></button>';
+				html += '<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' + esc(i18n.additionalUsers) + '"';
+				if (!isExpanded) html += ' style="display:none"';
+				html += '>';
+				overflow.forEach(function(entry) {
+					html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
+				});
+				html += '</ul>';
+				html += '<button type="button" class="presence-overflow-toggle" data-action="collapse" aria-controls="presence-overflow-list"';
+				if (!isExpanded) html += ' style="display:none"';
+				html += '>' + esc(i18n.showLess) + '</button>';
+			}
+		}
+		return html;
+	}
+
+	$(document).on('heartbeat-send', function(event, data) {
+		if (lastHash) {
+			data['presence-online-hash'] = lastHash;
+		}
+	});
+
+	// Update the widget when heartbeat response comes back.
+	$(document).on('heartbeat-tick', function(event, data) {
+		if (data['presence-online-unchanged']) {
+			// Only freshness can have moved, so feed the idle sweep and leave
+			// the DOM alone.
+			var seen = data['presence-online-unchanged'];
+			for (var i = 0; i < lastEntries.length; i++) {
+				if (seen[lastEntries[i].user_id]) {
+					lastEntries[i].date_gmt = seen[lastEntries[i].user_id];
+				}
+			}
+			return;
+		}
+
+		if (!data['presence-online']) {
+			return;
+		}
+
+		lastHash = data['presence-online-hash'] || '';
+
+		var container = $('#presence-whos-online-list');
+		if (!container.length) {
+			return;
+		}
+
+		var entries = data['presence-online'];
+		lastEntries = entries;
+
+		if (!entries.length) {
+			if (lastSignature !== '') {
+				var clearFocus = captureFocus(container);
+				container.html('<p>' + esc(i18n.noUsersOnline) + '</p>');
+				restoreFocus(container, clearFocus);
+				lastSignature = '';
+			}
+			return;
+		}
+
+		// Sort by most recently active first.
+		entries.sort(function(a, b) {
+			return (b.date_gmt || '').localeCompare(a.date_gmt || '');
+		});
+
+		var maxRows = config.maxRows;
+		var visible = entries.slice(0, maxRows);
+		var overflow = entries.slice(maxRows);
+
+		// The payload is capped, so its length understates a large room. Below
+		// the threshold the cap cannot bite and the array holds all of them.
+		var total = typeof data['presence-online-total'] === 'number' ? data['presence-online-total'] : entries.length;
+		var overflowTotal = total - maxRows;
+
+		// Build a signature of user IDs + screens to detect real changes. The
+		// total leads it because the overflow count is now derived from the
+		// total, which moves while the capped entries stay identical.
+		var sig = total + '|' + entries.map(function(e) { return e.user_id + ':' + (e.screen || ''); }).join(',');
+
+		if (sig !== lastSignature) {
+			// Content changed — swap HTML instantly.
+			var focusInfo = captureFocus(container);
+			container.html(buildFullHtml(visible, overflow, overflowTotal));
+			restoreFocus(container, focusInfo);
+			lastSignature = sig;
+		} else {
+			// Same users, same screens — update only dot tooltips.
+			container.find('.presence-user-item').each(function() {
+				var uid = $(this).data('user-id');
+				for (var i = 0; i < entries.length; i++) {
+					if (entries[i].user_id === uid) {
+						var timeStr = entries[i].date_gmt ? relativeTime(entries[i].date_gmt) : '';
+						var dotTitle = timeStr || i18n.onlineNow;
+						$(this).find('.presence-online-dot').attr('title', dotTitle).attr('aria-label', dotTitle);
+						break;
+					}
+				}
+			});
+		}
+	});
+
+	// Re-evaluate idle dots between heartbeat ticks.
+	setInterval(function() {
+		if (!lastEntries.length) return;
+		$('#presence-whos-online-list .presence-user-item').each(function() {
+			var uid = $(this).data('user-id');
+			for (var i = 0; i < lastEntries.length; i++) {
+				if (lastEntries[i].user_id === uid && lastEntries[i].date_gmt) {
+					var elapsed = Math.floor(Date.now() / 1000 - new Date(lastEntries[i].date_gmt + 'Z').getTime() / 1000);
+					var dot = $(this).find('.presence-online-dot');
+					dot.toggleClass('is-idle', elapsed >= idleThreshold);
+					var timeStr = relativeTime(lastEntries[i].date_gmt);
+					var dotTitle = timeStr || i18n.onlineNow;
+					dot.attr('title', dotTitle).attr('aria-label', dotTitle);
+					break;
+				}
+			}
+		});
+	}, 5000);
+
+	// Toggle expand/collapse.
+	$('#presence-whos-online-list').on('click', '.presence-overflow-toggle', function() {
+		isExpanded = $(this).data('action') === 'expand';
+		var wrap = $('#presence-whos-online-list');
+		wrap.find('[data-action="expand"]').toggle(!isExpanded).attr('aria-expanded', String(!isExpanded));
+		wrap.find('#presence-overflow-list').toggle(isExpanded);
+		wrap.find('[data-action="collapse"]').toggle(isExpanded).attr('aria-expanded', String(isExpanded));
+	});
+})(jQuery);

--- a/assets/js/whos-online-widget.js
+++ b/assets/js/whos-online-widget.js
@@ -1,261 +1,393 @@
 /**
  * Who's Online dashboard widget client.
  *
+ * @param {jQuery} $ The jQuery instance.
  * @package Presence_API
  */
 
-(function($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
+( function ( $ ) {
+	if ( typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined' ) {
 		return;
 	}
 
-	var config = window.wpPresenceWhosOnline || {};
-	var screenLabels = config.screenLabels || {};
-	var screenUrls = config.screenUrls || {};
-	var i18n = config.i18n || {};
-	var idleThreshold = config.idleThreshold;
-	var overflowThreshold = config.overflowThreshold;
-	var usersUrl = config.usersUrl || '';
-	var avatarMax = config.avatarMax;
+	const config = window.wpPresenceWhosOnline || {};
+	const screenLabels = config.screenLabels || {};
+	const screenUrls = config.screenUrls || {};
+	const i18n = config.i18n || {};
+	const idleThreshold = config.idleThreshold;
+	const overflowThreshold = config.overflowThreshold;
+	const usersUrl = config.usersUrl || '';
+	const avatarMax = config.avatarMax;
 
-	function esc(str) {
-		var el = document.createElement('span');
+	function esc( str ) {
+		const el = document.createElement( 'span' );
 		el.textContent = str;
 		return el.innerHTML;
 	}
 
-	function friendlyScreen(slug) {
-		if (screenLabels[slug]) {
-			return screenLabels[slug];
+	function friendlyScreen( slug ) {
+		if ( screenLabels[ slug ] ) {
+			return screenLabels[ slug ];
 		}
-		return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+		return slug.replace( /[-_]/g, ' ' ).replace( /\b\w/g, function ( c ) {
+			return c.toUpperCase();
+		} );
 	}
 
-	function relativeTime(dateGmt) {
-		var seconds = Math.floor(Date.now() / 1000 - new Date(dateGmt + 'Z').getTime() / 1000);
-		if (seconds < idleThreshold) {
+	function relativeTime( dateGmt ) {
+		const seconds = Math.floor(
+			Date.now() / 1000 - new Date( dateGmt + 'Z' ).getTime() / 1000
+		);
+		if ( seconds < idleThreshold ) {
 			return '';
 		}
-		if (seconds < 60) {
-			return i18n.secondsAgo.replace('%d', seconds);
+		if ( seconds < 60 ) {
+			return i18n.secondsAgo.replace( '%d', seconds );
 		}
-		var minutes = Math.floor(seconds / 60);
-		if (minutes < 60) {
-			return i18n.minutesAgo.replace('%d', minutes);
+		const minutes = Math.floor( seconds / 60 );
+		if ( minutes < 60 ) {
+			return i18n.minutesAgo.replace( '%d', minutes );
 		}
-		var hours = Math.floor(minutes / 60);
-		return (hours > 1 ? i18n.hoursAgo : i18n.hourAgo).replace('%d', hours);
+		const hours = Math.floor( minutes / 60 );
+		return ( hours > 1 ? i18n.hoursAgo : i18n.hourAgo ).replace(
+			'%d',
+			hours
+		);
 	}
 
-	var isExpanded = false;
-	var lastSignature = '';
-	var lastEntries = [];
-	var lastHash = '';
+	let isExpanded = false;
+	let lastSignature = '';
+	let lastEntries = [];
+	let lastHash = '';
 
-	function captureFocus(container) {
-		var active = document.activeElement;
-		if (!active || !$.contains(container[0], active)) {
+	function captureFocus( container ) {
+		const active = document.activeElement;
+		if ( ! active || ! $.contains( container[ 0 ], active ) ) {
 			return null;
 		}
-		var $active = $(active);
-		var item = $active.closest('[data-user-id]');
-		if (item.length) {
-			return { type: 'user', id: item.data('user-id') };
+		const $active = $( active );
+		const item = $active.closest( '[data-user-id]' );
+		if ( item.length ) {
+			return { type: 'user', id: item.data( 'user-id' ) };
 		}
-		var action = $active.data('action');
-		if (action) {
-			return { type: 'action', action: action };
+		const action = $active.data( 'action' );
+		if ( action ) {
+			return { type: 'action', action };
 		}
 		return { type: 'none' };
 	}
 
-	function restoreFocus(container, info) {
-		if (!info) {
+	function restoreFocus( container, info ) {
+		if ( ! info ) {
 			return;
 		}
-		var target = null;
-		if (info.type === 'user') {
-			target = container.find('[data-user-id="' + info.id + '"] a, [data-user-id="' + info.id + '"] button').first();
-		} else if (info.type === 'action') {
-			target = container.find('[data-action="' + info.action + '"]');
+		let target = null;
+		if ( info.type === 'user' ) {
+			target = container
+				.find(
+					'[data-user-id="' +
+						info.id +
+						'"] a, [data-user-id="' +
+						info.id +
+						'"] button'
+				)
+				.first();
+		} else if ( info.type === 'action' ) {
+			target = container.find( '[data-action="' + info.action + '"]' );
 		}
-		if (target && target.length) {
-			target.trigger('focus');
+		if ( target && target.length ) {
+			target.trigger( 'focus' );
 		} else {
-			container.trigger('focus');
+			container.trigger( 'focus' );
 		}
 	}
 
-	function buildRowHtml(entry) {
-		var html = '';
-		if (entry.avatar_url) {
-			html += '<img src="' + esc(entry.avatar_url) + '" width="24" height="24" alt="' + esc(entry.display_name) + '" />';
+	function buildRowHtml( entry ) {
+		let html = '';
+		if ( entry.avatar_url ) {
+			html +=
+				'<img src="' +
+				esc( entry.avatar_url ) +
+				'" width="24" height="24" alt="' +
+				esc( entry.display_name ) +
+				'" />';
 		}
-		var timeStr = entry.date_gmt ? relativeTime(entry.date_gmt) : '';
-		var dotTitle = timeStr || i18n.onlineNow;
-		var elapsed = entry.date_gmt ? Math.floor(Date.now() / 1000 - new Date(entry.date_gmt + 'Z').getTime() / 1000) : 0;
-		var idleClass = elapsed >= idleThreshold ? ' is-idle' : '';
+		const timeStr = entry.date_gmt ? relativeTime( entry.date_gmt ) : '';
+		const dotTitle = timeStr || i18n.onlineNow;
+		const elapsed = entry.date_gmt
+			? Math.floor(
+					Date.now() / 1000 -
+						new Date( entry.date_gmt + 'Z' ).getTime() / 1000
+			  )
+			: 0;
+		const idleClass = elapsed >= idleThreshold ? ' is-idle' : '';
 		html += '<div class="presence-user-info">';
-		html += '<span class="presence-name">' + esc(entry.display_name) + '</span>';
-		if (entry.screen) {
-			var screenText = entry.screen_label || friendlyScreen(entry.screen);
-			var parts = screenText.split(' ');
-			var formatted = parts.length > 1 ? '<em>' + esc(parts[0]) + '</em> ' + esc(parts.slice(1).join(' ')) : esc(screenText);
-			if (screenUrls[entry.screen]) {
-				html += '<span class="presence-screen"><a href="' + esc(screenUrls[entry.screen]) + '">' + formatted + '</a></span>';
+		html +=
+			'<span class="presence-name">' +
+			esc( entry.display_name ) +
+			'</span>';
+		if ( entry.screen ) {
+			const screenText =
+				entry.screen_label || friendlyScreen( entry.screen );
+			const parts = screenText.split( ' ' );
+			const formatted =
+				parts.length > 1
+					? '<em>' +
+					  esc( parts[ 0 ] ) +
+					  '</em> ' +
+					  esc( parts.slice( 1 ).join( ' ' ) )
+					: esc( screenText );
+			if ( screenUrls[ entry.screen ] ) {
+				html +=
+					'<span class="presence-screen"><a href="' +
+					esc( screenUrls[ entry.screen ] ) +
+					'">' +
+					formatted +
+					'</a></span>';
 			} else {
-				html += '<span class="presence-screen">' + formatted + '</span>';
+				html +=
+					'<span class="presence-screen">' + formatted + '</span>';
 			}
 		}
 		html += '</div>';
-		html += '<span class="presence-online-dot' + idleClass + '" role="img" aria-label="' + esc(dotTitle) + '" title="' + esc(dotTitle) + '"></span>';
+		html +=
+			'<span class="presence-online-dot' +
+			idleClass +
+			'" role="img" aria-label="' +
+			esc( dotTitle ) +
+			'" title="' +
+			esc( dotTitle ) +
+			'"></span>';
 		return html;
 	}
 
-	function buildFullHtml(visible, overflow, overflowTotal) {
-		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.usersOnline) + '">';
-		visible.forEach(function(entry) {
-			html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
-		});
+	function buildFullHtml( visible, overflow, overflowTotal ) {
+		let html =
+			'<ul class="presence-user-list" aria-label="' +
+			esc( i18n.usersOnline ) +
+			'">';
+		visible.forEach( function ( entry ) {
+			html +=
+				'<li class="presence-user-item" data-user-id="' +
+				entry.user_id +
+				'">' +
+				buildRowHtml( entry ) +
+				'</li>';
+		} );
 		html += '</ul>';
-		if (overflow.length) {
-			if (overflowTotal > overflowThreshold) {
+		if ( overflow.length ) {
+			if ( overflowTotal > overflowThreshold ) {
 				// Summary mode: avatar stack + count linking to Users page.
-				html += '<a href="' + esc(usersUrl) + '" class="presence-overflow-toggle">';
-				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
-				html += '<span class="presence-overflow-text">' + esc(i18n.moreCountLink.replace('%d', overflowTotal)) + '</span></a>';
+				html +=
+					'<a href="' +
+					esc( usersUrl ) +
+					'" class="presence-overflow-toggle">';
+				html += window.wpPresenceBuildAvatarStack(
+					overflow,
+					avatarMax
+				);
+				html +=
+					'<span class="presence-overflow-text">' +
+					esc( i18n.moreCountLink.replace( '%d', overflowTotal ) ) +
+					'</span></a>';
 			} else {
 				// Expandable list mode.
-				html += '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="presence-overflow-list"';
-				if (isExpanded) html += ' style="display:none"';
+				html +=
+					'<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="' +
+					( isExpanded ? 'true' : 'false' ) +
+					'" aria-controls="presence-overflow-list"';
+				if ( isExpanded ) {
+					html += ' style="display:none"';
+				}
 				html += '>';
-				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
-				html += '<span class="presence-overflow-text">' + esc(i18n.moreCount.replace('%d', overflow.length)) + '</span></button>';
-				html += '<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' + esc(i18n.additionalUsers) + '"';
-				if (!isExpanded) html += ' style="display:none"';
+				html += window.wpPresenceBuildAvatarStack(
+					overflow,
+					avatarMax
+				);
+				html +=
+					'<span class="presence-overflow-text">' +
+					esc( i18n.moreCount.replace( '%d', overflow.length ) ) +
+					'</span></button>';
+				html +=
+					'<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' +
+					esc( i18n.additionalUsers ) +
+					'"';
+				if ( ! isExpanded ) {
+					html += ' style="display:none"';
+				}
 				html += '>';
-				overflow.forEach(function(entry) {
-					html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
-				});
+				overflow.forEach( function ( entry ) {
+					html +=
+						'<li class="presence-user-item" data-user-id="' +
+						entry.user_id +
+						'">' +
+						buildRowHtml( entry ) +
+						'</li>';
+				} );
 				html += '</ul>';
-				html += '<button type="button" class="presence-overflow-toggle" data-action="collapse" aria-controls="presence-overflow-list"';
-				if (!isExpanded) html += ' style="display:none"';
-				html += '>' + esc(i18n.showLess) + '</button>';
+				html +=
+					'<button type="button" class="presence-overflow-toggle" data-action="collapse" aria-controls="presence-overflow-list"';
+				if ( ! isExpanded ) {
+					html += ' style="display:none"';
+				}
+				html += '>' + esc( i18n.showLess ) + '</button>';
 			}
 		}
 		return html;
 	}
 
-	$(document).on('heartbeat-send', function(event, data) {
-		if (lastHash) {
-			data['presence-online-hash'] = lastHash;
+	$( document ).on( 'heartbeat-send', function ( event, data ) {
+		if ( lastHash ) {
+			data[ 'presence-online-hash' ] = lastHash;
 		}
-	});
+	} );
 
 	// Update the widget when heartbeat response comes back.
-	$(document).on('heartbeat-tick', function(event, data) {
-		if (data['presence-online-unchanged']) {
+	$( document ).on( 'heartbeat-tick', function ( event, data ) {
+		if ( data[ 'presence-online-unchanged' ] ) {
 			// Only freshness can have moved, so feed the idle sweep and leave
 			// the DOM alone.
-			var seen = data['presence-online-unchanged'];
-			for (var i = 0; i < lastEntries.length; i++) {
-				if (seen[lastEntries[i].user_id]) {
-					lastEntries[i].date_gmt = seen[lastEntries[i].user_id];
+			const seen = data[ 'presence-online-unchanged' ];
+			for ( let i = 0; i < lastEntries.length; i++ ) {
+				if ( seen[ lastEntries[ i ].user_id ] ) {
+					lastEntries[ i ].date_gmt =
+						seen[ lastEntries[ i ].user_id ];
 				}
 			}
 			return;
 		}
 
-		if (!data['presence-online']) {
+		if ( ! data[ 'presence-online' ] ) {
 			return;
 		}
 
-		lastHash = data['presence-online-hash'] || '';
+		lastHash = data[ 'presence-online-hash' ] || '';
 
-		var container = $('#presence-whos-online-list');
-		if (!container.length) {
+		const container = $( '#presence-whos-online-list' );
+		if ( ! container.length ) {
 			return;
 		}
 
-		var entries = data['presence-online'];
+		const entries = data[ 'presence-online' ];
 		lastEntries = entries;
 
-		if (!entries.length) {
-			if (lastSignature !== '') {
-				var clearFocus = captureFocus(container);
-				container.html('<p>' + esc(i18n.noUsersOnline) + '</p>');
-				restoreFocus(container, clearFocus);
+		if ( ! entries.length ) {
+			if ( lastSignature !== '' ) {
+				const clearFocus = captureFocus( container );
+				container.html( '<p>' + esc( i18n.noUsersOnline ) + '</p>' );
+				restoreFocus( container, clearFocus );
 				lastSignature = '';
 			}
 			return;
 		}
 
 		// Sort by most recently active first.
-		entries.sort(function(a, b) {
-			return (b.date_gmt || '').localeCompare(a.date_gmt || '');
-		});
+		entries.sort( function ( a, b ) {
+			return ( b.date_gmt || '' ).localeCompare( a.date_gmt || '' );
+		} );
 
-		var maxRows = config.maxRows;
-		var visible = entries.slice(0, maxRows);
-		var overflow = entries.slice(maxRows);
+		const maxRows = config.maxRows;
+		const visible = entries.slice( 0, maxRows );
+		const overflow = entries.slice( maxRows );
 
 		// The payload is capped, so its length understates a large room. Below
 		// the threshold the cap cannot bite and the array holds all of them.
-		var total = typeof data['presence-online-total'] === 'number' ? data['presence-online-total'] : entries.length;
-		var overflowTotal = total - maxRows;
+		const total =
+			typeof data[ 'presence-online-total' ] === 'number'
+				? data[ 'presence-online-total' ]
+				: entries.length;
+		const overflowTotal = total - maxRows;
 
 		// Build a signature of user IDs + screens to detect real changes. The
 		// total leads it because the overflow count is now derived from the
 		// total, which moves while the capped entries stay identical.
-		var sig = total + '|' + entries.map(function(e) { return e.user_id + ':' + (e.screen || ''); }).join(',');
+		const sig =
+			total +
+			'|' +
+			entries
+				.map( function ( e ) {
+					return e.user_id + ':' + ( e.screen || '' );
+				} )
+				.join( ',' );
 
-		if (sig !== lastSignature) {
+		if ( sig !== lastSignature ) {
 			// Content changed — swap HTML instantly.
-			var focusInfo = captureFocus(container);
-			container.html(buildFullHtml(visible, overflow, overflowTotal));
-			restoreFocus(container, focusInfo);
+			const focusInfo = captureFocus( container );
+			container.html( buildFullHtml( visible, overflow, overflowTotal ) );
+			restoreFocus( container, focusInfo );
 			lastSignature = sig;
 		} else {
 			// Same users, same screens — update only dot tooltips.
-			container.find('.presence-user-item').each(function() {
-				var uid = $(this).data('user-id');
-				for (var i = 0; i < entries.length; i++) {
-					if (entries[i].user_id === uid) {
-						var timeStr = entries[i].date_gmt ? relativeTime(entries[i].date_gmt) : '';
-						var dotTitle = timeStr || i18n.onlineNow;
-						$(this).find('.presence-online-dot').attr('title', dotTitle).attr('aria-label', dotTitle);
+			container.find( '.presence-user-item' ).each( function () {
+				const uid = $( this ).data( 'user-id' );
+				for ( let i = 0; i < entries.length; i++ ) {
+					if ( entries[ i ].user_id === uid ) {
+						const timeStr = entries[ i ].date_gmt
+							? relativeTime( entries[ i ].date_gmt )
+							: '';
+						const dotTitle = timeStr || i18n.onlineNow;
+						$( this )
+							.find( '.presence-online-dot' )
+							.attr( 'title', dotTitle )
+							.attr( 'aria-label', dotTitle );
 						break;
 					}
 				}
-			});
+			} );
 		}
-	});
+	} );
 
 	// Re-evaluate idle dots between heartbeat ticks.
-	setInterval(function() {
-		if (!lastEntries.length) return;
-		$('#presence-whos-online-list .presence-user-item').each(function() {
-			var uid = $(this).data('user-id');
-			for (var i = 0; i < lastEntries.length; i++) {
-				if (lastEntries[i].user_id === uid && lastEntries[i].date_gmt) {
-					var elapsed = Math.floor(Date.now() / 1000 - new Date(lastEntries[i].date_gmt + 'Z').getTime() / 1000);
-					var dot = $(this).find('.presence-online-dot');
-					dot.toggleClass('is-idle', elapsed >= idleThreshold);
-					var timeStr = relativeTime(lastEntries[i].date_gmt);
-					var dotTitle = timeStr || i18n.onlineNow;
-					dot.attr('title', dotTitle).attr('aria-label', dotTitle);
-					break;
+	setInterval( function () {
+		if ( ! lastEntries.length ) {
+			return;
+		}
+		$( '#presence-whos-online-list .presence-user-item' ).each(
+			function () {
+				const uid = $( this ).data( 'user-id' );
+				for ( let i = 0; i < lastEntries.length; i++ ) {
+					if (
+						lastEntries[ i ].user_id === uid &&
+						lastEntries[ i ].date_gmt
+					) {
+						const elapsed = Math.floor(
+							Date.now() / 1000 -
+								new Date(
+									lastEntries[ i ].date_gmt + 'Z'
+								).getTime() /
+									1000
+						);
+						const dot = $( this ).find( '.presence-online-dot' );
+						dot.toggleClass( 'is-idle', elapsed >= idleThreshold );
+						const timeStr = relativeTime(
+							lastEntries[ i ].date_gmt
+						);
+						const dotTitle = timeStr || i18n.onlineNow;
+						dot.attr( 'title', dotTitle ).attr(
+							'aria-label',
+							dotTitle
+						);
+						break;
+					}
 				}
 			}
-		});
-	}, 5000);
+		);
+	}, 5000 );
 
 	// Toggle expand/collapse.
-	$('#presence-whos-online-list').on('click', '.presence-overflow-toggle', function() {
-		isExpanded = $(this).data('action') === 'expand';
-		var wrap = $('#presence-whos-online-list');
-		wrap.find('[data-action="expand"]').toggle(!isExpanded).attr('aria-expanded', String(!isExpanded));
-		wrap.find('#presence-overflow-list').toggle(isExpanded);
-		wrap.find('[data-action="collapse"]').toggle(isExpanded).attr('aria-expanded', String(isExpanded));
-	});
-})(jQuery);
+	$( '#presence-whos-online-list' ).on(
+		'click',
+		'.presence-overflow-toggle',
+		function () {
+			isExpanded = $( this ).data( 'action' ) === 'expand';
+			const wrap = $( '#presence-whos-online-list' );
+			wrap.find( '[data-action="expand"]' )
+				.toggle( ! isExpanded )
+				.attr( 'aria-expanded', String( ! isExpanded ) );
+			wrap.find( '#presence-overflow-list' ).toggle( isExpanded );
+			wrap.find( '[data-action="collapse"]' )
+				.toggle( isExpanded )
+				.attr( 'aria-expanded', String( isExpanded ) );
+		}
+	);
+} )( jQuery );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,10 +79,18 @@ module.exports = [
 				wp: 'readonly',
 			},
 		},
+	},
+
+	{
+		// A screenshot-artifact generator, not a correctness suite: waits are
+		// real time (idle/expiry has no DOM signal), the admin bar dropdown
+		// check is screen-size dependent, and a captured screenshot is the
+		// pass condition rather than an expect().
+		files: [ 'tests/e2e/presence-screenshots.test.js' ],
 		rules: {
-			// Swapping these waits changes what the specs actually wait for,
-			// so they are flagged to be revisited rather than failed on.
-			'playwright/no-networkidle': 'warn',
+			'playwright/expect-expect': 'off',
+			'playwright/no-wait-for-timeout': 'off',
+			'playwright/no-conditional-in-test': 'off',
 		},
 	},
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,93 @@
+/**
+ * ESLint flat config.
+ *
+ * @package Presence_API
+ */
+
+const globals = require( 'globals' );
+const wpPlugin = require( '@wordpress/eslint-plugin' );
+
+/**
+ * Retargets a shipped config array at a set of files.
+ *
+ * @param {Array}    config Config objects from @wordpress/eslint-plugin.
+ * @param {string[]} files  Glob patterns the config should apply to.
+ * @return {Array} Retargeted config objects.
+ */
+const scopeTo = ( config, files ) =>
+	config.map( ( entry ) => ( { ...entry, files } ) );
+
+module.exports = [
+	{
+		ignores: [ '**/build/**', 'node_modules/**', 'vendor/**' ],
+	},
+
+	...wpPlugin.configs.recommended,
+
+	{
+		rules: {
+			// File headers carry `@package Presence_API`, as the PHP does.
+			'jsdoc/empty-tags': 'off',
+		},
+	},
+
+	{
+		// Admin scripts load as classic scripts and talk to jQuery and wp.
+		files: [ 'assets/js/**/*.js' ],
+		languageOptions: {
+			sourceType: 'script',
+			globals: {
+				...globals.browser,
+				jQuery: 'readonly',
+				wp: 'readonly',
+			},
+		},
+		rules: {
+			// Focus retention reads the element the browser actually has.
+			'@wordpress/no-global-active-element': 'off',
+		},
+	},
+
+	{
+		// Repository tooling runs under Node, not in a browser.
+		files: [ '.github/scripts/**/*.js' ],
+		languageOptions: {
+			sourceType: 'commonjs',
+			globals: globals.node,
+		},
+		rules: {
+			// These scripts report to the workflow log.
+			'no-console': 'off',
+			// GitHub API payloads are snake_case.
+			camelcase: 'off',
+			// A leading underscore marks a parameter kept only for arity.
+			'no-unused-vars': [ 'error', { argsIgnorePattern: '^_' } ],
+		},
+	},
+
+	...scopeTo( wpPlugin.configs[ 'test-playwright' ], [
+		'tests/e2e/**/*.js',
+	] ),
+
+	{
+		// Bodies passed to page.evaluate() run in the browser.
+		files: [ 'tests/e2e/**/*.js' ],
+		languageOptions: {
+			globals: {
+				...globals.browser,
+				jQuery: 'readonly',
+				wp: 'readonly',
+			},
+		},
+		rules: {
+			// Swapping these waits changes what the specs actually wait for,
+			// so they are flagged to be revisited rather than failed on.
+			'playwright/no-networkidle': 'warn',
+		},
+	},
+
+	...scopeTo( wpPlugin.configs[ 'test-unit' ], [
+		'**/test/**/*.js',
+		'**/*.test.js',
+	] ),
+];

--- a/includes/widgets/class-wp-presence-network-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-network-widget-whos-online.php
@@ -56,10 +56,19 @@ class WP_Presence_Network_Widget_Whos_Online {
 		wp_enqueue_script( 'heartbeat' );
 		wp_presence_enqueue_avatar_stack_script();
 
-		// A handle of its own so the inline script can declare what it needs.
-		wp_register_script( 'presence-network-widget', false, array( 'jquery', 'heartbeat', 'wp-presence-avatar-stack' ), WP_PRESENCE_VERSION, true );
-		wp_enqueue_script( 'presence-network-widget' );
-		wp_add_inline_script( 'presence-network-widget', self::get_inline_script() );
+		wp_enqueue_script(
+			'presence-network-widget',
+			WP_PRESENCE_PLUGIN_URL . 'assets/js/network-whos-online-widget.js',
+			array( 'jquery', 'heartbeat', 'wp-presence-avatar-stack' ),
+			WP_PRESENCE_VERSION,
+			true
+		);
+
+		wp_add_inline_script(
+			'presence-network-widget',
+			sprintf( 'window.wpPresenceNetworkWhosOnline = %s;', wp_json_encode( self::get_script_config() ) ),
+			'before'
+		);
 
 		wp_presence_enqueue_avatar_stack_style();
 
@@ -233,13 +242,15 @@ class WP_Presence_Network_Widget_Whos_Online {
 	}
 
 	/**
-	 * Returns the inline JavaScript for Heartbeat integration.
+	 * Returns the configuration the widget's client script reads.
 	 *
-	 * @return string JavaScript code.
+	 * @return array Script configuration.
 	 */
-	private static function get_inline_script() {
-		$i18n_json = wp_json_encode(
-			array(
+	private static function get_script_config() {
+		return array(
+			'viewAllUrl' => esc_url_raw( network_admin_url( 'sites.php' ) ),
+			'avatarMax'  => WP_PRESENCE_NETWORK_AVATARS,
+			'i18n'       => array(
 				'noUsersOnline' => __( 'No users are currently online anywhere on the network.', 'presence-api' ),
 				'notAggregated' => __( 'Presence is not aggregated across this network, so who is online cannot be shown.', 'presence-api' ),
 				'sitesOnline'   => __( 'Sites with online users', 'presence-api' ),
@@ -247,135 +258,7 @@ class WP_Presence_Network_Widget_Whos_Online {
 				'moreSite'      => __( '+%d more site — view all', 'presence-api' ),
 				/* translators: %d: Number of additional sites with online users. */
 				'moreSites'     => __( '+%d more sites — view all', 'presence-api' ),
-			)
-		);
-
-		return sprintf(
-			<<<'JS'
-(function($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
-		return;
-	}
-
-	var i18n = %s;
-	var viewAllUrl = %s;
-	var avatarMax = %d;
-	var lastHash = '';
-	var lastSignature = '';
-
-	function esc(str) {
-		var el = document.createElement('span');
-		el.textContent = str;
-		return el.innerHTML;
-	}
-
-	// The swap below replaces every node, so a keyboard user standing on a site
-	// link lands on the body unless the spot is recorded and handed back.
-	function captureFocus(container) {
-		var active = document.activeElement;
-		if (!active || !$.contains(container[0], active)) {
-			return null;
-		}
-		var item = $(active).closest('[data-blog-id]');
-		if (item.length) {
-			return { type: 'site', id: item.data('blog-id') };
-		}
-		if ($(active).hasClass('presence-more-link')) {
-			return { type: 'more' };
-		}
-		return { type: 'none' };
-	}
-
-	function restoreFocus(container, info) {
-		if (!info) {
-			return;
-		}
-		var target = null;
-		if (info.type === 'site') {
-			target = container.find('[data-blog-id="' + info.id + '"] a').first();
-		} else if (info.type === 'more') {
-			target = container.find('.presence-more-link');
-		}
-		if (target && target.length) {
-			target.trigger('focus');
-		} else {
-			container.trigger('focus');
-		}
-	}
-
-	// Already cut to the sites and avatars this widget shows, so nothing is
-	// sliced here; overflow is a count the server sends, not what is left over.
-	function buildListHtml(sites, overflow, aggregating) {
-		if (!aggregating) {
-			return '<p>' + esc(i18n.notAggregated) + '</p>';
-		}
-
-		if (!sites.length) {
-			return '<p>' + esc(i18n.noUsersOnline) + '</p>';
-		}
-
-		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.sitesOnline) + '">';
-		sites.forEach(function(site) {
-			html += '<li class="presence-site-item" data-blog-id="' + parseInt(site.blog_id, 10) + '">' + window.wpPresenceBuildAvatarStack(site.users, avatarMax);
-			html += '<span class="presence-site-info"><a href="' + esc(site.url) + '">' + esc(site.domain + site.path) + '</a></span>';
-			html += '<span class="presence-site-count">' + site.user_count + '</span></li>';
-		});
-		html += '</ul>';
-
-		if (overflow > 0) {
-			// Both forms come from the server because _n() cannot be called from
-			// here; picking on the count is as close as this gets to its rules.
-			var moreLabel = (overflow === 1 ? i18n.moreSite : i18n.moreSites).replace('%%d', overflow);
-			html += '<a href="' + esc(viewAllUrl) + '" class="presence-more-link">' + esc(moreLabel) + '</a>';
-		}
-
-		return html;
-	}
-
-	$(document).on('heartbeat-send', function(event, data) {
-		data['presence-network-widget-ping'] = true;
-		if (lastHash) {
-			data['presence-network-widget-hash'] = lastHash;
-		}
-	});
-
-	$(document).on('heartbeat-tick', function(event, data) {
-		if (data['presence-network-widget-unchanged']) {
-			return;
-		}
-
-		if (!data['presence-network-widget']) {
-			return;
-		}
-
-		lastHash = data['presence-network-widget-hash'] || '';
-
-		var container = $('#presence-network-widget-list');
-		if (!container.length) {
-			return;
-		}
-
-		var sites = data['presence-network-widget'];
-		var overflow = data['presence-network-widget-overflow'] || 0;
-		var aggregating = data['presence-network-widget-aggregating'] !== false;
-
-		// Signature over what gets drawn, matching the server-side hash: a
-		// rename or a new avatar has to repaint, and the order is already the
-		// order it renders in.
-		var sig = JSON.stringify([sites, overflow, aggregating]);
-
-		if (sig !== lastSignature) {
-			var focusInfo = captureFocus(container);
-			container.html(buildListHtml(sites, overflow, aggregating));
-			restoreFocus(container, focusInfo);
-			lastSignature = sig;
-		}
-	});
-})(jQuery);
-JS,
-			$i18n_json,
-			wp_json_encode( esc_url_raw( network_admin_url( 'sites.php' ) ) ),
-			WP_PRESENCE_NETWORK_AVATARS
+			),
 		);
 	}
 }

--- a/includes/widgets/class-wp-presence-widget-whos-online.php
+++ b/includes/widgets/class-wp-presence-widget-whos-online.php
@@ -132,10 +132,19 @@ class WP_Presence_Widget_Whos_Online {
 
 		wp_presence_enqueue_avatar_stack_script();
 
-		// A handle of its own so the inline script can declare what it needs.
-		wp_register_script( 'presence-dashboard-widget', false, array( 'jquery', 'heartbeat', 'wp-presence-avatar-stack' ), WP_PRESENCE_VERSION, true );
-		wp_enqueue_script( 'presence-dashboard-widget' );
-		wp_add_inline_script( 'presence-dashboard-widget', self::get_inline_script() );
+		wp_enqueue_script(
+			'presence-dashboard-widget',
+			WP_PRESENCE_PLUGIN_URL . 'assets/js/whos-online-widget.js',
+			array( 'jquery', 'heartbeat', 'wp-presence-avatar-stack' ),
+			WP_PRESENCE_VERSION,
+			true
+		);
+
+		wp_add_inline_script(
+			'presence-dashboard-widget',
+			sprintf( 'window.wpPresenceWhosOnline = %s;', wp_json_encode( self::get_script_config() ) ),
+			'before'
+		);
 
 		wp_presence_enqueue_avatar_stack_style();
 
@@ -259,13 +268,11 @@ class WP_Presence_Widget_Whos_Online {
 	}
 
 	/**
-	 * Returns the inline JavaScript for Heartbeat integration.
+	 * Returns the configuration the widget's client script reads.
 	 *
-	 * @return string JavaScript code.
+	 * @return array Script configuration.
 	 */
-	private static function get_inline_script() {
-		$labels_json = wp_json_encode( self::get_screen_labels() );
-
+	private static function get_script_config() {
 		// Build URL map for linkable screens.
 		$screen_urls = array();
 		foreach ( array_keys( self::get_screen_labels() ) as $slug ) {
@@ -274,9 +281,16 @@ class WP_Presence_Widget_Whos_Online {
 				$screen_urls[ $slug ] = $url;
 			}
 		}
-		$urls_json = wp_json_encode( $screen_urls );
-		$i18n_json = wp_json_encode(
-			array(
+
+		return array(
+			'screenLabels'      => self::get_screen_labels(),
+			'screenUrls'        => $screen_urls,
+			'idleThreshold'     => self::IDLE_THRESHOLD,
+			'overflowThreshold' => self::get_overflow_threshold(),
+			'usersUrl'          => admin_url( 'users.php?presence_status=online' ),
+			'avatarMax'         => self::AVATAR_STACK_MAX,
+			'maxRows'           => self::VISIBLE_ROWS,
+			'i18n'              => array(
 				'noUsersOnline'   => __( 'No users are online.', 'presence-api' ),
 				'onlineNow'       => __( 'Online now', 'presence-api' ),
 				'usersOnline'     => __( 'Users currently online', 'presence-api' ),
@@ -294,274 +308,7 @@ class WP_Presence_Widget_Whos_Online {
 				'hourAgo'         => __( '%d hour ago', 'presence-api' ),
 				/* translators: %d: Number of hours (plural). */
 				'hoursAgo'        => __( '%d hours ago', 'presence-api' ),
-			)
-		);
-
-		return sprintf(
-			<<<'JS'
-(function($) {
-	if (typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined') {
-		return;
-	}
-
-	var screenLabels = %s;
-	var screenUrls = %s;
-	var i18n = %s;
-	var idleThreshold = %d;
-	var overflowThreshold = %d;
-	var usersUrl = %s;
-	var avatarMax = %d;
-
-	function esc(str) {
-		var el = document.createElement('span');
-		el.textContent = str;
-		return el.innerHTML;
-	}
-
-	function friendlyScreen(slug) {
-		if (screenLabels[slug]) {
-			return screenLabels[slug];
-		}
-		return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-	}
-
-	function relativeTime(dateGmt) {
-		var seconds = Math.floor(Date.now() / 1000 - new Date(dateGmt + 'Z').getTime() / 1000);
-		if (seconds < idleThreshold) {
-			return '';
-		}
-		if (seconds < 60) {
-			return i18n.secondsAgo.replace('%%d', seconds);
-		}
-		var minutes = Math.floor(seconds / 60);
-		if (minutes < 60) {
-			return i18n.minutesAgo.replace('%%d', minutes);
-		}
-		var hours = Math.floor(minutes / 60);
-		return (hours > 1 ? i18n.hoursAgo : i18n.hourAgo).replace('%%d', hours);
-	}
-
-	var isExpanded = false;
-	var lastSignature = '';
-	var lastEntries = [];
-	var lastHash = '';
-
-	function captureFocus(container) {
-		var active = document.activeElement;
-		if (!active || !$.contains(container[0], active)) {
-			return null;
-		}
-		var $active = $(active);
-		var item = $active.closest('[data-user-id]');
-		if (item.length) {
-			return { type: 'user', id: item.data('user-id') };
-		}
-		var action = $active.data('action');
-		if (action) {
-			return { type: 'action', action: action };
-		}
-		return { type: 'none' };
-	}
-
-	function restoreFocus(container, info) {
-		if (!info) {
-			return;
-		}
-		var target = null;
-		if (info.type === 'user') {
-			target = container.find('[data-user-id="' + info.id + '"] a, [data-user-id="' + info.id + '"] button').first();
-		} else if (info.type === 'action') {
-			target = container.find('[data-action="' + info.action + '"]');
-		}
-		if (target && target.length) {
-			target.trigger('focus');
-		} else {
-			container.trigger('focus');
-		}
-	}
-
-	function buildRowHtml(entry) {
-		var html = '';
-		if (entry.avatar_url) {
-			html += '<img src="' + esc(entry.avatar_url) + '" width="24" height="24" alt="' + esc(entry.display_name) + '" />';
-		}
-		var timeStr = entry.date_gmt ? relativeTime(entry.date_gmt) : '';
-		var dotTitle = timeStr || i18n.onlineNow;
-		var elapsed = entry.date_gmt ? Math.floor(Date.now() / 1000 - new Date(entry.date_gmt + 'Z').getTime() / 1000) : 0;
-		var idleClass = elapsed >= idleThreshold ? ' is-idle' : '';
-		html += '<div class="presence-user-info">';
-		html += '<span class="presence-name">' + esc(entry.display_name) + '</span>';
-		if (entry.screen) {
-			var screenText = entry.screen_label || friendlyScreen(entry.screen);
-			var parts = screenText.split(' ');
-			var formatted = parts.length > 1 ? '<em>' + esc(parts[0]) + '</em> ' + esc(parts.slice(1).join(' ')) : esc(screenText);
-			if (screenUrls[entry.screen]) {
-				html += '<span class="presence-screen"><a href="' + esc(screenUrls[entry.screen]) + '">' + formatted + '</a></span>';
-			} else {
-				html += '<span class="presence-screen">' + formatted + '</span>';
-			}
-		}
-		html += '</div>';
-		html += '<span class="presence-online-dot' + idleClass + '" role="img" aria-label="' + esc(dotTitle) + '" title="' + esc(dotTitle) + '"></span>';
-		return html;
-	}
-
-	function buildFullHtml(visible, overflow, overflowTotal) {
-		var html = '<ul class="presence-user-list" aria-label="' + esc(i18n.usersOnline) + '">';
-		visible.forEach(function(entry) {
-			html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
-		});
-		html += '</ul>';
-		if (overflow.length) {
-			if (overflowTotal > overflowThreshold) {
-				// Summary mode: avatar stack + count linking to Users page.
-				html += '<a href="' + esc(usersUrl) + '" class="presence-overflow-toggle">';
-				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
-				html += '<span class="presence-overflow-text">' + esc(i18n.moreCountLink.replace('%%d', overflowTotal)) + '</span></a>';
-			} else {
-				// Expandable list mode.
-				html += '<button type="button" class="presence-overflow-toggle" data-action="expand" aria-expanded="' + (isExpanded ? 'true' : 'false') + '" aria-controls="presence-overflow-list"';
-				if (isExpanded) html += ' style="display:none"';
-				html += '>';
-				html += window.wpPresenceBuildAvatarStack(overflow, avatarMax);
-				html += '<span class="presence-overflow-text">' + esc(i18n.moreCount.replace('%%d', overflow.length)) + '</span></button>';
-				html += '<ul id="presence-overflow-list" class="presence-overflow-expanded" aria-label="' + esc(i18n.additionalUsers) + '"';
-				if (!isExpanded) html += ' style="display:none"';
-				html += '>';
-				overflow.forEach(function(entry) {
-					html += '<li class="presence-user-item" data-user-id="' + entry.user_id + '">' + buildRowHtml(entry) + '</li>';
-				});
-				html += '</ul>';
-				html += '<button type="button" class="presence-overflow-toggle" data-action="collapse" aria-controls="presence-overflow-list"';
-				if (!isExpanded) html += ' style="display:none"';
-				html += '>' + esc(i18n.showLess) + '</button>';
-			}
-		}
-		return html;
-	}
-
-	$(document).on('heartbeat-send', function(event, data) {
-		if (lastHash) {
-			data['presence-online-hash'] = lastHash;
-		}
-	});
-
-	// Update the widget when heartbeat response comes back.
-	$(document).on('heartbeat-tick', function(event, data) {
-		if (data['presence-online-unchanged']) {
-			// Only freshness can have moved, so feed the idle sweep and leave
-			// the DOM alone.
-			var seen = data['presence-online-unchanged'];
-			for (var i = 0; i < lastEntries.length; i++) {
-				if (seen[lastEntries[i].user_id]) {
-					lastEntries[i].date_gmt = seen[lastEntries[i].user_id];
-				}
-			}
-			return;
-		}
-
-		if (!data['presence-online']) {
-			return;
-		}
-
-		lastHash = data['presence-online-hash'] || '';
-
-		var container = $('#presence-whos-online-list');
-		if (!container.length) {
-			return;
-		}
-
-		var entries = data['presence-online'];
-		lastEntries = entries;
-
-		if (!entries.length) {
-			if (lastSignature !== '') {
-				var clearFocus = captureFocus(container);
-				container.html('<p>' + esc(i18n.noUsersOnline) + '</p>');
-				restoreFocus(container, clearFocus);
-				lastSignature = '';
-			}
-			return;
-		}
-
-		// Sort by most recently active first.
-		entries.sort(function(a, b) {
-			return (b.date_gmt || '').localeCompare(a.date_gmt || '');
-		});
-
-		var maxRows = %d;
-		var visible = entries.slice(0, maxRows);
-		var overflow = entries.slice(maxRows);
-
-		// The payload is capped, so its length understates a large room. Below
-		// the threshold the cap cannot bite and the array holds all of them.
-		var total = typeof data['presence-online-total'] === 'number' ? data['presence-online-total'] : entries.length;
-		var overflowTotal = total - maxRows;
-
-		// Build a signature of user IDs + screens to detect real changes. The
-		// total leads it because the overflow count is now derived from the
-		// total, which moves while the capped entries stay identical.
-		var sig = total + '|' + entries.map(function(e) { return e.user_id + ':' + (e.screen || ''); }).join(',');
-
-		if (sig !== lastSignature) {
-			// Content changed — swap HTML instantly.
-			var focusInfo = captureFocus(container);
-			container.html(buildFullHtml(visible, overflow, overflowTotal));
-			restoreFocus(container, focusInfo);
-			lastSignature = sig;
-		} else {
-			// Same users, same screens — update only dot tooltips.
-			container.find('.presence-user-item').each(function() {
-				var uid = $(this).data('user-id');
-				for (var i = 0; i < entries.length; i++) {
-					if (entries[i].user_id === uid) {
-						var timeStr = entries[i].date_gmt ? relativeTime(entries[i].date_gmt) : '';
-						var dotTitle = timeStr || i18n.onlineNow;
-						$(this).find('.presence-online-dot').attr('title', dotTitle).attr('aria-label', dotTitle);
-						break;
-					}
-				}
-			});
-		}
-	});
-
-	// Re-evaluate idle dots between heartbeat ticks.
-	setInterval(function() {
-		if (!lastEntries.length) return;
-		$('#presence-whos-online-list .presence-user-item').each(function() {
-			var uid = $(this).data('user-id');
-			for (var i = 0; i < lastEntries.length; i++) {
-				if (lastEntries[i].user_id === uid && lastEntries[i].date_gmt) {
-					var elapsed = Math.floor(Date.now() / 1000 - new Date(lastEntries[i].date_gmt + 'Z').getTime() / 1000);
-					var dot = $(this).find('.presence-online-dot');
-					dot.toggleClass('is-idle', elapsed >= idleThreshold);
-					var timeStr = relativeTime(lastEntries[i].date_gmt);
-					var dotTitle = timeStr || i18n.onlineNow;
-					dot.attr('title', dotTitle).attr('aria-label', dotTitle);
-					break;
-				}
-			}
-		});
-	}, 5000);
-
-	// Toggle expand/collapse.
-	$('#presence-whos-online-list').on('click', '.presence-overflow-toggle', function() {
-		isExpanded = $(this).data('action') === 'expand';
-		var wrap = $('#presence-whos-online-list');
-		wrap.find('[data-action="expand"]').toggle(!isExpanded).attr('aria-expanded', String(!isExpanded));
-		wrap.find('#presence-overflow-list').toggle(isExpanded);
-		wrap.find('[data-action="collapse"]').toggle(isExpanded).attr('aria-expanded', String(isExpanded));
-	});
-})(jQuery);
-JS,
-			$labels_json,
-			$urls_json,
-			$i18n_json,
-			self::IDLE_THRESHOLD,
-			self::get_overflow_threshold(),
-			wp_json_encode( admin_url( 'users.php?presence_status=online' ) ),
-			self::AVATAR_STACK_MAX,
-			self::VISIBLE_ROWS
+			),
 		);
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"@wordpress/env": "^11.14.0",
 				"@wordpress/eslint-plugin": "^25.9.0",
 				"@wordpress/scripts": "^34.2.0",
-				"globals": "^16.5.0"
+				"globals": "^16.5.0",
+				"jquery": "^4.0.0"
 			},
 			"peerDependencies": {
 				"@wordpress/api-fetch": "^7.0.0",
@@ -8194,9 +8195,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8211,9 +8209,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8228,9 +8223,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8245,9 +8237,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8262,9 +8251,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8279,9 +8265,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8296,9 +8279,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8313,9 +8293,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8330,9 +8307,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -8347,9 +8321,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -17711,6 +17682,13 @@
 			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/jquery": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+			"integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-library-detector": {
 			"version": "6.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/e2e-test-utils-playwright": "^1.54.0",
 				"@wordpress/env": "^11.14.0",
-				"@wordpress/scripts": "^34.2.0"
+				"@wordpress/eslint-plugin": "^25.9.0",
+				"@wordpress/scripts": "^34.2.0",
+				"globals": "^16.5.0"
 			},
 			"peerDependencies": {
 				"@wordpress/api-fetch": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"@wordpress/env": "^11.14.0",
 		"@wordpress/eslint-plugin": "^25.9.0",
 		"@wordpress/scripts": "^34.2.0",
-		"globals": "^16.5.0"
+		"globals": "^16.5.0",
+		"jquery": "^4.0.0"
 	},
 	"peerDependencies": {
 		"@wordpress/api-fetch": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"env:stop": "wp-env stop",
 		"env:stop:multisite": "cd tests/e2e/multisite && wp-env stop",
 		"env:cli": "wp-env run cli wp",
+		"lint:js": "wp-scripts lint-js",
 		"test": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit --testdox",
 		"test:multisite": "wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- env WP_MULTISITE=1 ./vendor/bin/phpunit --testdox",
 		"test:e2e": "playwright test --config tests/e2e/playwright.config.js",
@@ -19,7 +20,9 @@
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/e2e-test-utils-playwright": "^1.54.0",
 		"@wordpress/env": "^11.14.0",
-		"@wordpress/scripts": "^34.2.0"
+		"@wordpress/eslint-plugin": "^25.9.0",
+		"@wordpress/scripts": "^34.2.0",
+		"globals": "^16.5.0"
 	},
 	"peerDependencies": {
 		"@wordpress/api-fetch": "^7.0.0",

--- a/src/hooks/use-presence-users.js
+++ b/src/hooks/use-presence-users.js
@@ -32,10 +32,11 @@ import { subscribeToPresencePolling } from '../utils/presence-poll-coordinator';
  *     avatarUrl: string
  *   }>,
  *   error: Error|null
- * }}
+ * }} The room's occupants and the state of the poll behind them.
  */
 export default function usePresenceUsers( room, options = {} ) {
-	const { includeSelf = false, fields = 'user_id,display_name,avatar_url' } = options;
+	const { includeSelf = false, fields = 'user_id,display_name,avatar_url' } =
+		options;
 
 	const [ users, setUsers ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );

--- a/src/utils/heartbeat-events.js
+++ b/src/utils/heartbeat-events.js
@@ -23,10 +23,14 @@ export function onHeartbeatTick( callback ) {
 	};
 
 	if ( typeof window.jQuery !== 'undefined' ) {
-		window.jQuery( document ).on( 'heartbeat-tick.presenceApi', wrappedCallback );
+		window
+			.jQuery( document )
+			.on( 'heartbeat-tick.presenceApi', wrappedCallback );
 
 		return () => {
-			window.jQuery( document ).off( 'heartbeat-tick.presenceApi', wrappedCallback );
+			window
+				.jQuery( document )
+				.off( 'heartbeat-tick.presenceApi', wrappedCallback );
 		};
 	}
 

--- a/src/utils/presence-poll-coordinator.js
+++ b/src/utils/presence-poll-coordinator.js
@@ -75,7 +75,9 @@ function createCoordinator( room, fields ) {
 		heartbeatCleanup: null,
 		releaseLock: null,
 		lockAbortController:
-			typeof AbortController === 'function' ? new AbortController() : null,
+			typeof AbortController === 'function'
+				? new AbortController()
+				: null,
 		channel:
 			typeof BroadcastChannel === 'function'
 				? new BroadcastChannel( lockName )
@@ -137,7 +139,9 @@ function createCoordinator( room, fields ) {
 
 	function becomeLeader() {
 		fetchAndBroadcast();
-		coordinator.heartbeatCleanup = onHeartbeatTick( () => fetchAndBroadcast() );
+		coordinator.heartbeatCleanup = onHeartbeatTick( () =>
+			fetchAndBroadcast()
+		);
 	}
 
 	coordinator.start = function () {
@@ -164,10 +168,15 @@ function createCoordinator( room, fields ) {
 		// The rest wait and listen on BroadcastChannel instead. Closing or
 		// crashing the leader's tab releases the lock automatically.
 		navigator.locks
-			.request( lockName, options, () => new Promise( ( resolve ) => {
-				coordinator.releaseLock = resolve;
-				becomeLeader();
-			} ) )
+			.request(
+				lockName,
+				options,
+				() =>
+					new Promise( ( resolve ) => {
+						coordinator.releaseLock = resolve;
+						becomeLeader();
+					} )
+			)
 			.catch( () => {} );
 	};
 

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -31,7 +31,7 @@ function assertNotMultisite() {
 
 /**
  * @param {import('@playwright/test').FullConfig} config
- * @returns {Promise<void>}
+ * @return {Promise<void>}
  */
 async function globalSetup( config ) {
 	const authenticated = new Set();

--- a/tests/e2e/network-helpers.js
+++ b/tests/e2e/network-helpers.js
@@ -48,7 +48,7 @@ export const NETWORK_USERS = {
  * Returns the admin URL of a site on the fixture network.
  *
  * @param {string} [slug] Sub-site slug, omitted for the main site.
- * @returns {string} Site URL, with a trailing slash.
+ * @return {string} Site URL, with a trailing slash.
  */
 export function siteUrl( slug = '' ) {
 	return slug ? `${ BASE_URL }/${ slug }/` : `${ BASE_URL }/`;
@@ -61,7 +61,7 @@ export function siteUrl( slug = '' ) {
  * is the host and port the instance runs on.
  *
  * @param {string} [slug] Sub-site slug, omitted for the main site.
- * @returns {string} Site label, e.g. `localhost:8890/team/`.
+ * @return {string} Site label, e.g. `localhost:8890/team/`.
  */
 export function siteLabel( slug = '' ) {
 	return new URL( siteUrl( slug ) ).host + ( slug ? `/${ slug }/` : '/' );
@@ -70,10 +70,10 @@ export function siteLabel( slug = '' ) {
 /**
  * Runs a WP-CLI command against the multisite instance.
  *
- * @param {string} command WP-CLI command, without the leading `wp`.
+ * @param {string} command       WP-CLI command, without the leading `wp`.
  * @param {Object} [options]
  * @param {string} [options.url] Site to run against, for a per-site command.
- * @returns {string} The command's last line of output, trimmed.
+ * @return {string} The command's last line of output, trimmed.
  */
 export function wpCli( command, { url } = {} ) {
 	const scope = url ? ` --url=${ url }` : '';
@@ -132,11 +132,12 @@ export function clearNetworkPresence() {
  * available on all three screens under test.
  *
  * @param {import('@playwright/test').Page} page
- * @returns {Promise<void>}
+ * @return {Promise<void>}
  */
 export async function forceHeartbeatTick( page ) {
 	await page.waitForFunction(
-		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
 	);
 
 	await page.evaluate(
@@ -152,7 +153,7 @@ export async function forceHeartbeatTick( page ) {
  * Returns the ID of a seeded user.
  *
  * @param {string} login Seeded user's login.
- * @returns {number} User ID.
+ * @return {number} User ID.
  */
 export function networkUserId( login ) {
 	return parseInt( wpCli( `user get ${ login } --field=ID` ), 10 );
@@ -162,7 +163,7 @@ export function networkUserId( login ) {
  * Returns the blog ID of a site on the fixture network.
  *
  * @param {string} slug Sub-site slug.
- * @returns {number} Blog ID.
+ * @return {number} Blog ID.
  */
 export function networkSiteId( slug ) {
 	const id = parseInt(
@@ -182,7 +183,7 @@ export function networkSiteId( slug ) {
  * be worth doing once per environment rather than once per run.
  *
  * @param {string} slug Sub-site slug.
- * @returns {number} Blog ID.
+ * @return {number} Blog ID.
  */
 export function ensureNetworkSite( slug ) {
 	const existing = networkSiteId( slug );

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -19,9 +19,7 @@ process.env.MULTISITE_STORAGE_STATE_PATH ??= path.join(
 	'storage-states/admin-multisite.json'
 );
 
-const baseUrl = new URL(
-	process.env.WP_BASE_URL || 'http://localhost:8888'
-);
+const baseUrl = new URL( process.env.WP_BASE_URL || 'http://localhost:8888' );
 
 process.env.WP_BASE_URL = baseUrl.href;
 

--- a/tests/e2e/presence-active-posts-coalescing.test.js
+++ b/tests/e2e/presence-active-posts-coalescing.test.js
@@ -38,14 +38,23 @@ function captureHeartbeatSend( page ) {
 }
 
 async function waitForLeaderPing( page, maxAttempts = 20 ) {
-	for ( let attempt = 0; attempt < maxAttempts; attempt++ ) {
-		const data = await captureHeartbeatSend( page );
-		if ( data[ 'presence-active-posts-ping' ] ) {
-			return data;
-		}
-		await page.waitForTimeout( 100 );
-	}
-	throw new Error( 'Tab never won presence-active-posts-ping leadership.' );
+	let winningData;
+
+	await expect
+		.poll(
+			async () => {
+				winningData = await captureHeartbeatSend( page );
+				return Boolean( winningData[ 'presence-active-posts-ping' ] );
+			},
+			{
+				intervals: [ 0 ],
+				timeout: maxAttempts * 100,
+				message: 'Tab never won presence-active-posts-ping leadership.',
+			}
+		)
+		.toBe( true );
+
+	return winningData;
 }
 
 function waitForActivePostsTick( page, timeoutMs = 8000 ) {

--- a/tests/e2e/presence-active-posts-coalescing.test.js
+++ b/tests/e2e/presence-active-posts-coalescing.test.js
@@ -20,7 +20,8 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 function waitForHeartbeat( page ) {
 	return page.waitForFunction(
-		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
 	);
 }
 
@@ -143,7 +144,9 @@ test.describe( 'Presence Active Posts Tab Coalescing', () => {
 			page.evaluate( () => wp.heartbeat.connectNow() ),
 		] );
 
-		expect( relayed[ 'presence-active-posts' ].length ).toBeGreaterThan( 0 );
+		expect( relayed[ 'presence-active-posts' ].length ).toBeGreaterThan(
+			0
+		);
 		expect( relayed[ 'presence-active-posts' ][ 0 ].post_id ).toBe(
 			post.id
 		);

--- a/tests/e2e/presence-admin-bar-contrast.test.js
+++ b/tests/e2e/presence-admin-bar-contrast.test.js
@@ -36,9 +36,7 @@ function relativeLuminance( rgb ) {
 		} );
 
 	return (
-		0.2126 * channels[ 0 ] +
-		0.7152 * channels[ 1 ] +
-		0.0722 * channels[ 2 ]
+		0.2126 * channels[ 0 ] + 0.7152 * channels[ 1 ] + 0.0722 * channels[ 2 ]
 	);
 }
 
@@ -88,29 +86,29 @@ test.describe.serial( 'Presence admin bar contrast', () => {
 		demoSeeder( 'wp_presence_demo_cleanup();' );
 	} );
 
-	test(
-		'Light scheme text meets WCAG AA contrast',
-		async ( { admin, page } ) => {
-			await admin.visitAdminPage( '/' );
+	test( 'Light scheme text meets WCAG AA contrast', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( '/' );
 
-			const barNode = page.locator( '#wp-admin-bar-presence-online' );
-			await expect( barNode ).toBeVisible();
-			await barNode.hover();
+		const barNode = page.locator( '#wp-admin-bar-presence-online' );
+		await expect( barNode ).toBeVisible();
+		await barNode.hover();
 
-			const text = [
-				page.locator( '.presence-bar-count' ).first(),
-				page.locator( '.presence-bar-you' ).first(),
-				page.locator( '.presence-bar-screen' ).first(),
-				page.locator( '.presence-bar-group-label' ).first(),
-			];
+		const text = [
+			page.locator( '.presence-bar-count' ).first(),
+			page.locator( '.presence-bar-you' ).first(),
+			page.locator( '.presence-bar-screen' ).first(),
+			page.locator( '.presence-bar-group-label' ).first(),
+		];
 
-			for ( const element of text ) {
-				await expect( element ).toBeVisible();
-				const { foreground, background } = await computedColors( element );
-				expect( contrastRatio( foreground, background ) ).toBeGreaterThanOrEqual(
-					4.5
-				);
-			}
+		for ( const element of text ) {
+			await expect( element ).toBeVisible();
+			const { foreground, background } = await computedColors( element );
+			expect(
+				contrastRatio( foreground, background )
+			).toBeGreaterThanOrEqual( 4.5 );
 		}
-	);
+	} );
 } );

--- a/tests/e2e/presence-heartbeat-backoff.test.js
+++ b/tests/e2e/presence-heartbeat-backoff.test.js
@@ -76,6 +76,8 @@ test.describe( 'Presence Heartbeat Idle Backoff', () => {
 		admin,
 		page,
 		requestUtils,
+		// eslint-disable-next-line no-unused-vars -- requested only to create the second user the post-lock dialog needs.
+		testUsers,
 	} ) => {
 		const post = await requestUtils.createPost( {
 			title: 'E2E Heartbeat Backoff Test',

--- a/tests/e2e/presence-heartbeat-backoff.test.js
+++ b/tests/e2e/presence-heartbeat-backoff.test.js
@@ -97,22 +97,19 @@ test.describe( 'Presence Heartbeat Idle Backoff', () => {
 
 		// One tick establishes the room's hash; repeat until the client sees
 		// enough consecutive unchanged ticks to back off.
-		let widened = false;
-		for ( let i = 0; i < 10 && ! widened; i++ ) {
-			await captureHeartbeatTick( page );
-			const current = await page.evaluate( () =>
-				wp.heartbeat.interval()
-			);
-			if ( current > normalInterval ) {
-				widened = true;
-			}
-		}
-
-		expect( widened ).toBe( true );
-		const widenedInterval = await page.evaluate( () =>
-			wp.heartbeat.interval()
-		);
-		expect( widenedInterval ).toBeGreaterThan( normalInterval );
+		let widenedInterval = normalInterval;
+		await expect
+			.poll(
+				async () => {
+					await captureHeartbeatTick( page );
+					widenedInterval = await page.evaluate( () =>
+						wp.heartbeat.interval()
+					);
+					return widenedInterval;
+				},
+				{ intervals: [ 0 ], timeout: 20_000 }
+			)
+			.toBeGreaterThan( normalInterval );
 		// The idle interval is itself under the TTL.
 		const idleInterval = await page.evaluate(
 			() => window.wpPresenceConfig.idleInterval

--- a/tests/e2e/presence-heartbeat-backoff.test.js
+++ b/tests/e2e/presence-heartbeat-backoff.test.js
@@ -44,7 +44,8 @@ const test = base.extend( {
 
 function waitForHeartbeat( page ) {
 	return page.waitForFunction(
-		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
 	);
 }
 
@@ -52,7 +53,7 @@ function waitForHeartbeat( page ) {
  * Forces a heartbeat tick and resolves with the data object the tick carried.
  *
  * @param {import('@playwright/test').Page} page
- * @returns {Promise<object>}
+ * @return {Promise<object>} The recorded Heartbeat activity.
  */
 function captureHeartbeatTick( page ) {
 	return page.evaluate(
@@ -75,19 +76,23 @@ test.describe( 'Presence Heartbeat Idle Backoff', () => {
 		admin,
 		page,
 		requestUtils,
-		testUsers,
 	} ) => {
 		const post = await requestUtils.createPost( {
 			title: 'E2E Heartbeat Backoff Test',
 			status: 'publish',
 		} );
 
-		await admin.visitAdminPage( 'post.php', `post=${ post.id }&action=edit` );
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
 		await waitForHeartbeat( page );
 
 		// The post-lock dialog is present (2+ users exist), so post.js has
 		// already set the interval to 10 seconds by the time heartbeat is ready.
-		const normalInterval = await page.evaluate( () => wp.heartbeat.interval() );
+		const normalInterval = await page.evaluate( () =>
+			wp.heartbeat.interval()
+		);
 		expect( normalInterval ).toBe( 10 );
 
 		// One tick establishes the room's hash; repeat until the client sees
@@ -95,24 +100,34 @@ test.describe( 'Presence Heartbeat Idle Backoff', () => {
 		let widened = false;
 		for ( let i = 0; i < 10 && ! widened; i++ ) {
 			await captureHeartbeatTick( page );
-			const current = await page.evaluate( () => wp.heartbeat.interval() );
+			const current = await page.evaluate( () =>
+				wp.heartbeat.interval()
+			);
 			if ( current > normalInterval ) {
 				widened = true;
 			}
 		}
 
 		expect( widened ).toBe( true );
-		const widenedInterval = await page.evaluate( () => wp.heartbeat.interval() );
+		const widenedInterval = await page.evaluate( () =>
+			wp.heartbeat.interval()
+		);
 		expect( widenedInterval ).toBeGreaterThan( normalInterval );
 		// The idle interval is itself under the TTL.
-		const idleInterval = await page.evaluate( () => window.wpPresenceConfig.idleInterval );
+		const idleInterval = await page.evaluate(
+			() => window.wpPresenceConfig.idleInterval
+		);
 		expect( widenedInterval ).toBeLessThanOrEqual( idleInterval );
 
 		await page.evaluate( () => {
-			document.dispatchEvent( new KeyboardEvent( 'keydown', { bubbles: true } ) );
+			document.dispatchEvent(
+				new KeyboardEvent( 'keydown', { bubbles: true } )
+			);
 		} );
 
-		const afterKeydown = await page.evaluate( () => wp.heartbeat.interval() );
+		const afterKeydown = await page.evaluate( () =>
+			wp.heartbeat.interval()
+		);
 		expect( afterKeydown ).toBe( normalInterval );
 	} );
 } );

--- a/tests/e2e/presence-network-sites-column.test.js
+++ b/tests/e2e/presence-network-sites-column.test.js
@@ -42,7 +42,7 @@ test.describe( 'Network Sites Online column', () => {
 	 * network.
 	 *
 	 * @param {import('@playwright/test').Page} page
-	 * @returns {import('@playwright/test').Locator}
+	 * @return {import('@playwright/test').Locator} The matching cell.
 	 */
 	function onlineCell( page ) {
 		return page
@@ -63,7 +63,9 @@ test.describe( 'Network Sites Online column', () => {
 			'Online'
 		);
 
-		const avatars = onlineCell( page ).locator( '.presence-avatar-stack img' );
+		const avatars = onlineCell( page ).locator(
+			'.presence-avatar-stack img'
+		);
 
 		await expect( avatars ).toHaveCount( 1 );
 		await expect( avatars ).toHaveAttribute(

--- a/tests/e2e/presence-network-users-list.test.js
+++ b/tests/e2e/presence-network-users-list.test.js
@@ -45,8 +45,8 @@ test.describe( 'Network Users Online view and column', () => {
 	 * Returns the Online cell of one user's row.
 	 *
 	 * @param {import('@playwright/test').Page} page
-	 * @param {number} userId
-	 * @returns {import('@playwright/test').Locator}
+	 * @param {number}                          userId
+	 * @return {import('@playwright/test').Locator} The matching cell.
 	 */
 	function onlineCell( page, userId ) {
 		return page.locator( `#user-${ userId } .column-presence_online` );
@@ -56,7 +56,7 @@ test.describe( 'Network Users Online view and column', () => {
 	 * Returns the "Online" entry in the list of views above the table.
 	 *
 	 * @param {import('@playwright/test').Page} page
-	 * @returns {import('@playwright/test').Locator}
+	 * @return {import('@playwright/test').Locator} The matching cell.
 	 */
 	function onlineView( page ) {
 		return page.locator( '.subsubsub li.presence_online a' );
@@ -72,7 +72,9 @@ test.describe( 'Network Users Online view and column', () => {
 
 		// User A on the sub-site, plus the admin this page just wrote online.
 		await expect( onlineView( page ) ).toContainText( 'Online' );
-		await expect( onlineView( page ).locator( '.count' ) ).toHaveText( '(2)' );
+		await expect( onlineView( page ).locator( '.count' ) ).toHaveText(
+			'(2)'
+		);
 	} );
 
 	test( 'names the sites a user is online on, and an em dash for a user online nowhere', async ( {
@@ -83,7 +85,9 @@ test.describe( 'Network Users Online view and column', () => {
 
 		await admin.visitAdminPage( 'network/users.php' );
 
-		await expect( onlineCell( page, userA ) ).toHaveText( siteLabel( SITE_SLUG ) );
+		await expect( onlineCell( page, userA ) ).toHaveText(
+			siteLabel( SITE_SLUG )
+		);
 		await expect( onlineCell( page, userB ) ).toHaveText( '—' );
 	} );
 

--- a/tests/e2e/presence-network-widget.test.js
+++ b/tests/e2e/presence-network-widget.test.js
@@ -40,7 +40,7 @@ const OVERFLOW_SLUGS = [ 'over1', 'over2', 'over3', 'over4', 'over5' ];
 let mainSiteId;
 let teamSiteId;
 
-test.describe( 'Network Who\'s Online widget', () => {
+test.describe( "Network Who's Online widget", () => {
 	test.beforeAll( () => {
 		mainSiteId = 1;
 		teamSiteId = networkSiteId( SITE_SLUG );
@@ -56,16 +56,18 @@ test.describe( 'Network Who\'s Online widget', () => {
 
 	/**
 	 * @param {import('@playwright/test').Page} page
-	 * @returns {import('@playwright/test').Locator}
+	 * @return {import('@playwright/test').Locator} The matching element.
 	 */
 	function widgetList( page ) {
-		return page.locator( '#presence-network-widget-list ul.presence-user-list' );
+		return page.locator(
+			'#presence-network-widget-list ul.presence-user-list'
+		);
 	}
 
 	/**
 	 * @param {import('@playwright/test').Page} page
-	 * @param {number} blogId
-	 * @returns {import('@playwright/test').Locator}
+	 * @param {number}                          blogId
+	 * @return {import('@playwright/test').Locator} The matching element.
 	 */
 	function siteItem( page, blogId ) {
 		return page.locator(
@@ -94,7 +96,9 @@ test.describe( 'Network Who\'s Online widget', () => {
 		await expect( team.locator( '.presence-site-info a' ) ).toHaveText(
 			siteLabel( SITE_SLUG )
 		);
-		await expect( team.locator( '.presence-site-count' ) ).toHaveText( '1' );
+		await expect( team.locator( '.presence-site-count' ) ).toHaveText(
+			'1'
+		);
 	} );
 
 	test( 'adds a site over a heartbeat tick, without a reload', async ( {

--- a/tests/e2e/presence-screenshots.test.js
+++ b/tests/e2e/presence-screenshots.test.js
@@ -10,12 +10,15 @@
  * @package WordPress
  * @since 7.1.0
  */
-import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
+import { test as base } from '@wordpress/e2e-test-utils-playwright';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 
-const SCREENSHOTS_DIR = path.resolve( __dirname, '../../artifacts/screenshots' );
+const SCREENSHOTS_DIR = path.resolve(
+	__dirname,
+	'../../artifacts/screenshots'
+);
 
 function wpCli( command ) {
 	execSync( `npx wp-env run cli wp ${ command }`, {
@@ -78,8 +81,16 @@ test.describe.serial( 'Presence Screenshots', () => {
 		await page.waitForTimeout( 3000 );
 
 		await snap( page, '01-empty-dashboard' );
-		await snapElement( page, '#presence-whos-online-list', '01-empty-whos-online' );
-		await snapElement( page, '#presence-active-posts-list', '01-empty-active-posts' );
+		await snapElement(
+			page,
+			'#presence-whos-online-list',
+			'01-empty-whos-online'
+		);
+		await snapElement(
+			page,
+			'#presence-active-posts-list',
+			'01-empty-active-posts'
+		);
 	} );
 
 	test( '02 — Active users (5)', async ( { admin, page } ) => {
@@ -89,9 +100,21 @@ test.describe.serial( 'Presence Screenshots', () => {
 		await page.waitForTimeout( 3000 );
 
 		await snap( page, '02-active-dashboard' );
-		await snapElement( page, '#presence-whos-online-list', '02-active-whos-online' );
-		await snapElement( page, '#presence-active-posts-list', '02-active-active-posts' );
-		await snapElement( page, '#wp-admin-bar-presence-online', '02-active-admin-bar' );
+		await snapElement(
+			page,
+			'#presence-whos-online-list',
+			'02-active-whos-online'
+		);
+		await snapElement(
+			page,
+			'#presence-active-posts-list',
+			'02-active-active-posts'
+		);
+		await snapElement(
+			page,
+			'#wp-admin-bar-presence-online',
+			'02-active-admin-bar'
+		);
 
 		const barNode = page.locator( '#wp-admin-bar-presence-online' );
 		if ( await barNode.isVisible().catch( () => false ) ) {
@@ -110,8 +133,16 @@ test.describe.serial( 'Presence Screenshots', () => {
 		await page.waitForTimeout( 3000 );
 
 		await snap( page, '03-scale-dashboard' );
-		await snapElement( page, '#presence-whos-online-list', '03-scale-whos-online' );
-		await snapElement( page, '#presence-active-posts-list', '03-scale-active-posts' );
+		await snapElement(
+			page,
+			'#presence-whos-online-list',
+			'03-scale-whos-online'
+		);
+		await snapElement(
+			page,
+			'#presence-active-posts-list',
+			'03-scale-active-posts'
+		);
 	} );
 
 	test( '04 — Post list editors column', async ( { admin, page } ) => {
@@ -133,8 +164,16 @@ test.describe.serial( 'Presence Screenshots', () => {
 		await page.waitForTimeout( 3000 );
 
 		await snap( page, '06-idle-dashboard' );
-		await snapElement( page, '#presence-whos-online-list', '06-idle-whos-online' );
-		await snapElement( page, '#presence-active-posts-list', '06-idle-active-posts' );
+		await snapElement(
+			page,
+			'#presence-whos-online-list',
+			'06-idle-whos-online'
+		);
+		await snapElement(
+			page,
+			'#presence-active-posts-list',
+			'06-idle-active-posts'
+		);
 	} );
 
 	test( '07 — Expired (back to empty)', async ( { admin, page } ) => {

--- a/tests/e2e/presence-stale-screen-coalescing.test.js
+++ b/tests/e2e/presence-stale-screen-coalescing.test.js
@@ -83,14 +83,23 @@ function captureHeartbeatSend( page ) {
 }
 
 async function waitForLeaderPing( page, maxAttempts = 20 ) {
-	for ( let attempt = 0; attempt < maxAttempts; attempt++ ) {
-		const data = await captureHeartbeatSend( page );
-		if ( data[ 'presence-screen-ping' ] ) {
-			return data;
-		}
-		await page.waitForTimeout( 100 );
-	}
-	throw new Error( 'Tab never won presence-screen-ping leadership.' );
+	let winningData;
+
+	await expect
+		.poll(
+			async () => {
+				winningData = await captureHeartbeatSend( page );
+				return Boolean( winningData[ 'presence-screen-ping' ] );
+			},
+			{
+				intervals: [ 0 ],
+				timeout: maxAttempts * 100,
+				message: 'Tab never won presence-screen-ping leadership.',
+			}
+		)
+		.toBe( true );
+
+	return winningData;
 }
 
 test.describe( 'Presence Stale-Screen Tab Coalescing', () => {
@@ -188,9 +197,9 @@ test.describe( 'Presence Stale-Screen Tab Coalescing', () => {
 		);
 
 		await Promise.all( [
-			sibling.waitForSelector( '.wp-presence-stale-notice', {
-				timeout: 8000,
-			} ),
+			expect(
+				sibling.locator( '.wp-presence-stale-notice' )
+			).toBeVisible( { timeout: 8000 } ),
 			page.evaluate( () => wp.heartbeat.connectNow() ),
 		] );
 
@@ -246,23 +255,27 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 
 		editAsUser( post.id, otherUserId );
 		await Promise.all( [
-			page.waitForSelector( '.wp-presence-stale-notice', {
+			expect( page.locator( '.wp-presence-stale-notice' ) ).toBeVisible( {
 				timeout: 8000,
 			} ),
 			page.evaluate( () => wp.heartbeat.connectNow() ),
 		] );
 
-		await page.click( '.wp-presence-stale-notice .notice-dismiss' );
+		await page
+			.locator( '.wp-presence-stale-notice .notice-dismiss' )
+			.click();
 		await expect( page.locator( '.wp-presence-stale-notice' ) ).toHaveCount(
 			0
 		);
 
-		// Past the one-second resolution of the revision.
+		// Past the one-second resolution of the revision — no DOM state to
+		// poll for yet, so the wait has to be real time.
+		// eslint-disable-next-line playwright/no-wait-for-timeout
 		await page.waitForTimeout( 1200 );
 		editAsUser( post.id, otherUserId );
 
 		await Promise.all( [
-			page.waitForSelector( '.wp-presence-stale-notice', {
+			expect( page.locator( '.wp-presence-stale-notice' ) ).toBeVisible( {
 				timeout: 8000,
 			} ),
 			page.evaluate( () => wp.heartbeat.connectNow() ),
@@ -290,6 +303,9 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 		editAsUser( post.id, viewerId );
 		for ( let tick = 0; tick < 3; tick++ ) {
 			await page.evaluate( () => wp.heartbeat.connectNow() );
+			// Paces ticks a fixed interval apart; there is no DOM state to
+			// poll for between them.
+			// eslint-disable-next-line playwright/no-wait-for-timeout
 			await page.waitForTimeout( 500 );
 		}
 		await expect( page.locator( '.wp-presence-stale-notice' ) ).toHaveCount(
@@ -297,11 +313,13 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 		);
 
 		// A banner here proves the self-save advanced the baseline rather
-		// than the screen having gone inert.
+		// than the screen having gone inert. Past the one-second resolution
+		// of the revision — no DOM state to poll for yet.
+		// eslint-disable-next-line playwright/no-wait-for-timeout
 		await page.waitForTimeout( 1200 );
 		editAsUser( post.id, otherUserId );
 		await Promise.all( [
-			page.waitForSelector( '.wp-presence-stale-notice', {
+			expect( page.locator( '.wp-presence-stale-notice' ) ).toBeVisible( {
 				timeout: 8000,
 			} ),
 			page.evaluate( () => wp.heartbeat.connectNow() ),
@@ -325,19 +343,24 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 
 		editAsUser( post.id, otherUserId );
 		await Promise.all( [
-			page.waitForSelector( '.wp-presence-stale-notice', {
+			expect( page.locator( '.wp-presence-stale-notice' ) ).toBeVisible( {
 				timeout: 8000,
 			} ),
 			page.evaluate( () => wp.heartbeat.connectNow() ),
 		] );
 
-		await page.click( '.wp-presence-stale-notice .notice-dismiss' );
+		await page
+			.locator( '.wp-presence-stale-notice .notice-dismiss' )
+			.click();
 
 		// The revision that raised the banner is still ahead of the page's
 		// original baseline, so a fix that only clears the shown flag brings
 		// the same banner straight back.
 		for ( let tick = 0; tick < 3; tick++ ) {
 			await page.evaluate( () => wp.heartbeat.connectNow() );
+			// Paces ticks a fixed interval apart; there is no DOM state to
+			// poll for between them.
+			// eslint-disable-next-line playwright/no-wait-for-timeout
 			await page.waitForTimeout( 500 );
 		}
 

--- a/tests/e2e/presence-stale-screen-coalescing.test.js
+++ b/tests/e2e/presence-stale-screen-coalescing.test.js
@@ -65,7 +65,8 @@ function wpEval( phpExpression ) {
 
 function waitForHeartbeat( page ) {
 	return page.waitForFunction(
-		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
 	);
 }
 
@@ -252,9 +253,9 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 		] );
 
 		await page.click( '.wp-presence-stale-notice .notice-dismiss' );
-		await expect(
-			page.locator( '.wp-presence-stale-notice' )
-		).toHaveCount( 0 );
+		await expect( page.locator( '.wp-presence-stale-notice' ) ).toHaveCount(
+			0
+		);
 
 		// Past the one-second resolution of the revision.
 		await page.waitForTimeout( 1200 );
@@ -291,9 +292,9 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 			await page.evaluate( () => wp.heartbeat.connectNow() );
 			await page.waitForTimeout( 500 );
 		}
-		await expect(
-			page.locator( '.wp-presence-stale-notice' )
-		).toHaveCount( 0 );
+		await expect( page.locator( '.wp-presence-stale-notice' ) ).toHaveCount(
+			0
+		);
 
 		// A banner here proves the self-save advanced the baseline rather
 		// than the screen having gone inert.
@@ -340,8 +341,8 @@ test.describe( 'Presence Stale-Screen Banner', () => {
 			await page.waitForTimeout( 500 );
 		}
 
-		await expect(
-			page.locator( '.wp-presence-stale-notice' )
-		).toHaveCount( 0 );
+		await expect( page.locator( '.wp-presence-stale-notice' ) ).toHaveCount(
+			0
+		);
 	} );
 } );

--- a/tests/e2e/presence-tab-coalescing.test.js
+++ b/tests/e2e/presence-tab-coalescing.test.js
@@ -57,14 +57,23 @@ function captureHeartbeatSend( page ) {
  * @return {Promise<object>} The `heartbeat-send` data from the winning attempt.
  */
 async function waitForLeaderPing( page, maxAttempts = 20 ) {
-	for ( let attempt = 0; attempt < maxAttempts; attempt++ ) {
-		const data = await captureHeartbeatSend( page );
-		if ( data[ 'presence-ping' ] ) {
-			return data;
-		}
-		await page.waitForTimeout( 100 );
-	}
-	throw new Error( 'Tab never won presence-ping leadership.' );
+	let winningData;
+
+	await expect
+		.poll(
+			async () => {
+				winningData = await captureHeartbeatSend( page );
+				return Boolean( winningData[ 'presence-ping' ] );
+			},
+			{
+				intervals: [ 0 ],
+				timeout: maxAttempts * 100,
+				message: 'Tab never won presence-ping leadership.',
+			}
+		)
+		.toBe( true );
+
+	return winningData;
 }
 
 /**

--- a/tests/e2e/presence-tab-coalescing.test.js
+++ b/tests/e2e/presence-tab-coalescing.test.js
@@ -24,7 +24,8 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
  */
 function waitForHeartbeat( page ) {
 	return page.waitForFunction(
-		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
 	);
 }
 
@@ -33,7 +34,7 @@ function waitForHeartbeat( page ) {
  * `heartbeat-send` listeners saw.
  *
  * @param {import('@playwright/test').Page} page
- * @return {Promise<object>}
+ * @return {Promise<object>} The recorded Heartbeat activity.
  */
 function captureHeartbeatSend( page ) {
 	return page.evaluate(
@@ -72,7 +73,7 @@ async function waitForLeaderPing( page, maxAttempts = 20 ) {
  *
  * @param {import('@playwright/test').Page} page
  * @param {number}                          timeoutMs
- * @return {Promise<object>}
+ * @return {Promise<object>} The recorded Heartbeat activity.
  */
 function waitForOnlineDataTick( page, timeoutMs = 8000 ) {
 	return page.evaluate( ( timeout ) => {
@@ -164,7 +165,8 @@ test.describe( 'Presence Tab Coalescing', () => {
 		] );
 
 		expect(
-			relayed[ 'presence-online' ] || relayed[ 'presence-online-unchanged' ]
+			relayed[ 'presence-online' ] ||
+				relayed[ 'presence-online-unchanged' ]
 		).toBeTruthy();
 
 		await sibling.close();
@@ -189,9 +191,7 @@ test.describe( 'Presence Tab Coalescing', () => {
 		expect( dataA[ 'presence-editor-ping' ].post_id ).toBe( postA.id );
 
 		const pageB = await page.context().newPage();
-		await pageB.goto(
-			`/wp-admin/post.php?post=${ postB.id }&action=edit`
-		);
+		await pageB.goto( `/wp-admin/post.php?post=${ postB.id }&action=edit` );
 		await waitForHeartbeat( pageB );
 
 		// A different post is a different context, so this tab must win

--- a/tests/e2e/presence-visibility.test.js
+++ b/tests/e2e/presence-visibility.test.js
@@ -19,7 +19,10 @@
 import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
 import { chromium } from '@playwright/test';
 
-const BASE_URL = ( process.env.WP_BASE_URL || 'http://localhost:8888' ).replace( /\/$/, '' );
+const BASE_URL = ( process.env.WP_BASE_URL || 'http://localhost:8888' ).replace(
+	/\/$/,
+	''
+);
 
 const TEST_USERS = [
 	{
@@ -86,7 +89,8 @@ async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
  */
 function waitForHeartbeat( page ) {
 	return page.waitForFunction(
-		() => typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
 	);
 }
 
@@ -111,7 +115,7 @@ async function setVisibility( page, state ) {
  * `heartbeat-send` listeners (including the plugin's) saw.
  *
  * @param {import('@playwright/test').Page} page
- * @returns {Promise<object>}
+ * @return {Promise<object>} The recorded Heartbeat activity.
  */
 function captureHeartbeatSend( page ) {
 	return page.evaluate(
@@ -205,7 +209,9 @@ test.describe( 'Presence Visibility', () => {
 			);
 
 			// User B clicks "Take over" to become the active lock holder.
-			const takeOverButton = userB.page.locator( 'a:has-text("Take over")' );
+			const takeOverButton = userB.page.locator(
+				'a:has-text("Take over")'
+			);
 			await takeOverButton.click();
 
 			// Wait for heartbeat library on User B's page.
@@ -214,7 +220,9 @@ test.describe( 'Presence Visibility', () => {
 			// Verify that wp-refresh-post-lock is present when visible initially.
 			const initial = await captureHeartbeatSend( userB.page );
 			expect( initial[ 'wp-refresh-post-lock' ] ).toBeDefined();
-			expect( initial[ 'wp-refresh-post-lock' ].post_id ).toBe( String( post.id ) );
+			expect( initial[ 'wp-refresh-post-lock' ].post_id ).toBe(
+				String( post.id )
+			);
 
 			// Verify that wp-refresh-post-lock is deleted when page is hidden.
 			await setVisibility( userB.page, 'hidden' );

--- a/tests/e2e/presence-visibility.test.js
+++ b/tests/e2e/presence-visibility.test.js
@@ -71,13 +71,8 @@ async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
 
 	const userPage = await context.newPage();
 	await userPage.goto( destinationUrl || `${ BASE_URL }/wp-admin/` );
-	await userPage.waitForLoadState( 'networkidle' );
-
-	await userPage.evaluate( () => {
-		if ( typeof wp !== 'undefined' && wp.heartbeat ) {
-			wp.heartbeat.connectNow();
-		}
-	} );
+	await waitForHeartbeat( userPage );
+	await userPage.evaluate( () => wp.heartbeat.connectNow() );
 
 	return { context, page: userPage };
 }

--- a/tests/e2e/presence-widgets.test.js
+++ b/tests/e2e/presence-widgets.test.js
@@ -67,6 +67,18 @@ const test = base.extend( {
 } );
 
 /**
+ * Waits until the WordPress heartbeat library is ready on the page.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+/**
  * Log in a user on a headless browser and navigate to a URL.
  *
  * Uses request-based auth (POST to wp-login.php) to avoid
@@ -94,13 +106,8 @@ async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
 
 	const userPage = await context.newPage();
 	await userPage.goto( destinationUrl || `${ BASE_URL }/wp-admin/` );
-	await userPage.waitForLoadState( 'networkidle' );
-
-	await userPage.evaluate( () => {
-		if ( typeof wp !== 'undefined' && wp.heartbeat ) {
-			wp.heartbeat.connectNow();
-		}
-	} );
+	await waitForHeartbeat( userPage );
+	await userPage.evaluate( () => wp.heartbeat.connectNow() );
 
 	return { context, page: userPage };
 }
@@ -193,7 +200,6 @@ test.describe( 'Presence Widgets', () => {
 
 		await admin.visitAdminPage( '/' );
 		await page.evaluate( () => wp.heartbeat.connectNow() );
-		await page.waitForTimeout( 3000 );
 
 		const activePostsList = page.locator( '#presence-active-posts-list' );
 		await expect( activePostsList ).toContainText(

--- a/tests/e2e/presence-widgets.test.js
+++ b/tests/e2e/presence-widgets.test.js
@@ -13,7 +13,11 @@ import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
 import { chromium } from '@playwright/test';
 import { execSync } from 'node:child_process';
 
-const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8888';
+// Trailing slash stripped so `${BASE_URL}/wp-admin/` below can't double up.
+const BASE_URL = ( process.env.WP_BASE_URL || 'http://localhost:8888' ).replace(
+	/\/$/,
+	''
+);
 
 function wpCli( command ) {
 	execSync( `npx wp-env run cli wp ${ command }`, {

--- a/tests/e2e/presence-widgets.test.js
+++ b/tests/e2e/presence-widgets.test.js
@@ -71,6 +71,9 @@ const test = base.extend( {
  *
  * Uses request-based auth (POST to wp-login.php) to avoid
  * form interaction issues with WordPress 7.0's login page.
+ * @param {import('@playwright/test').Browser}   headlessBrowser The browser to open a context on.
+ * @param {{username: string, password: string}} user            Credentials to log in with.
+ * @param {string}                               destinationUrl  Where to land after logging in.
  */
 async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
 	const context = await headlessBrowser.newContext( {
@@ -103,7 +106,7 @@ async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
 }
 
 test.describe( 'Presence Widgets', () => {
-	test( 'User B appears in Who\'s Online widget', async ( {
+	test( "User B appears in Who's Online widget", async ( {
 		admin,
 		page,
 		testUsers,
@@ -138,26 +141,38 @@ test.describe( 'Presence Widgets', () => {
 		page,
 		testUsers,
 	} ) => {
-		const userBId = wpCliOutput( `user get ${ testUsers[ 0 ].username } --field=ID` );
+		const userBId = wpCliOutput(
+			`user get ${ testUsers[ 0 ].username } --field=ID`
+		);
 
 		await admin.visitAdminPage( '/' );
 		await page.evaluate( () => wp.heartbeat.connectNow() );
 
-		wpCli( `eval 'wp_set_presence( wp_presence_admin_room(), "session-b", array( "screen" => "dashboard" ), ${ userBId } );'` );
+		wpCli(
+			`eval 'wp_set_presence( wp_presence_admin_room(), "session-b", array( "screen" => "dashboard" ), ${ userBId } );'`
+		);
 		await page.evaluate( () => wp.heartbeat.connectNow() );
 
-		const userRow = page.locator( `#presence-whos-online-list [data-user-id="${ userBId }"]` );
+		const userRow = page.locator(
+			`#presence-whos-online-list [data-user-id="${ userBId }"]`
+		);
 		await expect( userRow ).toBeVisible( { timeout: 30_000 } );
 
 		const userLink = userRow.locator( 'a' ).first();
 		await userLink.focus();
 		await expect( userLink ).toBeFocused();
 
-		wpCli( `eval 'wp_set_presence( wp_presence_admin_room(), "session-b", array( "screen" => "edit" ), ${ userBId } );'` );
+		wpCli(
+			`eval 'wp_set_presence( wp_presence_admin_room(), "session-b", array( "screen" => "edit" ), ${ userBId } );'`
+		);
 		await page.evaluate( () => wp.heartbeat.connectNow() );
 
 		await expect(
-			page.locator( `#presence-whos-online-list [data-user-id="${ userBId }"] a` ).first()
+			page
+				.locator(
+					`#presence-whos-online-list [data-user-id="${ userBId }"] a`
+				)
+				.first()
 		).toBeFocused( { timeout: 30_000 } );
 	} );
 
@@ -172,7 +187,9 @@ test.describe( 'Presence Widgets', () => {
 		} );
 
 		// Seed a presence entry for the post via wp eval (CLI --user flag collides with WP-CLI global).
-		wpCli( `eval 'wp_set_presence( "postType/post:${ post.id }", "editor-1", array( "action" => "editing", "screen" => "post" ), 1 );'` );
+		wpCli(
+			`eval 'wp_set_presence( "postType/post:${ post.id }", "editor-1", array( "action" => "editing", "screen" => "post" ), 1 );'`
+		);
 
 		await admin.visitAdminPage( '/' );
 		await page.evaluate( () => wp.heartbeat.connectNow() );
@@ -195,7 +212,9 @@ test.describe( 'Presence Widgets', () => {
 			status: 'draft',
 		} );
 
-		wpCli( `eval 'wp_set_presence( "postType/post:${ post.id }", "session-a", array( "action" => "editing", "screen" => "post" ), 1 );'` );
+		wpCli(
+			`eval 'wp_set_presence( "postType/post:${ post.id }", "session-a", array( "action" => "editing", "screen" => "post" ), 1 );'`
+		);
 
 		await admin.visitAdminPage( '/' );
 		await page.evaluate( () => wp.heartbeat.connectNow() );
@@ -217,12 +236,12 @@ test.describe( 'Presence Widgets', () => {
 		);
 		await page.evaluate( () => wp.heartbeat.connectNow() );
 
-		await expect( page.locator( '#presence-active-posts-list' ) ).toContainText(
-			'Idle',
-			{ timeout: 30_000 }
-		);
+		await expect(
+			page.locator( '#presence-active-posts-list' )
+		).toContainText( 'Idle', { timeout: 30_000 } );
 		await expect( postLink ).toBeFocused();
 	} );
+
 	/**
 	 * The heartbeat payload is capped well below a large room, so the overflow
 	 * count and its link to the Users screen can only come from the total the
@@ -242,11 +261,14 @@ test.describe( 'Presence Widgets', () => {
 			await page.addInitScript( () => {
 				window.__presenceTicks = 0;
 				document.addEventListener( 'DOMContentLoaded', () => {
-					jQuery( document ).on( 'heartbeat-tick', ( event, data ) => {
-						if ( data[ 'presence-online' ] ) {
-							window.__presenceTicks++;
+					jQuery( document ).on(
+						'heartbeat-tick',
+						( event, data ) => {
+							if ( data[ 'presence-online' ] ) {
+								window.__presenceTicks++;
+							}
 						}
-					} );
+					);
 				} );
 			} );
 
@@ -264,7 +286,9 @@ test.describe( 'Presence Widgets', () => {
 			);
 
 			const tick = async () => {
-				const before = await page.evaluate( () => window.__presenceTicks );
+				const before = await page.evaluate(
+					() => window.__presenceTicks
+				);
 				await page.evaluate( () => wp.heartbeat.connectNow() );
 				await page.waitForFunction(
 					( seen ) => window.__presenceTicks > seen,
@@ -275,9 +299,13 @@ test.describe( 'Presence Widgets', () => {
 
 			await tick();
 
-			await expect( summary ).toContainText( `+${ online - visibleRows } more` );
+			await expect( summary ).toContainText(
+				`+${ online - visibleRows } more`
+			);
 			await expect(
-				page.locator( '#presence-whos-online-list #presence-overflow-list' )
+				page.locator(
+					'#presence-whos-online-list #presence-overflow-list'
+				)
 			).toHaveCount( 0 );
 
 			// Drop a user ranked below the payload cap: the entries the client

--- a/tests/widgets/test-network-widget-whos-online.php
+++ b/tests/widgets/test-network-widget-whos-online.php
@@ -227,7 +227,7 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 	public function test_inline_script_carries_the_accessible_names_the_render_uses() {
 		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'index.php' );
 
-		$script = implode( '', (array) wp_scripts()->get_data( 'presence-network-widget', 'after' ) );
+		$script = implode( '', (array) wp_scripts()->get_data( 'presence-network-widget', 'before' ) );
 
 		$this->assertStringContainsString( 'Sites with online users', $script, 'The rebuilt list has no accessible name.' );
 		$this->assertStringContainsString( '+%d more site \u2014 view all', $script, 'The rebuilt overflow link stops saying what it counts.' );
@@ -289,7 +289,7 @@ class WP_Test_Presence_Network_Widget_Whos_Online extends WP_Presence_Network_Un
 	public function test_inline_script_carries_the_not_aggregated_message() {
 		WP_Presence_Network_Widget_Whos_Online::enqueue_scripts( 'index.php' );
 
-		$script = implode( '', (array) wp_scripts()->get_data( 'presence-network-widget', 'after' ) );
+		$script = implode( '', (array) wp_scripts()->get_data( 'presence-network-widget', 'before' ) );
 
 		$this->assertStringContainsString( 'not aggregated across this network', $script );
 	}

--- a/tests/widgets/test-widget-whos-online.php
+++ b/tests/widgets/test-widget-whos-online.php
@@ -406,8 +406,10 @@ class WP_Test_Presence_Widget_Whos_Online extends WP_Presence_UnitTestCase {
 		$css = wp_styles()->get_data( 'presence-dashboard-widget', 'after' );
 		$this->assertStringContainsString( '#presence-whos-online-list', implode( '', (array) $css ) );
 
-		$script = implode( '', (array) wp_scripts()->get_data( 'presence-dashboard-widget', 'after' ) );
-		$this->assertStringContainsString( 'presence-whos-online-list', $script );
+		$this->assertStringContainsString( 'assets/js/whos-online-widget.js', wp_scripts()->registered['presence-dashboard-widget']->src );
+
+		$config = implode( '', (array) wp_scripts()->get_data( 'presence-dashboard-widget', 'before' ) );
+		$this->assertStringContainsString( 'window.wpPresenceWhosOnline', $config );
 
 		// The inline script calls into the shared file, so it has to load first.
 		$this->assertTrue( wp_script_is( 'wp-presence-avatar-stack', 'enqueued' ) );


### PR DESCRIPTION
Fixes #394

Two thirds of the plugin's JavaScript sat inside PHP heredocs, unreachable by a linter, which is how the same focus-retention defect shipped twice (#265, then #389).

<details>
<summary><b>Use of AI Tools</b></summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5

Used for: Assisting with the extraction, lint setup, and test coverage

</details>