### PR TITLE
fix: stop PHPStan's bootstrap from silently exiting before analysis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -27,6 +27,7 @@ package.json
 package-lock.json
 phpcs.xml.dist
 phpstan.neon.dist
+phpstan-bootstrap.php
 phpunit.xml.dist
 release-please-config.json
 scripts/

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Constants PHPStan can't resolve by parsing presence-api.php alone.
+ *
+ * @package Presence_API
+ */
+
+define( 'WP_PRESENCE_PLUGIN_URL', 'https://example.com/wp-content/plugins/presence-api/' );
+define( 'MINUTE_IN_SECONDS', 60 );

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
 	level: 3
 	bootstrapFiles:
-		- presence-api.php
+		- phpstan-bootstrap.php
 	paths:
 		- presence-api.php
 		- includes/


### PR DESCRIPTION
Related: #413

@i-am-chitti flagged this while investigating #413; the stub-version bump discussed there is still blocked upstream on wp-cli-stubs.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 5
Used for: Assisting with diagnosis and the fix.

</details>