### PR TITLE
feat: add a Settings link to the plugin row actions

### DIFF
--- a/presence-api.php
+++ b/presence-api.php
@@ -283,11 +283,12 @@ function wp_presence_deactivate( $network_wide = false ) {
 /**
  * Adds action links to the plugin list table.
  *
- * The plugin has no settings screen, so the link points at the Users list
- * filtered to the users who are currently online.
+ * The online users link points at the Users list filtered to the users who are
+ * currently online. The plugin has no settings screen of its own, so the
+ * settings link points at Settings > General, where the recording switch lives.
  *
  * @param string[] $links Existing plugin action links.
- * @return string[] Action links with the online users link prepended.
+ * @return string[] Action links with the plugin's own links prepended.
  */
 function wp_presence_plugin_action_links( $links ) {
 	$online_users_link = sprintf(
@@ -296,7 +297,13 @@ function wp_presence_plugin_action_links( $links ) {
 		esc_html__( 'View Online Users', 'presence-api' )
 	);
 
-	array_unshift( $links, $online_users_link );
+	$settings_link = sprintf(
+		'<a href="%1$s">%2$s</a>',
+		esc_url( admin_url( 'options-general.php' ) ),
+		esc_html__( 'Settings', 'presence-api' )
+	);
+
+	array_unshift( $links, $online_users_link, $settings_link );
 
 	return $links;
 }

--- a/tests/test-plugin-action-links.php
+++ b/tests/test-plugin-action-links.php
@@ -22,10 +22,10 @@ class WP_Test_Presence_Plugin_Action_Links extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_presence_plugin_action_links
 	 */
-	public function test_prepends_a_single_link() {
+	public function test_prepends_both_of_our_links() {
 		$links = wp_presence_plugin_action_links( $this->core_links() );
 
-		$this->assertCount( 2, $links );
+		$this->assertCount( 3, $links );
 		$this->assertSame( 'Deactivate', wp_strip_all_tags( end( $links ) ) );
 	}
 
@@ -44,10 +44,10 @@ class WP_Test_Presence_Plugin_Action_Links extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_presence_plugin_action_links
 	 */
-	public function test_returns_only_our_link_when_no_links_exist() {
+	public function test_returns_only_our_links_when_no_links_exist() {
 		$links = wp_presence_plugin_action_links( array() );
 
-		$this->assertCount( 1, $links );
+		$this->assertCount( 2, $links );
 	}
 
 	/**
@@ -62,6 +62,17 @@ class WP_Test_Presence_Plugin_Action_Links extends WP_UnitTestCase {
 
 		$this->assertStringStartsWith( admin_url( 'users.php' ), $href );
 		$this->assertStringContainsString( 'presence_status=online', $href );
+	}
+
+	/**
+	 * @covers ::wp_presence_plugin_action_links
+	 */
+	public function test_settings_link_points_at_the_general_settings_screen() {
+		$links = wp_presence_plugin_action_links( array() );
+
+		$this->assertSame( 1, preg_match( '#href="([^"]+)"#', $links[1], $matches ) );
+		$this->assertSame( admin_url( 'options-general.php' ), html_entity_decode( $matches[1] ) );
+		$this->assertSame( 'Settings', wp_strip_all_tags( $links[1] ) );
 	}
 
 	/**


### PR DESCRIPTION
Beyond the issue's task list, this also renames `test_prepends_a_single_link` and `test_returns_only_our_link_when_no_links_exist` — both now assert the opposite of what their names say. Happy to drop the renames if you'd rather keep the diff to the three tasks.

The Settings link points at `options-general.php` as specified, which lands on General and leaves you to find the "Presence" row. The field registers `label_for => wp_presence_recording`, so `options-general.php#wp_presence_recording` would jump straight to it — say the word if you'd prefer that.

Fixes #484

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 5
Used for: Drafting the implementation and tests; reviewed by me.

</details>
