### PR TITLE
ci: reuse the project's own wp-env in plugin-check instead of a global install

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -29,8 +29,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
+          cache: npm
 
-      - run: npm install -g @wordpress/env@11.8.1
+      - run: npm ci
 
       - name: Authenticate composer to GitHub
         run: composer config --global --auth github-oauth.github.com '${{ secrets.GITHUB_TOKEN }}'
@@ -46,16 +47,16 @@ jobs:
           { "plugins": [ "./build/presence-api" ] }
           JSON
 
-      - run: wp-env start
+      - run: npx wp-env start
 
       - name: Install Plugin Check
         run: |
-          wp-env run cli wp plugin install plugin-check --activate
-          wp-env run cli wp plugin activate presence-api
+          npx wp-env run cli wp plugin install plugin-check --activate
+          npx wp-env run cli wp plugin activate presence-api
 
       - name: Run Plugin Check
         run: |
-          wp-env run cli wp plugin check presence-api \
+          npx wp-env run cli wp plugin check presence-api \
             --format=strict-json \
             --fields=file,line,column,type,code,message > plugin-check.json
 


### PR DESCRIPTION
Fixes #495

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 5
Used for: Assisting with the fix.

</details>