### PR TITLE
ci: cache wp-env's WordPress core checkout in the e2e job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,10 @@ jobs:
     name: Playwright
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      # Pinned so the cache path below doesn't depend on wp-env's runner-specific
+      # snap detection (~/.wp-env vs ~/wp-env).
+      WP_ENV_HOME: ${{ github.workspace }}/.wp-env-cache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -48,7 +52,7 @@ jobs:
       - name: Cache wp-env WordPress core
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.wp-env
+          path: ${{ env.WP_ENV_HOME }}
           key: ${{ runner.os }}-wp-env-${{ steps.wp-env-date.outputs.date }}
 
       # The Playwright config declares a `webServer` that would start wp-env on

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,14 +40,8 @@ jobs:
       - run: npx playwright install chromium
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
 
-      # `core: null` in both .wp-env.json files means a cold run clones
-      # WordPress/WordPress.git from scratch, which is most of the ~2min
-      # boot cost (see #498). wp-env records a hash of the resolved config
-      # under this directory and skips re-downloading/reconfiguring entirely
-      # when a start sees the same hash again, so restoring it is what makes
-      # a cache hit skip the network work rather than just the disk I/O. The
-      # date in the key bounds staleness to a day rather than caching
-      # "latest" indefinitely.
+      # core: null reclones WordPress/WordPress.git from scratch each cold
+      # run (#498's boot cost). The date key bounds how stale a hit can be.
       - name: Determine wp-env cache date
         id: wp-env-date
         run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,24 @@ jobs:
       - run: npx playwright install chromium
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
 
+      # `core: null` in both .wp-env.json files means a cold run clones
+      # WordPress/WordPress.git from scratch, which is most of the ~2min
+      # boot cost (see #498). wp-env records a hash of the resolved config
+      # under this directory and skips re-downloading/reconfiguring entirely
+      # when a start sees the same hash again, so restoring it is what makes
+      # a cache hit skip the network work rather than just the disk I/O. The
+      # date in the key bounds staleness to a day rather than caching
+      # "latest" indefinitely.
+      - name: Determine wp-env cache date
+        id: wp-env-date
+        run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+      - name: Cache wp-env WordPress core
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.wp-env
+          key: ${{ runner.os }}-wp-env-${{ steps.wp-env-date.outputs.date }}
+          restore-keys: ${{ runner.os }}-wp-env-
+
       # The Playwright config declares a `webServer` that would start wp-env on
       # demand, but starting it here keeps a boot failure in its own step
       # instead of buried in Playwright's server output. `reuseExistingServer`

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           path: ~/.wp-env
           key: ${{ runner.os }}-wp-env-${{ steps.wp-env-date.outputs.date }}
-          restore-keys: ${{ runner.os }}-wp-env-
 
       # The Playwright config declares a `webServer` that would start wp-env on
       # demand, but starting it here keeps a boot failure in its own step

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -43,6 +43,10 @@ export default defineConfig( {
 	globalSetup: path.resolve( __dirname, 'global-setup.js' ),
 	reporter: process.env.CI ? [ [ 'github' ] ] : [ [ 'list' ] ],
 	retries: process.env.CI ? 2 : 0,
+	// Every spec shares one live wp-env instance and database rather than
+	// getting its own — presence-screenshots.test.js truncates wp_presence
+	// directly, and several specs call deleteAllPosts()/deleteAllUsers().
+	// Parallel workers would race those against each other's fixtures.
 	workers: 1,
 	timeout: 100_000,
 	reportSlowTests: null,

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -43,10 +43,8 @@ export default defineConfig( {
 	globalSetup: path.resolve( __dirname, 'global-setup.js' ),
 	reporter: process.env.CI ? [ [ 'github' ] ] : [ [ 'list' ] ],
 	retries: process.env.CI ? 2 : 0,
-	// Every spec shares one live wp-env instance and database rather than
-	// getting its own — presence-screenshots.test.js truncates wp_presence
-	// directly, and several specs call deleteAllPosts()/deleteAllUsers().
-	// Parallel workers would race those against each other's fixtures.
+	// Specs share one live wp-env db; some truncate wp_presence or delete
+	// all posts/users, which parallel workers would race against.
 	workers: 1,
 	timeout: 100_000,
 	reportSlowTests: null,


### PR DESCRIPTION
Related: #498

Opened as a draft since the wp_presence table truncation there in presence-screenshots.test.js, plus the deleteAllPosts/deleteAllUsers calls elsewhere, made me draw the workers:1 conclusion from reading the specs rather than from a real racy-parallel CI run, and I haven't yet measured actual before/after wall-clock on a same-day cache hit in CI.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Assisting with investigating wp-env's boot cost and drafting the fix.

</details>