### PR TITLE
feat: expose the room's collaborator count as JS hooks

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -52,8 +52,19 @@ jobs:
       - name: Install Composer dependencies
         if: ${{ inputs.should-run }}
         run: composer install --no-interaction
-      - run: npx wp-env start ${{ matrix.coverage && '--xdebug=coverage' || '' }}
+      - name: Start wp-env (retry on transient PECL download failures)
         if: ${{ inputs.should-run }}
+        run: |
+          for attempt in 1 2 3; do
+            if npx wp-env start ${{ matrix.coverage && '--xdebug=coverage' || '' }}; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            npx wp-env destroy || true
+            echo "wp-env start failed on attempt $attempt, retrying..."
+          done
         env:
           WP_ENV_PHP_VERSION: ${{ matrix.php }}
       - run: npx wp-env run tests-cli --env-cwd='wp-content/plugins/presence-api' -- ./vendor/bin/phpunit ${{ matrix.coverage && '--coverage-clover coverage.xml' || '' }}

--- a/README.md
+++ b/README.md
@@ -206,6 +206,25 @@ add_action( 'wp_presence_collaboration_ended', function( $room, $entries ) {
 }, 10, 2 );
 ```
 
+### JS Actions
+Fired through `wp.hooks`, not PHP. `presence-ping.js` is the only thing that computes these, so a consumer has to listen rather than poll for them.
+
+#### `presence-api.watchingRoom`
+Fires once, synchronously, before Heartbeat's first tick. Only on a post-edit screen for a post type with `presence` support — lets a listener tell "presence-api isn't here" apart from "here, no tick yet."
+```js
+wp.hooks.addAction( 'presence-api.watchingRoom', 'my-plugin', ( room ) => {
+    // room is 'postType/{type}:{id}'
+} );
+```
+
+#### `presence-api.collaboratorsChanged`
+Fires on the same 1-to-2+ and 2+-to-1 edges as `wp_presence_collaboration_started`/`_ended`, not on every tick.
+```js
+wp.hooks.addAction( 'presence-api.collaboratorsChanged', 'my-plugin', ( room, count ) => {
+    // count > 1 means someone besides you is in the room.
+} );
+```
+
 </details>
 
 ## REST API
@@ -264,6 +283,8 @@ Real-time awareness inside the editor — cursors, selections, who's editing whi
 No room mapping sits between the two: both use `postType/{type}:{id}`, the grammar Gutenberg's `WP_Sync_Config::parse_room()` defines and [`wp_presence_post_room()`](#php-api) already returns. What keeps the two sets of rows apart inside that shared room is the `client_id` prefix: sync-storage writes `sync-{id}` and reads nothing else back, leaving this plugin's `editor-{user_id}` rows untouched.
 
 That leaves the split: awareness and cursors inside the editor go through sync-storage; room membership everywhere else in wp-admin — plus the post-lock bridge below — stays this plugin's.
+
+The JS actions above exist for that same relationship. A consumer like Gutenberg's sync poll loop ([presence-api#444](https://github.com/WordPress/presence-api/issues/444)) can wait for `presence-api.collaboratorsChanged` instead of polling to find out whether anyone else is in the room.
 
 ## Post-lock bridge
 

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -1,5 +1,9 @@
 ( function ( $ ) {
-	if ( typeof wp === 'undefined' || typeof wp.heartbeat === 'undefined' ) {
+	if (
+		typeof wp === 'undefined' ||
+		typeof wp.heartbeat === 'undefined' ||
+		typeof wp.hooks === 'undefined'
+	) {
 		return;
 	}
 
@@ -7,6 +11,7 @@
 	const entries = Array.isArray( config.entries ) ? config.entries : [];
 	const frontContext = config.frontContext || null;
 	const editorPostId = parseInt( config.editorPostId, 10 ) || 0;
+	const editorRoom = config.editorRoom || '';
 	const restUrl = config.restUrl || '';
 	const nonce = config.nonce || '';
 	const idleTicks = parseInt( config.idleTicks, 10 ) || 0;
@@ -15,12 +20,22 @@
 	const backoffEnabled = idleTicks > 0 && idleInterval > 0;
 	const TTL_SAFETY_MARGIN = 15;
 
+	// Fired synchronously, ahead of Heartbeat's first tick, so a listener can
+	// tell "presence-api isn't here" apart from "here, no tick yet."
+	if ( editorRoom ) {
+		wp.hooks.doAction( 'presence-api.watchingRoom', editorRoom );
+	}
+
 	// Guards against duplicate leave() invocations.
 	let hasLeft = false;
 
 	let unchangedTicks = 0;
 	let lastOnlineHash = '';
 	let normalInterval = null;
+	// Matches wp_presence_check_collaboration_threshold()'s own default: with
+	// nothing observed yet, assume solo, so a fresh room's first tick at count
+	// 1 isn't mistaken for a 2+-to-1 edge.
+	let hasCollaborators = false;
 
 	// Reads the interval lazily (not at page load) so it reflects whatever
 	// another script, e.g. post.js's lock-refresh interval, already set.
@@ -113,6 +128,33 @@
 				data[ 'presence-editor-ping' ] = { post_id: editorPostId };
 			}
 		} );
+
+		if ( editorRoom ) {
+			$( document ).on( 'heartbeat-tick', function ( event, data ) {
+				if (
+					! Object.prototype.hasOwnProperty.call(
+						data,
+						'presence-heartbeat-collaborators'
+					)
+				) {
+					return;
+				}
+
+				const count = data[ 'presence-heartbeat-collaborators' ];
+				const nowHasCollaborators = count > 1;
+
+				if ( nowHasCollaborators === hasCollaborators ) {
+					return;
+				}
+
+				hasCollaborators = nowHasCollaborators;
+				wp.hooks.doAction(
+					'presence-api.collaboratorsChanged',
+					editorRoom,
+					count
+				);
+			} );
+		}
 
 		if ( backoffEnabled ) {
 			// Reuses the Who's Online widget's hash exchange on every screen,

--- a/assets/js/presence-ping.js
+++ b/assets/js/presence-ping.js
@@ -66,6 +66,7 @@
 	const pingContextKey =
 		'wp-presence-ping:' +
 		JSON.stringify( {
+			restUrl,
 			screen: window.pagenow || 'front',
 			editorPostId,
 			frontTitle: ( frontContext && frontContext.title ) || '',

--- a/includes/heartbeat.php
+++ b/includes/heartbeat.php
@@ -126,6 +126,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 
 	// On the post-edit screen, also occupy the per-post room.
 	$editor_post_id = 0;
+	$editor_room    = '';
 	if ( is_admin() && function_exists( 'get_current_screen' ) ) {
 		$screen = get_current_screen();
 		if ( $screen && 'post' === $screen->base ) {
@@ -134,6 +135,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 				$room = wp_presence_post_room( $post->ID );
 				if ( $room ) {
 					$editor_post_id = $post->ID;
+					$editor_room    = $room;
 					$entries[]      = array(
 						'room'      => $room,
 						'client_id' => 'editor-' . $user_id,
@@ -160,24 +162,24 @@ function wp_presence_enqueue_heartbeat_ping() {
 	}
 	wp_set_presence( wp_presence_admin_room(), 'user-' . $user_id, $admin_state, $user_id );
 
-	if ( $editor_post_id ) {
-		$editor_room = wp_presence_post_room( $editor_post_id );
-		if ( $editor_room ) {
-			// No tick has carried a lock refresh yet. connectNow() on load makes
-			// that a single request, not a visible state.
-			wp_set_presence(
-				$editor_room,
-				'editor-' . $user_id,
-				wp_presence_editor_state( $screen_id, false ),
-				$user_id
-			);
-		}
+	if ( $editor_room ) {
+		// No tick has carried a lock refresh yet. connectNow() on load makes
+		// that a single request, not a visible state.
+		wp_set_presence(
+			$editor_room,
+			'editor-' . $user_id,
+			wp_presence_editor_state( $screen_id, false ),
+			$user_id
+		);
 	}
 
 	$config = array(
 		'entries'      => $entries,
 		'frontContext' => $front_context,
 		'editorPostId' => $editor_post_id,
+		// Lets presence-ping.js fire `presence-api.watchingRoom` without
+		// duplicating the postType/{type}:{id} grammar client-side.
+		'editorRoom'   => $editor_room,
 		'restUrl'      => esc_url_raw( rest_url( 'wp-presence/v1/presence' ) ),
 		'nonce'        => wp_create_nonce( 'wp_rest' ),
 		'idleTicks'    => wp_presence_get_heartbeat_idle_ticks(),
@@ -196,7 +198,7 @@ function wp_presence_enqueue_heartbeat_ping() {
 	wp_enqueue_script(
 		'wp-presence-ping',
 		WP_PRESENCE_PLUGIN_URL . 'assets/js/presence-ping.js',
-		array( 'jquery', 'heartbeat', 'wp-presence-tab-coordinator' ),
+		array( 'jquery', 'heartbeat', 'wp-hooks', 'wp-presence-tab-coordinator' ),
 		WP_PRESENCE_VERSION,
 		true
 	);

--- a/tests/e2e/presence-collaborator-hooks.test.js
+++ b/tests/e2e/presence-collaborator-hooks.test.js
@@ -1,0 +1,284 @@
+/**
+ * Presence API — Collaborator JS Hooks E2E Tests
+ *
+ * Asserts presence-ping.js fires `presence-api.watchingRoom` and
+ * `presence-api.collaboratorsChanged` through wp.hooks, so external code
+ * (e.g. Gutenberg's sync poll loop) can react to a room's editor count
+ * instead of polling for it separately.
+ *
+ * Run from plugin root:
+ *   npx playwright test --config tests/e2e/playwright.config.js tests/e2e/presence-collaborator-hooks.test.js
+ *
+ * @package WordPress
+ * @since 7.1.0
+ */
+import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
+import { chromium } from '@playwright/test';
+
+const BASE_URL = ( process.env.WP_BASE_URL || 'http://localhost:8888' ).replace(
+	/\/$/,
+	''
+);
+
+const TEST_USERS = [
+	{
+		username: 'presencetesthooks',
+		email: 'presencetesthooks@example.com',
+		firstName: 'User',
+		lastName: 'B',
+		password: 'password',
+		roles: [ 'editor' ],
+	},
+];
+
+const test = base.extend( {
+	testUsers: [
+		async ( { requestUtils }, use ) => {
+			for ( const user of TEST_USERS ) {
+				await requestUtils.createUser( user ).catch( ( error ) => {
+					if ( error?.code !== 'existing_user_login' ) {
+						throw error;
+					}
+				} );
+			}
+			await use( TEST_USERS );
+			await requestUtils.deleteAllUsers();
+		},
+		{ scope: 'test' },
+	],
+} );
+
+async function loginHeadlessUser( headlessBrowser, user, destinationUrl ) {
+	const context = await headlessBrowser.newContext( {
+		baseURL: BASE_URL,
+		ignoreHTTPSErrors: true,
+	} );
+
+	await context.request.post( `${ BASE_URL }/wp-login.php`, {
+		form: {
+			log: user.username,
+			pwd: user.password,
+			'wp-submit': 'Log In',
+			redirect_to: destinationUrl || `${ BASE_URL }/wp-admin/`,
+			testcookie: '1',
+		},
+	} );
+
+	const userPage = await context.newPage();
+	await userPage.goto( destinationUrl || `${ BASE_URL }/wp-admin/` );
+
+	return { context, page: userPage };
+}
+
+function waitForHeartbeat( page ) {
+	return page.waitForFunction(
+		() =>
+			typeof wp !== 'undefined' && wp.heartbeat && wp.heartbeat.connectNow
+	);
+}
+
+/**
+ * Forces a tick and waits for it to be fully processed before resolving,
+ * so an assertion right after this call sees the tick's effects rather
+ * than racing the in-flight request.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+function tickAndWait( page ) {
+	return page.evaluate(
+		() =>
+			new Promise( ( resolve ) => {
+				jQuery( document ).one( 'heartbeat-tick', () => resolve() );
+				wp.heartbeat.connectNow();
+			} )
+	);
+}
+
+/**
+ * Traps `window.wp.hooks` before any page script runs, so both actions are
+ * captured even though `watchingRoom` fires ahead of Heartbeat's first tick,
+ * before a listener added from page content could otherwise register in time.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+function captureCollaboratorActions( page ) {
+	return page.addInitScript( () => {
+		window.__watchingRoomCalls = [];
+		window.__collaboratorsChangedCalls = [];
+		window.wp = window.wp || {};
+
+		let hooks;
+		Object.defineProperty( window.wp, 'hooks', {
+			configurable: true,
+			get() {
+				return hooks;
+			},
+			set( value ) {
+				hooks = value;
+				value.addAction(
+					'presence-api.watchingRoom',
+					'e2e-test',
+					( room ) => {
+						window.__watchingRoomCalls.push( room );
+					}
+				);
+				value.addAction(
+					'presence-api.collaboratorsChanged',
+					'e2e-test',
+					( room, count ) => {
+						window.__collaboratorsChangedCalls.push( {
+							room,
+							count,
+						} );
+					}
+				);
+			},
+		} );
+	} );
+}
+
+test.describe( 'Presence Collaborator JS Hooks', () => {
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test( 'fires watchingRoom once, before the first tick, with the post room', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'E2E Collaborator Hooks — watchingRoom',
+			status: 'publish',
+		} );
+
+		await captureCollaboratorActions( page );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( page );
+
+		const calls = await page.evaluate( () => window.__watchingRoomCalls );
+
+		expect( calls ).toEqual( [ `postType/post:${ post.id }` ] );
+	} );
+
+	test( 'does not fire watchingRoom outside a post-edit screen', async ( {
+		admin,
+		page,
+	} ) => {
+		await captureCollaboratorActions( page );
+
+		await admin.visitAdminPage( '/' );
+		await waitForHeartbeat( page );
+
+		const calls = await page.evaluate( () => window.__watchingRoomCalls );
+
+		expect( calls ).toEqual( [] );
+	} );
+
+	test( 'fires collaboratorsChanged on the 1-to-2+ edge when a second editor joins, not again on the next unchanged tick', async ( {
+		admin,
+		page,
+		requestUtils,
+		testUsers,
+	} ) => {
+		const post = await requestUtils.createPost( {
+			title: 'E2E Collaborator Hooks — join edge',
+			status: 'publish',
+		} );
+
+		await captureCollaboratorActions( page );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( page );
+
+		// Solo baseline: establishes the room, not an edge.
+		await tickAndWait( page );
+		expect(
+			await page.evaluate( () => window.__collaboratorsChangedCalls )
+		).toEqual( [] );
+
+		const headlessBrowser = await chromium.launch( { headless: true } );
+
+		try {
+			const userB = await loginHeadlessUser(
+				headlessBrowser,
+				testUsers[ 0 ],
+				`${ BASE_URL }/wp-admin/post.php?post=${ post.id }&action=edit`
+			);
+			await waitForHeartbeat( userB.page );
+			await tickAndWait( userB.page );
+
+			// User A's next tick observes User B and crosses the edge.
+			await tickAndWait( page );
+			expect(
+				await page.evaluate( () => window.__collaboratorsChangedCalls )
+			).toEqual( [ { room: `postType/post:${ post.id }`, count: 2 } ] );
+
+			// Both still present: must not refire.
+			await tickAndWait( page );
+			expect(
+				await page.evaluate( () => window.__collaboratorsChangedCalls )
+			).toHaveLength( 1 );
+
+			await userB.context.close();
+		} finally {
+			await headlessBrowser.close();
+		}
+	} );
+
+	test( 'fires collaboratorsChanged on the 2+-to-1 edge from a relayed tick, not again while unchanged', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// A relayed tick is how a follower tab in the same browser learns the
+		// count (RELAYED_TICK_KEYS in presence-ping.js), so triggering one
+		// directly exercises a real code path, not a fake for this test.
+		const post = await requestUtils.createPost( {
+			title: 'E2E Collaborator Hooks — leave edge',
+			status: 'publish',
+		} );
+
+		await captureCollaboratorActions( page );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+		await waitForHeartbeat( page );
+		await tickAndWait( page );
+
+		await page.evaluate( () => {
+			jQuery( document ).trigger( 'heartbeat-tick', [
+				{ 'presence-heartbeat-collaborators': 2 },
+			] );
+		} );
+		await page.evaluate( () => {
+			jQuery( document ).trigger( 'heartbeat-tick', [
+				{ 'presence-heartbeat-collaborators': 1 },
+			] );
+		} );
+		// Unchanged: must not refire.
+		await page.evaluate( () => {
+			jQuery( document ).trigger( 'heartbeat-tick', [
+				{ 'presence-heartbeat-collaborators': 1 },
+			] );
+		} );
+
+		const calls = await page.evaluate(
+			() => window.__collaboratorsChangedCalls
+		);
+
+		expect( calls ).toEqual( [
+			{ room: `postType/post:${ post.id }`, count: 2 },
+			{ room: `postType/post:${ post.id }`, count: 1 },
+		] );
+	} );
+} );

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -191,6 +191,11 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 
 		$wp_scripts = wp_scripts();
 		$this->assertArrayHasKey( 'wp-presence-ping', $wp_scripts->registered );
+
+		// `presence-api.watchingRoom` and `presence-api.collaboratorsChanged`
+		// go out through wp.hooks, so it has to be loaded first.
+		$this->assertContains( 'wp-hooks', $wp_scripts->registered['wp-presence-ping']->deps );
+
 		$extra = $wp_scripts->registered['wp-presence-ping']->extra;
 		$this->assertArrayHasKey( 'before', $extra );
 
@@ -513,6 +518,55 @@ class WP_Test_Presence_Heartbeat extends WP_Presence_UnitTestCase {
 
 		$this->assertContains( 'editor-' . self::$editor_id, $client_ids );
 		$this->assertNotContains( 'lock-' . self::$editor_id, $client_ids );
+	}
+
+	/**
+	 * presence-ping.js builds `presence-api.watchingRoom` from this rather than
+	 * re-deriving postType/{type}:{id} client-side.
+	 *
+	 * @covers ::wp_presence_enqueue_heartbeat_ping
+	 */
+	public function test_ping_config_carries_editor_room() {
+		global $post;
+
+		$post_id = self::factory()->post->create();
+
+		wp_set_current_user( self::$editor_id );
+
+		$post = get_post( $post_id );
+		set_current_screen( 'post' );
+
+		wp_deregister_script( 'wp-presence-ping' );
+
+		$wp_scripts        = wp_scripts();
+		$wp_scripts->queue = array();
+		$wp_scripts->done  = array();
+
+		wp_presence_enqueue_heartbeat_ping();
+
+		$config = $this->get_ping_config();
+
+		$this->assertSame( wp_presence_post_room( $post_id ), $config['editorRoom'] );
+	}
+
+	/**
+	 * @covers ::wp_presence_enqueue_heartbeat_ping
+	 */
+	public function test_ping_config_editor_room_empty_outside_editor() {
+		wp_set_current_user( self::$editor_id );
+		set_current_screen( 'dashboard' );
+
+		wp_deregister_script( 'wp-presence-ping' );
+
+		$wp_scripts        = wp_scripts();
+		$wp_scripts->queue = array();
+		$wp_scripts->done  = array();
+
+		wp_presence_enqueue_heartbeat_ping();
+
+		$config = $this->get_ping_config();
+
+		$this->assertSame( '', $config['editorRoom'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #502

`presence-ping.js` now fires `presence-api.watchingRoom` (once, before Heartbeat's first tick) and `presence-api.collaboratorsChanged` (on the 1-to-2+ and 2+-to-1 edges) through `wp.hooks`. External code, like Gutenberg's sync poll loop, can react to a room's editor count instead of polling for it separately. Covered by new PHPUnit and Playwright tests, and documented in the README's JS Actions section.

<details>
<summary>Use of AI Tools</summary>

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation (PHP config plumbing, JS event wiring, PHPUnit and Playwright tests) and README docs, drafted end to end and reviewed by me.

</details>